### PR TITLE
feat(pipeline): integrate domains and guardrails into spec plan output

### DIFF
--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -74,7 +74,7 @@ export async function plan(
 
   // 8. Build vars and render
   const allHints = [...new Set(matches.flatMap((m) => m.rule.hints))];
-  const vars = buildTemplateVars(issue, matches, allHints, alwaysDocs, discoveredDocs, ruleDocs, missingDocs, repoPath, discoveredSources);
+  const vars = buildTemplateVars(issue, domains, matches, allHints, alwaysDocs, discoveredDocs, ruleDocs, missingDocs, repoPath, discoveredSources);
   const rendered = renderTemplate(DEFAULT_TEMPLATE, vars);
 
   // 9. Output
@@ -97,6 +97,7 @@ function renderDocList(docs: DocSection[]): string {
 
 function buildTemplateVars(
   issue: Issue,
+  domains: string[],
   matches: MatchResult[],
   allHints: string[],
   alwaysDocs: DocSection[],
@@ -115,6 +116,8 @@ function buildTemplateVars(
     ? missingDocs.map((d) => `- \`${d.filePath}\` — not found`).join('\n')
     : '(none)';
 
+  const nonDefaultMatches = matches.filter((m) => m.rule.id !== '__defaults__');
+
   return {
     issue_title: issue.title,
     issue_number: String(issue.number),
@@ -122,8 +125,16 @@ function buildTemplateVars(
     issue_body: issue.body || '(no description provided)',
     issue_labels: issue.labels.join(', ') || '(none)',
     issue_checklist: checklist,
+    detected_domains: domains.length > 0
+      ? domains.map((d) => `- ${d}`).join('\n')
+      : '(none)',
     matched_rule_ids: matches.map((m) => m.rule.id).join(', ') || '(none)',
     matched_rule_descriptions: matches.map((m) => m.rule.description).join(', ') || '(none)',
+    matched_guardrails: nonDefaultMatches.length > 0
+      ? nonDefaultMatches
+          .map((m) => `- **${m.rule.id}**: ${m.rule.description}`)
+          .join('\n')
+      : '(none matched)',
     matched_hints: allHints.map((h) => `- ${h}`).join('\n') || '(none)',
     always_docs: renderDocList(alwaysDocs.filter((d) => d.found)),
     discovered_docs: renderDocList(discoveredDocs),

--- a/src/template/default-template.ts
+++ b/src/template/default-template.ts
@@ -2,62 +2,65 @@ export const DEFAULT_TEMPLATE = `# Task Package: {{issue_title}}
 
 **Issue:** [#{{issue_number}}]({{issue_url}})
 **Generated:** {{generated_at}}
-**Matched rules:** {{matched_rule_ids}}
 **Repo:** \`{{repo_path}}\`
 
 ---
 
-## Issue Description
+## 1. Source Issue
+
+**Labels:** {{issue_labels}}
 
 {{issue_body}}
 
 ---
 
-## Labels
+## 2. Detected Domains
 
-{{issue_labels}}
-
----
-
-## Implementation Scope
-
-Based on matched rules: **{{matched_rule_descriptions}}**
-
-{{matched_hints}}
+{{detected_domains}}
 
 ---
 
-## Always-Read Documentation
+## 3. Always-Read Files
 
 {{always_docs}}
 
 ---
 
-## Auto-Discovered Documentation
+## 4. Auto-Discovered Documentation
 
 {{discovered_docs}}
 
 ---
 
-## Auto-Discovered Source Files
+## 5. Auto-Discovered Source Files
 
 {{discovered_sources}}
 
 ---
 
-## Rule-Matched Documentation
+## 6. Matched Guardrails
+
+{{matched_guardrails}}
+
+### Rule-Matched Documentation
 
 {{rule_docs}}
 
 ---
 
-## Missing Files
+## 7. Missing Files
 
 {{missing_docs}}
 
 ---
 
-## Acceptance Checklist
+## 8. Implementation Constraints
+
+{{matched_hints}}
+
+---
+
+## 9. Suggested Verification Checklist
 
 > Auto-extracted from issue body (edit as needed)
 

--- a/src/template/types.ts
+++ b/src/template/types.ts
@@ -5,14 +5,16 @@ export interface TemplateVars {
   issue_body: string;
   issue_labels: string;
   issue_checklist: string;
+  detected_domains: string;
   matched_rule_ids: string;
   matched_rule_descriptions: string;
+  matched_guardrails: string;
   matched_hints: string;
-  always_docs: string;       // docs from always_read that were found
-  discovered_docs: string;   // auto-discovered docs (keyword-scored)
-  rule_docs: string;         // docs from matched rules
-  missing_docs: string;      // files listed in always_read or rules that were not found
-  discovered_sources: string;  // auto-discovered source files
+  always_docs: string;
+  discovered_docs: string;
+  rule_docs: string;
+  missing_docs: string;
+  discovered_sources: string;
   repo_path: string;
   generated_at: string;
 }


### PR DESCRIPTION
## Source of truth

- Closes #4
- refs #4
- Related docs/specs:
  - CLAUDE.md
  - AGENTS.md
  - presets/core/ai-collaboration.md
  - src/template/default-template.ts
  - src/cli/plan.ts
  - src/template/types.ts

## 修改內容

- 將 detected domains 加入 spec plan task package output
- 新增 matched guardrails 輸出欄位
- 過濾 synthetic `__defaults__`，避免把 default fallback 顯示成 guardrail
- 將 DEFAULT_TEMPLATE 重構為 9 個清楚分離的章節：
  1. Source issue
  2. Detected domains
  3. Always-read files
  4. Auto-discovered docs
  5. Auto-discovered source files
  6. Matched guardrails
  7. Missing files
  8. Implementation constraints
  9. Suggested verification checklist

## 不包含範圍

- 不修改 domain classifier 行為
- 不修改 repo-aware discovery 行為
- 不修改 rules matching engine
- 不修改 config schema
- 不新增 LLM / API / local model
- 不新增 vector DB / semantic search
- 不新增測試框架
- 不修改 package 發佈設定

## 風險

- 低風險
- Task package template 標題與章節順序有變更
- 目前沒有下游工具依賴舊 template 字串；若未來有消費 rendered output 的工具，需同步檢查

## 驗證方式

- npm run build
- spec plan <issue-ref> --dry-run 驗證輸出格式
- git status --short 確認 working tree clean 或僅剩 unrelated pre-existing untracked files

## Checklist

- [x] PR 只處理一個明確 scope
- [x] 已對應 issue
- [x] 已遵守 presets/core/ai-collaboration.md
- [x] 已執行必要 build/test
- [x] 沒有混入 unrelated refactor
- [x] 沒有 breaking change
- [x] 未自行 merge PR