### PR TITLE
docs(workflow): add spec-plan AI command instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,15 @@
 - 不重構無關程式碼
 - 不確定時先確認，不自行假設
 
+## `/spec-plan <issue>` 委派實作規範
+Codex 若被委派 `/spec-plan <issue>` 後的實作任務，必須：
+- 先確認 Claude 產出的 task package / implementation plan
+- 只依 approved plan 實作
+- 不得自行擴大 scope
+- 不得跳過 guardrails
+- 不得修改 approved plan 以外的檔案
+- 若發現需要修改 plan 以外的檔案，必須停止並回報
+
 ## 實作工作流程
 1. 從 Claude 接收已核准的計畫
 2. 確認 scope（列出允許修改的檔案）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,50 @@
 - 嚴格遵守 Issue scope，不修改無關檔案
 - 不確定時先詢問，不自行擴展範圍
 
+## `/spec-plan <issue>` 工作流
+當使用者在 Claude Code 中輸入：
+
+```bash
+/spec-plan <issue>
+```
+
+Claude 必須先使用 compact prompt mode 執行：
+
+```bash
+spec plan <issue> --repo . --dry-run --format prompt --verbose
+```
+
+若 `spec` 指令不存在，Claude 必須回報此狀態，並建議使用者先執行：
+- `npm run build`
+- `npm link`
+- 或使用 repo-local executable
+
+Claude 不得因為 `spec` 指令不存在而自行修改、建立或刪除檔案。
+
+讀取 prompt output 後，Claude 必須摘要：
+- source issue
+- detected domains
+- matched guardrails
+- relevant file references
+- missing files
+- implementation constraints
+- suggested verification checklist
+
+接著 Claude 必須產生 implementation plan，並列出：
+- 預計修改檔案
+- 不包含範圍
+- 風險
+- 驗證方式
+
+最後必須停下來等待人類批准。未經批准，Claude 不得：
+- 修改檔案
+- 建立檔案
+- 刪除檔案
+- commit
+- push
+- 開 PR
+- merge PR
+
 ## 實作工作流程
 1. 閱讀需求與相關檔案
 2. 提出計畫並說明風險

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Requires: Node.js 20+, [`gh`](https://cli.github.com/) authenticated.
 
 ## Usage
 
-## AI Workflow Usage
+### AI Workflow Usage
 
 人類可在 Claude Code 中輸入 `/spec-plan <issue>`，讓 AI 先執行：
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ Requires: Node.js 20+, [`gh`](https://cli.github.com/) authenticated.
 
 ## Usage
 
+## AI Workflow Usage
+
+人類可在 Claude Code 中輸入 `/spec-plan <issue>`，讓 AI 先執行：
+
+```bash
+spec plan <issue> --repo . --dry-run --format prompt --verbose
+```
+
+AI 會先產生 implementation plan，並在人類批准後才進入實作。這是 repo-level instruction，不是 spec-injector runtime CLI command；真正的 CLI command 仍是 `spec plan`。
+
 ### 1. Initialize a repo
 
 ```bash


### PR DESCRIPTION
## Source of truth
Closes #21

## 修改內容
- 在 CLAUDE.md 新增 `/spec-plan <issue>` repo-level workflow：先執行 compact prompt mode 的 `spec plan` dry-run，摘要 prompt output，產生 implementation plan，並等待人類批准。
- 在 AGENTS.md 新增 Codex 被委派後只能依 approved plan 實作、不得跳過 guardrails 或擴大 scope 的規範。
- 在 README.md 新增短版 AI Workflow Usage，說明 `/spec-plan` 是 repo-level instruction，不是 runtime CLI command。

## 不包含範圍
- 未修改 runtime code、`src/**`、`bin/**`、`package.json`、`.github/**` 或 `presets/**`。
- 未新增 slash command plugin、GitHub Action、bot、MCP 或 docs 檔案。
- 未處理既有 untracked `.spec-injector/`、`docs/`。

## 風險
- 低風險，僅更新 repo-level workflow 文件。
- `npm test` 無法執行，因為 repo 目前沒有 `test` script。

## 驗證方式
- `npm run build`
- `npm test`（確認缺少 `test` script）
- `git diff --check -- CLAUDE.md AGENTS.md README.md`
- `rg` 檢查 `/spec-plan` 與 `spec plan <issue> --repo . --dry-run --format prompt --verbose` 文案

## Implementation Evidence
- Issue comment: https://github.com/Erick52106/spec-injector/issues/21#issuecomment-4361406077
- Commit: c3b2b9fc7eae0f641c088d7a6a9054c4ad85e744

## Checklist
- [x] 只處理 issue #21
- [x] 從最新 main 建立 `workflow/spec-plan-command`
- [x] 只修改 `CLAUDE.md`、`AGENTS.md`、`README.md`
- [x] 未修改 runtime code
- [x] `/spec-plan` 未描述成內建 CLI command
- [x] 明確寫入 compact prompt command
- [x] 未要求 AI 使用 full output
- [x] PR 非 draft
- [x] Issue evidence comment URL 已回填