### PR TITLE
fix(init): make default always_read tool-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,7 @@ Edit `.spec-injector/config.json` in your target repo:
     "name": "example",
     "type": "fullstack"
   },
-  "always_read": [
-    "CLAUDE.md",
-    "AGENTS.md"
-  ],
+  "always_read": [],
   "discovery": {
     "docs": [],
     "source": [
@@ -118,8 +115,8 @@ Edit `.spec-injector/config.json` in your target repo:
 
 - **version**: Must be `2`.
 - **project.name / project.type**: Metadata for display in validation and reports.
-- **always_read**: Team-defined files that should always be checked for every task package. `CLAUDE.md` and `AGENTS.md` in the example above are examples, not required files for every repository.
-  - Non-Claude/Codex teams can replace them with their own AI workflow, security, or architecture docs, such as `GEMINI.md`, `CURSOR.md`, `WINDSURF.md`, `docs/ai-guidelines.md`, `docs/security.md`, or `docs/architecture.md`.
+- **always_read**: Team-defined files that should always be checked for every task package. The default is empty; teams can add their own workflow, security, or architecture docs.
+  - Examples include `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `CURSOR.md`, `WINDSURF.md`, `docs/ai-guidelines.md`, `docs/security.md`, or `docs/architecture.md`.
   - Missing `always_read` files are reported under **Missing Files** by `spec plan`; this warning means the config should be checked and is not necessarily a tool failure. Missing `always_read` files are not treated as fatal plan errors.
   - In prompt mode, found `always_read` files are listed as references; their full contents are not inlined.
 - **discovery.docs**: Explicit paths to documentation files to always include.

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -7,10 +7,7 @@ const EXAMPLE_CONFIG = {
     name: "example",
     type: "fullstack",
   },
-  always_read: [
-    "CLAUDE.md",
-    "AGENTS.md",
-  ],
+  always_read: [],
   discovery: {
     docs: [],
     source: ["src"],


### PR DESCRIPTION
## Source of truth
Closes #31

## 修改內容
- 將 `spec init` 產生的 default `always_read` 改為空陣列，避免預設綁定 Claude Code / Codex 文件。
- 同步 README 的 default config example 為 `"always_read": []`。
- 保留 README 中 teams 可自行加入 `CLAUDE.md`、`AGENTS.md`、`GEMINI.md`、`CURSOR.md`、`WINDSURF.md` 或 repo-specific docs 的說明。

## 不包含範圍
- 未修改 config schema。
- 未修改 discovery / classifier / plan pipeline。
- 未新增 config management commands。
- 未新增 LLM / API / local model。
- 未新增 GitHub Action 或測試框架。
- 未處理 Layer 2 `/spec-plan` workflow。

## 風險
- 既有 repo 的 `.spec-injector/config.json` 不受影響。
- 新 repo 需要自行加入固定必讀文件；README 已保留自訂說明。

## 驗證方式
- `npm run build` ✅
- `spec init --repo /tmp/spec-injector-init-agnostic-test` ✅
- `cat /tmp/spec-injector-init-agnostic-test/.spec-injector/config.json` ✅：`"always_read": []`
- `spec validate --repo /tmp/spec-injector-init-agnostic-test` ✅：config valid、Always-read 0 file(s)
- Generated config search ✅：不包含 `CLAUDE.md` / `AGENTS.md`
- `npm test` 無法執行：package 未提供 `test` script。

## Implementation Evidence
- Issue comment: https://github.com/Erick52106/spec-injector/issues/31#issuecomment-4363062646
- Commit: 0b8848a38de26e61a66fe9a746a9b39d35fc5827

## Checklist
- [x] Only #31 scope handled
- [x] Only allowed files changed
- [x] No schema / plan / discovery / classifier changes
- [x] Generated `always_read` is empty
- [x] Build passed
- [x] Ready-for-review PR (not draft)
