### PR TITLE
docs(workflow): require implementation evidence comment before PR merge

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,6 +31,47 @@
 # 執行驗證指令
 ```
 
+## 實作證據 (Implementation Evidence)
+
+**Merge 前必須完成：** 在來源 issue 留下實作證據 comment，並將永久連結填入下方。
+
+Issue comment URL: <!-- https://github.com/owner/repo/issues/N#issuecomment-XXXXXXX -->
+
+<details>
+<summary>實作證據 comment 範本（展開複製至來源 issue）</summary>
+
+```markdown
+## 實作摘要
+
+<!-- 一句話說明此 PR 解決了什麼問題 -->
+
+## 修改檔案
+
+| 檔案 | 修改原因 |
+|---|---|
+| path/to/file | ... |
+
+## 驗證方式
+
+```bash
+# 驗證指令與預期輸出
+```
+
+## 風險 / 不包含範圍
+
+<!-- 明確說明邊界 -->
+
+## PR URL
+
+<!-- https://github.com/owner/repo/pull/N -->
+
+## Commit hash
+
+<!-- git log --oneline -1 -->
+```
+
+</details>
+
 ## Checklist
 
 - [ ] PR 只處理一個明確 scope
@@ -40,3 +81,4 @@
 - [ ] 沒有混入 unrelated refactor
 - [ ] 若有 breaking change，已明確標示
 - [ ] 若有 config/schema/CLI 行為變更，已更新文件
+- [ ] 已在來源 issue 留下實作證據 comment，並將 URL 填入上方「實作證據」欄位

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,8 @@
 2. 確認 scope（列出允許修改的檔案）
 3. 逐步實作
 4. 執行必要的驗證指令
-5. 回報結果給 Claude 審查
+5. 輸出實作證據摘要（修改檔案、驗證方式、風險範圍、commit hash），供 Claude 在來源 issue 留下 comment
+6. 回報結果給 Claude 審查
 
 ## 驗證指令
 實作完成後必須執行：
@@ -54,7 +55,8 @@ npm test
 2. 禁止直接 push 到 main
 3. Push feature branch 到 origin
 4. 通知 Claude 建立 PR
-5. 不自行 merge PR
+5. 確認 Claude 已在來源 issue 填入實作證據 comment URL
+6. 不自行 merge PR
 
 ## 禁止行為
 - 直接 push 到 main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,8 @@
 3. Push feature branch 到 origin
 4. 建立 PR，目標分支為 main
 5. 使用倉庫 PR 範本（`.github/pull_request_template.md`）
-6. 不自行 merge PR，由人類決定
+6. merge 前，在來源 issue 留下實作證據 comment，並將 URL 填入 PR 的「實作證據」欄位
+7. 不自行 merge PR，由人類決定
 
 ## 禁止行為
 - 直接 push 到 main

--- a/presets/core/ai-collaboration.md
+++ b/presets/core/ai-collaboration.md
@@ -32,6 +32,8 @@
 - Must explicitly state:
   - what is included
   - what is NOT included
+- Before merge, an implementation evidence comment must exist on the source issue
+- PR description must include the issue comment URL in the "Implementation Evidence" field
 
 ## Output Format (for AI)
 


### PR DESCRIPTION
## Source of truth

- Closes #1
- refs #1
- Related docs/specs:
  - .github/pull_request_template.md
  - CLAUDE.md
  - AGENTS.md
  - presets/core/ai-collaboration.md

## 修改內容

- 在 PR template 新增 `Implementation Evidence` 區塊
- 要求 merge 前必須在來源 issue 留下實作證據 comment
- 要求 PR 填入 issue comment URL
- 更新 CLAUDE.md / AGENTS.md / core preset，讓 Claude 與 Codex 都遵守此 workflow
- 實作證據 comment 需包含：
  - 實作摘要
  - 修改檔案
  - 驗證方式
  - 風險 / 不包含範圍
  - PR URL
  - Commit hash

## 不包含範圍

- 不修改 runtime code
- 不修改 package.json
- 不新增 GitHub Actions
- 不新增 bot
- 不新增 branch protection automation
- 不修改 issue templates
- 不修改 config schema

## 風險

- 低風險，僅修改文件與 template
- 目前仍是文件層級要求，無自動阻擋未填 evidence URL 的 merge
- 需由人類 reviewer 在 merge 前確認 evidence comment 已存在

## 驗證方式

- git status --short 確認只有指定文件被納入 commit
- 確認 PR template 包含 `Implementation Evidence` 區塊
- 確認 PR template 包含 issue comment URL 欄位
- 確認沒有 runtime code changes

## 實作證據 (Implementation Evidence)

**Merge 前必須完成：** 在來源 issue 留下實作證據 comment，並將永久連結填入下方。

Issue comment URL: <!-- PR 建立後，請在 issue #1 留下實作證據 comment，然後填入該 comment URL -->

## Checklist

- [x] PR 只處理一個明確 scope
- [x] 已對應 issue
- [x] 已遵守 presets/core/ai-collaboration.md
- [x] 無 runtime code changes
- [x] 沒有混入 unrelated refactor
- [x] 沒有 breaking change
- [ ] 已在來源 issue 留下實作證據 comment，並將 URL 填入上方「實作證據」欄位
- [x] 未自行 merge PR