### PR TITLE
feat(cli): add clean command for generated task packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,21 @@ spec validate --repo /path/to/repo
 
 Validates `.spec-injector/config.json` against the v2 schema and prints project metadata, always-read counts, discovery stats, and configured guardrails.
 
+### 4. Clean generated task packages
+
+```bash
+spec clean --repo /path/to/repo
+spec clean --repo /path/to/repo --issue 21
+```
+
+Removes only generated task package files matching `.spec-injector/out/issue-<number>-task-package.md`. Other files in `out/`, `.spec-injector/config.json`, `.spec-injector/.gitignore`, and repo docs are left untouched.
+
 ### 使用方式（中文）
 
 1. **初始化**：在目標 repo 執行 `spec init`，建立 `.spec-injector/config.json` 設定檔與 `.gitignore`（自動忽略 `out/` 目錄）。
 2. **產生任務包**：執行 `spec plan <issue-url>`。工具會依序執行：抓取 Issue、關鍵字領域分類、比對風險護欄、載入文件（固定載入與自動探索）、探索相關原始碼，最後將結果寫入 `.spec-injector/out/issue-<number>-task-package.md`。
 3. **驗證設定**：執行 `spec validate` 確認 `config.json` 格式正確，並查看專案資訊、探索設定與護欄清單。
+4. **清理任務包**：執行 `spec clean --repo .` 清理 `.spec-injector/out/` 中符合 `issue-<number>-task-package.md` 命名的 generated task packages；也可用 `--issue <number>` 只清理單一 issue。
 
 ---
 

--- a/src/cli/clean.ts
+++ b/src/cli/clean.ts
@@ -1,0 +1,80 @@
+import path from 'path';
+import fs from 'fs';
+
+const TASK_PACKAGE_PATTERN = /^issue-\d+-task-package\.md$/;
+
+export async function clean(opts: { repo?: string; issue?: string }): Promise<void> {
+  const repoPath = path.resolve(opts.repo ?? process.cwd());
+  const outDir = path.join(repoPath, '.spec-injector', 'out');
+
+  if (opts.issue !== undefined) {
+    await cleanIssue(outDir, opts.issue);
+    return;
+  }
+
+  await cleanAll(outDir);
+}
+
+async function cleanIssue(outDir: string, issue: string): Promise<void> {
+  if (!/^\d+$/.test(issue)) {
+    throw new Error('--issue must be an issue number.');
+  }
+
+  const fileName = `issue-${issue}-task-package.md`;
+  const filePath = path.join(outDir, fileName);
+
+  if (!(await isRegularFile(filePath))) {
+    console.log(`No generated task package found for issue ${issue}.`);
+    return;
+  }
+
+  await fs.promises.unlink(filePath);
+  console.log(`Removed generated task package: ${displayPath(fileName)}`);
+}
+
+async function cleanAll(outDir: string): Promise<void> {
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(outDir, { withFileTypes: true });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      console.log('No generated task packages found.');
+      return;
+    }
+    throw err;
+  }
+
+  const packageFiles = entries
+    .filter((entry) => entry.isFile() && TASK_PACKAGE_PATTERN.test(entry.name))
+    .map((entry) => path.join(outDir, entry.name));
+
+  if (packageFiles.length === 0) {
+    console.log('No generated task packages found.');
+    return;
+  }
+
+  for (const filePath of packageFiles) {
+    await fs.promises.unlink(filePath);
+  }
+
+  console.log(`Removed ${packageFiles.length} generated task package(s):`);
+  for (const filePath of packageFiles) {
+    console.log(`  ${displayPath(path.basename(filePath))}`);
+  }
+}
+
+function displayPath(fileName: string): string {
+  return path.join('.spec-injector', 'out', fileName);
+}
+
+async function isRegularFile(filePath: string): Promise<boolean> {
+  try {
+    const stat = await fs.promises.lstat(filePath);
+    return stat.isFile();
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return false;
+    }
+    throw err;
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -40,6 +40,17 @@ program
     await validate(opts);
   });
 
+// clean subcommand
+program
+  .command('clean')
+  .description('Remove generated task package files from .spec-injector/out')
+  .option('--repo <path>', 'Path to target repo (default: CWD)')
+  .option('--issue <number>', 'Only remove the generated task package for one issue')
+  .action(async (opts: { repo?: string; issue?: string }) => {
+    const { clean } = await import('./clean.js');
+    await clean(opts);
+  });
+
 program.parseAsync(process.argv).catch((err: unknown) => {
   console.error(`✗ ${(err as Error).message}`);
   process.exit(1);


### PR DESCRIPTION
## Source of truth
Closes #28

## 修改內容
- 新增 `spec clean` CLI command registration。
- 新增最小 `src/cli/clean.ts` implementation，只清理 `.spec-injector/out/issue-<number>-task-package.md` matching files。
- README 補充簡短 `spec clean` 用法。

## 不包含範圍
- 不修改 `spec plan`、`--dry-run`、`--format prompt`。
- 不修改 config schema、discovery、classifier、template rendering。
- 不新增 clean preview/dry-run、GitHub Action、bot、自動 post-merge cleanup。
- 不處理 Layer 2 `/spec-plan` workflow。

## 風險
- 風險低；刪除範圍限定在 repo-relative `.spec-injector/out/` 直接子檔案，且檔名需符合嚴格 pattern。
- `--issue` 只定位單一 `issue-<number>-task-package.md`。

## 驗證方式
- `npm run build`
- 手動驗證 `spec clean --repo /tmp/spec-injector-clean-test` 只刪除 matching generated task packages，保留 `unrelated.txt`、config、gitignore。
- 手動驗證 `spec clean --repo /tmp/spec-injector-clean-test --issue 1` 只刪除 issue 1 package，保留 issue 2 與 unrelated/config/gitignore。
- 手動驗證 `--issue 999` 與不存在 `.spec-injector/out/` 都顯示 friendly no-op 訊息。
- `npm test`：此 repo 目前沒有 `test` script，執行結果為 `Missing script: "test"`。

## Implementation Evidence
- Issue comment: https://github.com/Erick52106/spec-injector/issues/28#issuecomment-4363085852
- Commit: 63e889d7dea138a0f70739567b4954cc39bed05e

## Checklist
- [x] Branch created from latest `origin/main`.
- [x] Only issue #28 handled.
- [x] Scope limited to allowed files.
- [x] PR is ready for review, not draft.
- [x] No merge performed.