### PR TITLE
feat(plan): add compact prompt output mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ spec plan <issue-url>
 spec plan <issue-number> --repo /path/to/repo
 spec plan <issue-url> --dry-run    # print to stdout, don't write file
 spec plan <issue-url> --verbose    # show detailed pipeline steps
+spec plan <issue-url> --format prompt  # short AI planning prompt
 ```
 
 The pipeline:
@@ -45,6 +46,8 @@ The pipeline:
 2. **Classify & Match**: Keyword-based domain detection; matched domains trigger `guardrails`.
 3. **Load Docs & Source**: Loads `always_read` and `discovery.docs`; auto-discovers docs and source files; reports missing files.
 4. **Render**: Writes task package to `.spec-injector/out/issue-<number>-task-package.md` (or prints with `--dry-run`).
+
+By default, `spec plan` renders the full task package with inline context. Use `--format prompt` when a Layer 2 workflow or another AI should draft an implementation plan first: prompt output lists relevant references only, without inlining always-read docs, README content, discovered docs, or source snippets.
 
 ### 3. Validate config
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,7 +14,8 @@ program
   .option('--repo <path>', 'Path to target repo (default: CWD)')
   .option('--dry-run', 'Print output to stdout, do not write file')
   .option('--verbose', 'Show detailed matching steps')
-  .action(async (issue: string, opts: { repo?: string; dryRun?: boolean; verbose?: boolean }) => {
+  .option('--format <format>', 'Output format: full or prompt (default: full)')
+  .action(async (issue: string, opts: { repo?: string; dryRun?: boolean; verbose?: boolean; format?: string }) => {
     const { plan } = await import('./plan.js');
     await plan(issue, opts);
   });

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -4,6 +4,7 @@ import { loadConfig } from '../config/loader.js';
 import { loadExplicitDocs, discoverRelevantDocs, loadCorePreset, discoverSourceFiles } from '../docs/finder.js';
 import { renderTemplate } from '../template/renderer.js';
 import { DEFAULT_TEMPLATE } from '../template/default-template.js';
+import { PROMPT_TEMPLATE } from '../template/prompt-template.js';
 import { writePackage } from '../output/writer.js';
 import { classifyDomains } from '../classifier/domain.js';
 import type { TemplateVars } from '../template/types.js';
@@ -13,9 +14,13 @@ import type { DocSection } from '../docs/types.js';
 
 export async function plan(
   issueRef: string,
-  opts: { repo?: string; dryRun?: boolean; verbose?: boolean }
+  opts: { repo?: string; dryRun?: boolean; verbose?: boolean; format?: string }
 ): Promise<void> {
   const repoPath = path.resolve(opts.repo ?? process.cwd());
+  const format = opts.format ?? 'full';
+  if (!['full', 'prompt'].includes(format)) {
+    throw new Error(`Unsupported plan format: ${format}. Expected "full" or "prompt".`);
+  }
 
   if (opts.verbose) console.log(`→ Target repo: ${repoPath}`);
 
@@ -74,7 +79,8 @@ export async function plan(
 
   // 8. Build vars and render
   const vars = buildTemplateVars(issue, domains, matchedGuardrails, alwaysDocs, discoveredDocs, discoveryDocs, missingDocs, repoPath, discoveredSources);
-  const rendered = renderTemplate(DEFAULT_TEMPLATE, vars);
+  const template = format === 'prompt' ? PROMPT_TEMPLATE : DEFAULT_TEMPLATE;
+  const rendered = renderTemplate(template, vars);
 
   // 9. Output
   if (opts.dryRun) {
@@ -92,6 +98,17 @@ function renderDocList(docs: DocSection[]): string {
   return docs
     .map((d) => `### ${d.filePath}\n\n${d.content.trim()}`)
     .join('\n\n---\n\n');
+}
+
+function renderPathList(docs: DocSection[]): string {
+  if (docs.length === 0) return '(none)';
+  return docs.map((d) => `- \`${d.filePath}\``).join('\n');
+}
+
+function renderImplementationConstraints(matchedGuardrails: Guardrail[]): string {
+  const constraints = matchedGuardrails.map((g) => `- ${g.id}: ${g.risk}`);
+  constraints.push('- Stay within the source issue scope and referenced files.');
+  return constraints.join('\n');
 }
 
 function buildTemplateVars(
@@ -130,6 +147,11 @@ function buildTemplateVars(
       ? matchedGuardrails.map(g => `- **${g.id}**: ${g.risk}`).join('\n')
       : '(none matched)',
     matched_hints: '(none)',
+    prompt_always_files: renderPathList(alwaysDocs),
+    prompt_discovered_docs: renderPathList(discoveredDocs),
+    prompt_rule_docs: renderPathList(discoveryDocs.filter((d) => d.found)),
+    prompt_discovered_sources: renderPathList(discoveredSources),
+    prompt_implementation_constraints: renderImplementationConstraints(matchedGuardrails),
     always_docs: renderDocList(alwaysDocs.filter((d) => d.found)),
     discovered_docs: renderDocList(discoveredDocs),
     rule_docs: renderDocList(discoveryDocs.filter((d) => d.found)),

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -147,7 +147,7 @@ function buildTemplateVars(
       ? matchedGuardrails.map(g => `- **${g.id}**: ${g.risk}`).join('\n')
       : '(none matched)',
     matched_hints: '(none)',
-    prompt_always_files: renderPathList(alwaysDocs),
+    prompt_always_files: renderPathList(alwaysDocs.filter((d) => d.found)),
     prompt_discovered_docs: renderPathList(discoveredDocs),
     prompt_rule_docs: renderPathList(discoveryDocs.filter((d) => d.found)),
     prompt_discovered_sources: renderPathList(discoveredSources),

--- a/src/template/prompt-template.ts
+++ b/src/template/prompt-template.ts
@@ -1,0 +1,51 @@
+export const PROMPT_TEMPLATE = `# Implementation Plan Prompt: {{issue_title}}
+
+## 1. Source Issue
+
+- Issue: #{{issue_number}}
+- Title: {{issue_title}}
+- URL: {{issue_url}}
+- Labels: {{issue_labels}}
+
+## 2. Detected Domains
+
+{{detected_domains}}
+
+## 3. Matched Guardrails
+
+{{matched_guardrails}}
+
+## 4. Relevant File References
+
+### Always-Read Files
+
+{{prompt_always_files}}
+
+### Discovered Docs
+
+{{prompt_discovered_docs}}
+
+### Rule-Matched Docs
+
+{{prompt_rule_docs}}
+
+### Discovered Source Files
+
+{{prompt_discovered_sources}}
+
+## 5. Missing Files
+
+{{missing_docs}}
+
+## 6. Implementation Constraints
+
+{{prompt_implementation_constraints}}
+
+## 7. Suggested Verification Checklist
+
+{{issue_checklist}}
+
+## 8. Final Implementation Prompt
+
+Read the referenced files as needed, then propose an implementation plan for this issue. List the files you intend to modify, wait for human approval before editing, and do not modify out-of-scope files.
+`;

--- a/src/template/types.ts
+++ b/src/template/types.ts
@@ -10,6 +10,11 @@ export interface TemplateVars {
   matched_rule_descriptions: string;
   matched_guardrails: string;
   matched_hints: string;
+  prompt_always_files: string;
+  prompt_discovered_docs: string;
+  prompt_rule_docs: string;
+  prompt_discovered_sources: string;
+  prompt_implementation_constraints: string;
   always_docs: string;
   discovered_docs: string;
   rule_docs: string;


### PR DESCRIPTION
## Source of truth

Closes #18

## 修改內容

- 新增 `spec plan --format prompt`，輸出短版 implementation plan prompt skeleton。
- 新增 `src/template/prompt-template.ts`，prompt mode 只列 issue metadata、detected domains、matched guardrails、relevant file paths、missing files、verification checklist 與 final implementation prompt。
- 擴充 `TemplateVars` 與 `plan.ts`，讓 full mode 繼續使用既有 `DEFAULT_TEMPLATE`，prompt mode 使用新 template。
- 因 `--format prompt` 必須由 Commander subcommand 註冊，因此新增修改 `src/cli/index.ts`。該修改僅為 option wiring，不改變既有 default output 行為。
- README 補充 `--format prompt` 的短說明。

## 不包含範圍

- 不修改 classifier 行為。
- 不修改 discovery scoring。
- 不修改 config schema 或 `spec init` default config。
- 不新增 LLM / API / local model。
- 不新增 GitHub Actions、test framework 或 dependency。
- 不處理 #21 Layer 2 `/spec-plan` workflow。
- `src/cli/index.ts` 僅做最小 Commander option wiring，不修改其他 command 行為。

## 風險

- `--format` 目前只接受 `full` 與 `prompt`，其他值會報錯。
- 此 repo 沒有 `npm test` script；未新增測試框架。

## 驗證方式

- `npm run build`
- `spec plan --help`
- `spec plan 18 --repo . --dry-run --verbose`
- `spec plan 18 --repo . --dry-run --verbose --format prompt`
- prompt output keyword check confirmed no inline long docs/source snippets.
- `npm test` attempted, but package has no `test` script.

## Implementation Evidence

- Issue comment permalink: https://github.com/Erick52106/spec-injector/issues/18#issuecomment-4361332356
- Commit: b16080915cf6532ba74a5d92beaf434145b7c70a

## Checklist

- [x] Default full output remains available.
- [x] Prompt output is shorter than full output.
- [x] Prompt output lists references instead of inlining always-read docs, README, discovered docs, or source snippets.
- [x] `spec plan --help` shows the new option.
- [x] Build passes.
- [x] PR is draft and not merged.
