### PR TITLE
fix(cli): update help text for config schema v2

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -22,7 +22,7 @@ program
 // init subcommand
 program
   .command('init')
-  .description('Scaffold .spec-agent/ config in target repo')
+  .description('Scaffold .spec-injector/config.json in target repo')
   .option('--repo <path>', 'Path to target repo (default: CWD)')
   .action(async (opts: { repo?: string }) => {
     const { init } = await import('./init.js');
@@ -32,7 +32,7 @@ program
 // validate subcommand
 program
   .command('validate')
-  .description('Validate .spec-injector/rules.json syntax')
+  .description('Validate .spec-injector/config.json against schema v2')
   .option('--repo <path>', 'Path to target repo (default: CWD)')
   .action(async (opts: { repo?: string }) => {
     const { validate } = await import('./validate.js');


### PR DESCRIPTION
## Source of truth

Closes #17

## 修改內容

- Updated CLI command descriptions for `spec init` and `spec validate` to point at `.spec-injector/config.json`.
- Updated validate help text to describe schema v2 validation.

## 不包含範圍

- No config schema changes.
- No runtime behavior changes for `spec init`, `spec validate`, or `spec plan`.
- No test framework or GitHub Actions changes.
- Did not address classifier false positives, docs/architecture.md missing warning, or discovery noise.
- README unchanged because its matching help/config text is already aligned.

## 風險

- Low: help text only; no runtime code paths changed.

## 驗證方式

- `npm run build` passed.
- `spec --help` verified.
- `spec init --help` verified.
- `spec validate --help` verified.
- `npm test` is unavailable because this package has no test script.

## Implementation Evidence

- Commit: 866443d
- Changed files: `src/cli/index.ts`
- Issue evidence comment: https://github.com/Erick52106/spec-injector/issues/17#issuecomment-4361197312

## Checklist

- [x] Only handled issue #17.
- [x] Started from latest `main`.
- [x] Kept changes limited to CLI help text.
- [x] Did not modify config schema or runtime behavior.
- [x] Ran required build and help text verification.
