### PR TITLE
fix(discovery): add default excludes for generated planning docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ Edit `.spec-injector/config.json` in your target repo:
     ],
     "exclude": [
       "node_modules",
-      "dist"
+      "dist",
+      "docs/superpowers"
     ],
     "max_docs": 5,
     "max_source_files": 5
@@ -107,7 +108,7 @@ Edit `.spec-injector/config.json` in your target repo:
 - **always_read**: List of files that are always included in every task package.
 - **discovery.docs**: Explicit paths to documentation files to always include.
 - **discovery.source**: Directories to scan for auto-discovered source files.
-- **discovery.exclude**: Paths or directories to skip during auto-discovery.
+- **discovery.exclude**: Paths or directories to skip during auto-discovery. Use it to keep generated planning docs, AI scratch docs, and temporary agent notes out of task packages; for example, add a repo-local scratch directory such as `docs/superpowers` when you use one.
 - **discovery.max_docs**: Maximum number of auto-discovered docs (default: 5).
 - **discovery.max_source_files**: Maximum number of auto-discovered source files (default: 5).
 - **guardrails**:

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -14,7 +14,11 @@ const EXAMPLE_CONFIG = {
   discovery: {
     docs: [],
     source: ["src"],
-    exclude: [],
+    exclude: [
+      "node_modules",
+      "dist",
+      "docs/superpowers",
+    ],
     max_docs: 5,
     max_source_files: 5,
   },


### PR DESCRIPTION
## Source of truth
Closes #20

## 修改內容
- Updated `spec init` default config so `discovery.exclude` includes `node_modules`, `dist`, and `docs/superpowers`.
- Updated README configuration guidance to explain using `discovery.exclude` for generated planning docs, AI scratch docs, and temporary agent notes.

## 不包含範圍
- Did not change discovery scoring.
- Did not change `src/docs/finder.ts`, `src/cli/plan.ts`, config loader/types, classifier, templates, or `package.json`.
- Did not add a gitignore parser, glob engine, semantic search, LLM/API/local model, GitHub Actions, test framework, compact output mode, or Layer 2 `/spec-plan` workflow.

## 風險
- Low risk: this only changes generated default config and documentation.
- Existing repos are unaffected until they opt into the updated exclude list or re-run init in a fresh repo.

## 驗證方式
- `npm run build`
- `rm -rf /tmp/spec-injector-exclude-test`
- `mkdir -p /tmp/spec-injector-exclude-test`
- `spec init --repo /tmp/spec-injector-exclude-test`
- `cat /tmp/spec-injector-exclude-test/.spec-injector/config.json`
- `spec validate --repo /tmp/spec-injector-exclude-test`
- `npm test` attempted; repository has no `test` script.

## Implementation Evidence
- Issue comment: https://github.com/Erick52106/spec-injector/issues/20#issuecomment-4361277484
- Commit: 71b5bea454836ed6116cc0ef8257a8faf7ac1c69

## Checklist
- [x] Scope limited to #20
- [x] Branch created from latest `main`
- [x] Only allowed files changed
- [x] Default config contains the intended `discovery.exclude` values
- [x] README does not imply `docs/superpowers` always exists
- [x] Build passed
- [x] Init and validate smoke test passed
- [x] PR created without merging
