### PR TITLE
fix(init): remove missing architecture doc from default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,7 @@ Edit `.spec-injector/config.json` in your target repo:
     "AGENTS.md"
   ],
   "discovery": {
-    "docs": [
-      "docs/architecture.md"
-    ],
+    "docs": [],
     "source": [
       "src"
     ],

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -10,7 +10,6 @@ const EXAMPLE_CONFIG = {
   always_read: [
     "CLAUDE.md",
     "AGENTS.md",
-    "docs/architecture.md",
   ],
   discovery: {
     docs: [],


### PR DESCRIPTION
## Source of truth

Closes #19

## 修改內容

- Removed `docs/architecture.md` from the `spec init` default `always_read` list.
- Updated the README config example so `discovery.docs` does not imply `docs/architecture.md` exists by default.

## 不包含範圍

- Did not modify CLI help text.
- Did not modify config schema.
- Did not modify `loadConfig`.
- Did not modify the discovery pipeline.
- Did not add docs files, migrations, test frameworks, GitHub Actions, compact output mode, or discovery noise changes.
- Did not handle #18, #20, or #21.

## 風險

- Low risk: this only changes generated default config content and README example text.
- Existing user configs are unaffected.

## 驗證方式

- `npm run build`：passed.
- `npm test`：attempted; repository has no `test` script.
- `npm exec -- spec init --repo /tmp/spec-injector-init-test`：passed.
- `cat /tmp/spec-injector-init-test/.spec-injector/config.json`：confirmed generated config does not contain `docs/architecture.md`.
- `npm exec -- spec validate --repo /tmp/spec-injector-init-test`：passed.
- `npm exec -- spec plan 19 --repo /tmp/spec-injector-init-test --dry-run --verbose`：attempted; failed because `/tmp/spec-injector-init-test` is not a Git repo, so no scope expansion was done.

## Implementation Evidence

- Issue comment: https://github.com/Erick52106/spec-injector/issues/19#issuecomment-4361236902
- Commit: 347d9b56f062acc64ef2bfb33282344de8a7f478

## Checklist

- [x] Only issue #19 handled.
- [x] Branch created from latest `main`.
- [x] Default `always_read` no longer includes `docs/architecture.md`.
- [x] README default/config example checked and synchronized.
- [x] No `docs/architecture.md` file created.
- [x] Build verified.
- [x] Init and validate verified in a temp directory.
- [x] PR opened without merging.
