### PR TITLE
feat(discovery): add source file discovery and optional rules config

### DIFF
--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import { fetchIssue } from '../github/issue.js';
 import { loadConfig } from '../config/loader.js';
 import { matchRules } from '../rules/engine.js';
-import { loadExplicitDocs, discoverRelevantDocs, loadCorePreset } from '../docs/finder.js';
+import { loadExplicitDocs, discoverRelevantDocs, loadCorePreset, discoverSourceFiles } from '../docs/finder.js';
 import { renderTemplate } from '../template/renderer.js';
 import { DEFAULT_TEMPLATE } from '../template/default-template.js';
 import { writePackage } from '../output/writer.js';
@@ -57,18 +57,24 @@ export async function plan(
     ...alwaysDocs.map((d) => d.filePath),
     ...ruleDocs.map((d) => d.filePath),
   ]);
-  const discoveredDocs = await discoverRelevantDocs(issue, repoPath, loadedPaths);
+  const maxDocs = config.rulesFile.discovery?.max_docs ?? 5;
+  const discoveredDocs = await discoverRelevantDocs(issue, repoPath, loadedPaths, maxDocs);
+
+  // 6b. Auto-discover source files
+  const sourcePaths = config.rulesFile.discovery?.source_paths ?? [];
+  const maxSourceFiles = config.rulesFile.discovery?.max_source_files ?? 5;
+  const discoveredSources = await discoverSourceFiles(issue, repoPath, sourcePaths, maxSourceFiles);
 
   // 7. Summarise
   const missingDocs = [...alwaysDocs, ...ruleDocs].filter((d) => !d.found);
-  console.log(`✓ Docs — always: ${alwaysDocs.filter(d => d.found).length}, discovered: ${discoveredDocs.length}, rule: ${ruleDocs.filter(d => d.found).length}, missing: ${missingDocs.length}`);
+  console.log(`✓ Docs — always: ${alwaysDocs.filter(d => d.found).length}, discovered: ${discoveredDocs.length}, rule: ${ruleDocs.filter(d => d.found).length}, missing: ${missingDocs.length}, sources: ${discoveredSources.length}`);
   if (missingDocs.length > 0) {
     for (const d of missingDocs) console.warn(`  ⚠  Not found: ${d.filePath}`);
   }
 
   // 8. Build vars and render
   const allHints = [...new Set(matches.flatMap((m) => m.rule.hints))];
-  const vars = buildTemplateVars(issue, matches, allHints, alwaysDocs, discoveredDocs, ruleDocs, missingDocs, repoPath);
+  const vars = buildTemplateVars(issue, matches, allHints, alwaysDocs, discoveredDocs, ruleDocs, missingDocs, repoPath, discoveredSources);
   const rendered = renderTemplate(DEFAULT_TEMPLATE, vars);
 
   // 9. Output
@@ -97,7 +103,8 @@ function buildTemplateVars(
   discoveredDocs: DocSection[],
   ruleDocs: DocSection[],
   missingDocs: DocSection[],
-  repoPath: string
+  repoPath: string,
+  discoveredSources: DocSection[]
 ): TemplateVars {
   const checklist = issue.body
     .split('\n')
@@ -122,6 +129,7 @@ function buildTemplateVars(
     discovered_docs: renderDocList(discoveredDocs),
     rule_docs: renderDocList(ruleDocs.filter((d) => d.found)),
     missing_docs: missingList,
+    discovered_sources: renderDocList(discoveredSources),
     repo_path: repoPath,
     generated_at: new Date().toISOString(),
   };

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -10,9 +10,7 @@ export async function loadConfig(repoPath: string): Promise<Config> {
   const rulesPath = path.join(specAgentDir, 'rules.json');
   const rulesText = await safeReadFile(rulesPath);
   if (rulesText === null) {
-    throw new Error(
-      `No .spec-injector/rules.json found in ${resolved}. Run "spec init" to create one.`
-    );
+    return { repoPath: resolved, specAgentDir, rulesFile: { version: 1, rules: [] } };
   }
 
   let rulesFile: RulesFile;
@@ -96,9 +94,20 @@ function parseAndValidateRules(text: string, filePath: string): RulesFile {
     ? requireStringArray(raw['always_read'], 'always_read')
     : undefined;
 
+  const rawDiscovery = raw['discovery'] as Record<string, unknown> | undefined;
+
   return {
     version: 1,
     always_read: alwaysRead,
+    discovery: rawDiscovery
+      ? {
+          source_paths: rawDiscovery['source_paths'] !== undefined
+            ? requireStringArray(rawDiscovery['source_paths'], 'discovery.source_paths')
+            : undefined,
+          max_docs: typeof rawDiscovery['max_docs'] === 'number' ? rawDiscovery['max_docs'] : undefined,
+          max_source_files: typeof rawDiscovery['max_source_files'] === 'number' ? rawDiscovery['max_source_files'] : undefined,
+        }
+      : undefined,
     rules,
     defaults: rawDefaults
       ? {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,3 +1,9 @@
+export interface DiscoveryConfig {
+  source_paths?: string[];
+  max_docs?: number;
+  max_source_files?: number;
+}
+
 export interface Rule {
   id: string;
   description: string;
@@ -13,6 +19,7 @@ export interface Rule {
 export interface RulesFile {
   version: 1;
   always_read?: string[];   // included in every task package regardless of rule match
+  discovery?: DiscoveryConfig;
   rules: Rule[];
   defaults?: {
     docs?: string[];

--- a/src/docs/finder.ts
+++ b/src/docs/finder.ts
@@ -46,7 +46,8 @@ export async function loadCorePreset(): Promise<DocSection> {
 export async function discoverRelevantDocs(
   issue: Issue,
   repoPath: string,
-  excludePaths: Set<string>
+  excludePaths: Set<string>,
+  maxDocs: number = 5
 ): Promise<DocSection[]> {
   const keywords = tokenize(`${issue.title} ${issue.body}`);
   if (keywords.length === 0) return [];
@@ -64,7 +65,7 @@ export async function discoverRelevantDocs(
 
   scored.sort((a, b) => b.score - a.score);
 
-  return scored.slice(0, 5).map(({ filePath, content }) => ({
+  return scored.slice(0, maxDocs).map(({ filePath, content }) => ({
     filePath,
     content,
     found: true,
@@ -134,10 +135,80 @@ function tokenize(text: string): string[] {
 
 function scoreDoc(keywords: string[], filePath: string, content: string): number {
   const pathLower = filePath.toLowerCase();
+  const baseLower = path.basename(filePath).toLowerCase();
   const sample = content.slice(0, 2000).toLowerCase();
   let score = 0;
   for (const kw of keywords) {
     if (pathLower.includes(kw)) score += 2;
+    if (baseLower.includes(kw)) score += 2;
+    if (sample.includes(kw)) score += 1;
+  }
+  return score;
+}
+
+// --- source discovery ---
+
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.py', '.go', '.rs', '.java', '.sol', '.rb']);
+const SKIP_DIRS = new Set(['node_modules', '.git', 'dist', 'build', '.cache', 'vendor', 'coverage']);
+
+export async function discoverSourceFiles(
+  issue: Issue,
+  repoPath: string,
+  sourcePaths: string[],
+  maxFiles: number
+): Promise<DocSection[]> {
+  if (sourcePaths.length === 0 || maxFiles <= 0) return [];
+
+  const keywords = tokenize(`${issue.title} ${issue.body}`);
+  if (keywords.length === 0) return [];
+
+  const candidates: string[] = [];
+  for (const srcPath of sourcePaths) {
+    const absolute = path.resolve(repoPath, srcPath);
+    if (fs.existsSync(absolute) && fs.statSync(absolute).isDirectory()) {
+      walkSource(absolute, repoPath, candidates);
+    }
+  }
+
+  const scored: Array<{ filePath: string; score: number; content: string }> = [];
+  for (const relPath of candidates) {
+    const absolute = path.resolve(repoPath, relPath);
+    const raw = await safeReadFile(absolute);
+    if (raw === null) continue;
+    const score = scoreSrc(keywords, relPath, raw);
+    if (score > 0) scored.push({ filePath: relPath, score, content: raw.slice(0, 500) });
+  }
+
+  scored.sort((a, b) => b.score - a.score);
+
+  return scored.slice(0, maxFiles).map(({ filePath, content }) => ({
+    filePath,
+    content,
+    found: true,
+    kind: 'source' as DocSourceKind,
+  }));
+}
+
+function walkSource(dir: string, repoPath: string, results: string[]): void {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (SKIP_DIRS.has(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkSource(full, repoPath, results);
+    } else if (entry.isFile() && SOURCE_EXTENSIONS.has(path.extname(entry.name))) {
+      results.push(path.relative(repoPath, full));
+    }
+  }
+}
+
+function scoreSrc(keywords: string[], filePath: string, content: string): number {
+  const pathLower = filePath.toLowerCase();
+  const baseLower = path.basename(filePath).toLowerCase();
+  const sample = content.slice(0, 2000).toLowerCase();
+  let score = 0;
+  for (const kw of keywords) {
+    if (pathLower.includes(kw)) score += 2;
+    if (baseLower.includes(kw)) score += 2;
     if (sample.includes(kw)) score += 1;
   }
   return score;

--- a/src/docs/types.ts
+++ b/src/docs/types.ts
@@ -1,4 +1,4 @@
-export type DocSourceKind = 'always' | 'discovered' | 'rule' | 'missing';
+export type DocSourceKind = 'always' | 'discovered' | 'rule' | 'missing' | 'source';
 
 export interface DocSection {
   filePath: string;         // relative path from repo root

--- a/src/template/default-template.ts
+++ b/src/template/default-template.ts
@@ -39,6 +39,12 @@ Based on matched rules: **{{matched_rule_descriptions}}**
 
 ---
 
+## Auto-Discovered Source Files
+
+{{discovered_sources}}
+
+---
+
 ## Rule-Matched Documentation
 
 {{rule_docs}}

--- a/src/template/types.ts
+++ b/src/template/types.ts
@@ -12,6 +12,7 @@ export interface TemplateVars {
   discovered_docs: string;   // auto-discovered docs (keyword-scored)
   rule_docs: string;         // docs from matched rules
   missing_docs: string;      // files listed in always_read or rules that were not found
+  discovered_sources: string;  // auto-discovered source files
   repo_path: string;
   generated_at: string;
 }


### PR DESCRIPTION
## Source of truth

refs #3
- CLAUDE.md
- AGENTS.md
- presets/core/ai-collaboration.md

## 修改內容

- 新增 source file discovery
- 新增 DiscoveryConfig：
  - source_paths
  - max_docs
  - max_source_files
- rules.json 缺失時不再直接中止，而是使用空規則集繼續產生 task package
- discoverRelevantDocs() 支援 configurable maxDocs
- scoreDoc 新增 basename 獨立評分（+2），與 scoreSrc 一致，符合 Issue #3 「檔名匹配」評分準則
- task package 新增 Auto-Discovered Source Files 區塊
- 保持 deterministic keyword-based scoring
- 未修改 Issue #2 domain classifier

## 不包含範圍

- 不修改 domain classifier 行為
- 不修改 guardrails pipeline
- 不修改 config schema v2 完整結構
- 不加入 LLM / API / local model
- 不加入 vector DB / semantic search
- 不新增測試框架
- 不修改 package 發佈設定

## 風險

- 低風險
- source discovery 目前使用 String.includes()，可能存在少量 substring false positive
- source content 僅截取前 500 characters，以避免 task package 過大
- source walk 沒有額外 permission error handling，與既有 markdown walk 行為一致

## 驗證方式

```bash
npm run build
# smoke test：確認 docs discovery 與 source discovery 皆有穩定輸出
git diff main src/classifier/domain.ts  # 確認 Issue #2 classifier 未被修改
git status --short                      # 確認 working tree clean
```

## Checklist

- [x] PR 只處理一個明確 scope
- [x] 已對應 issue（`refs #3` 已加入 commit message）
- [x] 已遵守 `presets/core/ai-collaboration.md`
- [x] 已執行必要 build/test（npm run build 通過）
- [x] 沒有混入 unrelated refactor
- [x] 沒有 breaking change
- [x] 未自行 merge PR