### PR TITLE
docs(pr-template): add Closes keyword and zh-TW instructions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,15 @@
 ## Source of truth
 
-Closes #<!-- issue number -->
+- Closes #<issue-number>
+- refs #<issue-number>
+- Related docs/specs:
+  - ...
+
+<!--
+請將 `<issue-number>` 替換成來源 issue 編號。
+若此 PR merge 後應自動關閉 issue，請保留 `Closes #<issue-number>`。
+若此 PR 不應關閉任何 issue，請改成 `Closes: N/A` 並說明原因。
+-->
 
 ## 修改內容
 


### PR DESCRIPTION
## Source of truth

- Closes #1
- refs #1
- Related docs/specs:
  - .github/pull_request_template.md
  - presets/core/ai-collaboration.md
  - CLAUDE.md
  - AGENTS.md

## 修改內容

- 在 PR template 的 Source of truth 區段新增 `Closes #<issue-number>`
- 補充繁體中文註解，說明 PR merge 後 GitHub 會自動關閉 linked issue
- 說明若 PR 不應自動關閉 issue，應改寫為 `Closes: N/A` 並說明原因

## 不包含範圍

- 不修改 runtime code
- 不修改 package.json
- 不新增 GitHub Actions
- 不修改 branch protection
- 不修改 issue templates
- 不 stage 既有 untracked docs/

## 風險

- 低風險，僅修改 PR template
- 後續 PR 仍需人為正確替換 `<issue-number>`

## 驗證方式

- git status --short 確認只有 `.github/pull_request_template.md` 被納入 commit
- 確認 PR target 是 main
- 確認 PR body 包含 `Closes #1`

## Checklist

- [x] PR 只處理一個明確 scope
- [x] 已對應 issue
- [x] 已遵守 presets/core/ai-collaboration.md
- [x] 無 runtime code changes
- [x] 沒有混入 unrelated refactor
- [x] 沒有 breaking change
- [x] 未自行 merge PR