### PR TITLE
docs(config): document optional always_read files

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,10 @@ Edit `.spec-injector/config.json` in your target repo:
 
 - **version**: Must be `2`.
 - **project.name / project.type**: Metadata for display in validation and reports.
-- **always_read**: List of files that are always included in every task package.
+- **always_read**: Team-defined files that should always be checked for every task package. `CLAUDE.md` and `AGENTS.md` in the example above are examples, not required files for every repository.
+  - Non-Claude/Codex teams can replace them with their own AI workflow, security, or architecture docs, such as `GEMINI.md`, `CURSOR.md`, `WINDSURF.md`, `docs/ai-guidelines.md`, `docs/security.md`, or `docs/architecture.md`.
+  - Missing `always_read` files are reported under **Missing Files** by `spec plan`; this warning means the config should be checked and is not necessarily a tool failure. Missing `always_read` files are not treated as fatal plan errors.
+  - In prompt mode, found `always_read` files are listed as references; their full contents are not inlined.
 - **discovery.docs**: Explicit paths to documentation files to always include.
 - **discovery.source**: Directories to scan for auto-discovered source files.
 - **discovery.exclude**: Paths or directories to skip during auto-discovery. Use it to keep generated planning docs, AI scratch docs, and temporary agent notes out of task packages; for example, add a repo-local scratch directory such as `docs/superpowers` when you use one.


### PR DESCRIPTION
## Source of truth
Closes #29

## 修改內容
- 補充 README 的 `always_read` 說明，明確標示它是團隊可自訂的固定必讀文件清單。
- 說明 `CLAUDE.md` / `AGENTS.md` 是 examples，不是所有 repo 必備。
- 補充 missing always_read files 的 Missing Files、warning、非 fatal plan error 與 prompt mode references 行為。

## 不包含範圍
- 未修改 runtime code、config schema、spec init default config。
- 未修改 discovery / classifier / plan pipeline。
- 未新增 config command、GitHub Action 或測試框架。

## 風險
- Docs-only change；主要風險是說明文字與現有 README 風格的一致性。

## 驗證方式
- `npm run build` ✅
- README text search ✅：`always_read`、`Missing Files`、`CLAUDE.md` / `AGENTS.md` examples、非 Claude/Codex 自訂文件、missing always_read files 非 fatal plan errors。
- `npm test` 無法執行：package 未提供 `test` script。

## Implementation Evidence
- Issue comment: https://github.com/Erick52106/spec-injector/issues/29#issuecomment-4363045326
- Commit: 08bac77fc3a06b75f325454546411a0542e53650

## Checklist
- [x] Only #29 scope handled
- [x] Only README.md changed
- [x] No runtime/config/schema/default config changes
- [x] Build passed
- [x] Ready-for-review PR (not draft)
