### PR TITLE
feat(classifier): add generic domain classifier for spec plan

### DIFF
--- a/src/classifier/domain.ts
+++ b/src/classifier/domain.ts
@@ -1,0 +1,44 @@
+import type { Issue } from '../github/types.js';
+
+const DOMAIN_KEYWORDS: Record<string, string[]> = {
+  frontend: ['ui', 'component', 'render', 'css', 'style', 'react', 'vue', 'angular', 'svelte', 'button', 'form', 'page', 'layout', 'responsive', 'animation', 'dom', 'html', 'tailwind', 'visual', 'design'],
+  backend: ['server', 'service', 'handler', 'controller', 'middleware', 'worker', 'daemon', 'queue', 'job', 'cron', 'scheduler', 'grpc', 'rpc'],
+  api: ['api', 'endpoint', 'rest', 'graphql', 'http', 'route', 'swagger', 'openapi', 'webhook', 'request', 'response'],
+  auth: ['auth', 'login', 'logout', 'token', 'jwt', 'oauth', 'session', 'password', 'credential', 'permission', 'role', 'access', 'signup', 'register'],
+  database: ['database', 'db', 'sql', 'query', 'migration', 'schema', 'table', 'model', 'orm', 'postgres', 'mysql', 'mongo', 'redis', 'index', 'transaction'],
+  infra: ['infra', 'deploy', 'docker', 'kubernetes', 'k8s', 'terraform', 'helm', 'nginx', 'network', 'devops', 'provision', 'cloud', 'vm', 'container'],
+  'cloud-storage': ['s3', 'gcs', 'storage', 'bucket', 'upload', 'download', 'blob', 'cdn', 'file upload', 'asset', 'object storage'],
+  blockchain: ['blockchain', 'chain', 'block', 'hash', 'ledger', 'consensus', 'miner', 'ethereum', 'solana', 'web3', 'nft', 'defi'],
+  'smart-contract': ['smart contract', 'contract', 'solidity', 'abi', 'evm', 'vyper', 'bytecode', 'deploy contract'],
+  wallet: ['wallet', 'private key', 'public key', 'address', 'sign', 'transaction', 'send', 'receive', 'balance', 'seed phrase', 'mnemonic'],
+  i18n: ['i18n', 'l10n', 'locale', 'translation', 'lang', 'language', 'localize', 'multilang'],
+  testing: ['test', 'spec', 'unit', 'integration', 'e2e', 'mock', 'stub', 'coverage', 'jest', 'vitest', 'playwright', 'cypress', 'assert', 'fixture'],
+  docs: ['docs', 'documentation', 'readme', 'guide', 'changelog', 'wiki', 'jsdoc', 'typedoc'],
+  ci: ['ci', 'cd', 'pipeline', 'workflow', 'github action', 'jenkins', 'travis', 'circleci', 'build step', 'artifact', 'badge'],
+  tooling: ['lint', 'eslint', 'prettier', 'config', 'setup', 'cli', 'script', 'generator', 'plugin', 'npm', 'yarn', 'pnpm', 'bun'],
+};
+
+const MAX_DOMAINS = 5;
+
+export function classifyDomains(issue: Issue): string[] {
+  const title = issue.title.toLowerCase();
+  const body = issue.body.toLowerCase();
+  const labels = issue.labels.join(' ').toLowerCase();
+
+  const scores: Record<string, number> = {};
+
+  for (const [domain, keywords] of Object.entries(DOMAIN_KEYWORDS)) {
+    let score = 0;
+    for (const kw of keywords) {
+      if (title.includes(kw)) score += 3;
+      if (labels.includes(kw)) score += 2;
+      if (body.includes(kw)) score += 1;
+    }
+    if (score > 0) scores[domain] = score;
+  }
+
+  return Object.entries(scores)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, MAX_DOMAINS)
+    .map(([domain]) => domain);
+}

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -6,6 +6,7 @@ import { loadExplicitDocs, discoverRelevantDocs, loadCorePreset } from '../docs/
 import { renderTemplate } from '../template/renderer.js';
 import { DEFAULT_TEMPLATE } from '../template/default-template.js';
 import { writePackage } from '../output/writer.js';
+import { classifyDomains } from '../classifier/domain.js';
 import type { TemplateVars } from '../template/types.js';
 import type { MatchResult } from '../rules/types.js';
 import type { Issue } from '../github/types.js';
@@ -23,6 +24,8 @@ export async function plan(
   if (opts.verbose) console.log('→ Fetching issue...');
   const issue = await fetchIssue(issueRef, repoPath);
   console.log(`✓ Issue #${issue.number} fetched: ${issue.title}${issue.state === 'closed' ? ' [CLOSED]' : ''}`);
+  const domains = classifyDomains(issue);
+  console.log(`✓ Detected domains: ${domains.join(', ') || '(none)'}`);
 
   // 2. Load config
   if (opts.verbose) console.log('→ Loading config...');


### PR DESCRIPTION
## Source of truth
- refs #2
- presets/core/ai-collaboration.md
- CLAUDE.md
- AGENTS.md

## 修改內容
- 新增 generic domain classifier
- 支援 15 個通用 domain：
  - frontend
  - backend
  - api
  - auth
  - database
  - infra
  - cloud-storage
  - blockchain
  - smart-contract
  - wallet
  - i18n
  - testing
  - docs
  - ci
  - tooling
- 使用 deterministic keyword-based scoring
- 在 spec plan 抓取 issue 後輸出 detected domains
- 不依賴 LLM、API 或本地模型

## 不包含範圍
- 不修改 config schema
- 不修改 discovery pipeline
- 不修改 guardrails
- 不修正 word-boundary / substring false positive 問題
- 不新增測試框架
- 不修改 package 發佈設定

## 風險
- 低風險
- 目前使用 String.includes()，可能有少量 substring false positive
- 後續可另開 issue 改進 word-boundary matching

## 驗證方式
- npm run build
- smoke test：確認 classifier 對 frontend/backend/database 等案例有合理輸出
- git status --short 確認 working tree clean

## Checklist
- [x] PR 只處理一個明確 scope
- [x] 已對應 issue
- [x] 已遵守 presets/core/ai-collaboration.md
- [x] 已執行必要 build/test
- [x] 沒有混入 unrelated refactor
- [x] 沒有 breaking change
- [x] 未自行 merge PR