### PR TITLE
feat(config): add always_read management commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,17 @@ spec validate --repo /path/to/repo
 
 Validates `.spec-injector/config.json` against the v2 schema and prints project metadata, always-read counts, discovery stats, and configured guardrails.
 
-### 4. Clean generated task packages
+### 4. Manage always_read files
+
+```bash
+spec config list --repo .
+spec config add always-read docs/security.md --repo .
+spec config remove always-read AGENTS.md --repo .
+```
+
+The `spec config` command currently only manages the `always_read` list in `.spec-injector/config.json`.
+
+### 5. Clean generated task packages
 
 ```bash
 spec clean --repo /path/to/repo
@@ -82,7 +92,8 @@ Removes only generated task package files matching `.spec-injector/out/issue-<nu
 1. **初始化**：在目標 repo 執行 `spec init`，建立 `.spec-injector/config.json` 設定檔與 `.gitignore`（自動忽略 `out/` 目錄）。
 2. **產生任務包**：執行 `spec plan <issue-url>`。工具會依序執行：抓取 Issue、關鍵字領域分類、比對風險護欄、載入文件（固定載入與自動探索）、探索相關原始碼，最後將結果寫入 `.spec-injector/out/issue-<number>-task-package.md`。
 3. **驗證設定**：執行 `spec validate` 確認 `config.json` 格式正確，並查看專案資訊、探索設定與護欄清單。
-4. **清理任務包**：執行 `spec clean --repo .` 清理 `.spec-injector/out/` 中符合 `issue-<number>-task-package.md` 命名的 generated task packages；也可用 `--issue <number>` 只清理單一 issue。
+4. **管理 always_read**：執行 `spec config list --repo .` 查看必讀文件，或用 `spec config add always-read docs/security.md --repo .` 與 `spec config remove always-read AGENTS.md --repo .` 更新清單。目前只支援管理 `always_read`。
+5. **清理任務包**：執行 `spec clean --repo .` 清理 `.spec-injector/out/` 中符合 `issue-<number>-task-package.md` 命名的 generated task packages；也可用 `--issue <number>` 只清理單一 issue。
 
 ---
 

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -1,0 +1,127 @@
+import path from 'path';
+import fs from 'fs';
+
+type ConfigAction = 'list' | 'add' | 'remove';
+
+interface ConfigCommandOptions {
+  repo?: string;
+}
+
+export async function config(
+  action: string,
+  section: string | undefined,
+  filePath: string | undefined,
+  opts: ConfigCommandOptions
+): Promise<void> {
+  const repoPath = path.resolve(opts.repo ?? process.cwd());
+  const configPath = path.join(repoPath, '.spec-injector', 'config.json');
+
+  if (!fs.existsSync(configPath)) {
+    console.error(`✗ No .spec-injector/config.json found at ${configPath}`);
+    console.error(`  Run "spec init --repo ${repoPath}" first.`);
+    process.exit(1);
+  }
+
+  const normalizedAction = parseAction(action);
+
+  if (normalizedAction === 'list') {
+    listAlwaysRead(configPath);
+    return;
+  }
+
+  if (section !== 'always-read') {
+    console.error('✗ Unsupported config section. This command currently only supports always-read.');
+    process.exit(1);
+  }
+
+  if (!filePath) {
+    console.error(`✗ Missing path. Usage: spec config ${normalizedAction} always-read <path> --repo <repo>`);
+    process.exit(1);
+  }
+
+  if (normalizedAction === 'add') {
+    addAlwaysRead(configPath, filePath);
+    return;
+  }
+
+  removeAlwaysRead(configPath, filePath);
+}
+
+function parseAction(action: string): ConfigAction {
+  if (action === 'list' || action === 'add' || action === 'remove') {
+    return action;
+  }
+  console.error('✗ Unsupported config action. Use list, add, or remove.');
+  process.exit(1);
+}
+
+function readConfig(configPath: string): Record<string, unknown> {
+  const text = fs.readFileSync(configPath, 'utf8');
+  try {
+    const raw = JSON.parse(text) as unknown;
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      throw new Error('config.json must be a JSON object');
+    }
+    return raw as Record<string, unknown>;
+  } catch (err) {
+    console.error(`✗ Invalid config.json: ${(err as Error).message}`);
+    process.exit(1);
+  }
+}
+
+function readAlwaysRead(raw: Record<string, unknown>): string[] {
+  const value = raw['always_read'];
+  if (value === undefined) return [];
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    console.error('✗ Invalid config.json: always_read must be an array of strings');
+    process.exit(1);
+  }
+  return value as string[];
+}
+
+function writeConfig(configPath: string, raw: Record<string, unknown>): void {
+  fs.writeFileSync(configPath, `${JSON.stringify(raw, null, 2)}\n`, 'utf8');
+}
+
+function listAlwaysRead(configPath: string): void {
+  const raw = readConfig(configPath);
+  const alwaysRead = readAlwaysRead(raw);
+
+  if (alwaysRead.length === 0) {
+    console.log('No always_read files configured.');
+    return;
+  }
+
+  console.log('always_read files:');
+  for (const item of alwaysRead) {
+    console.log(`  ${item}`);
+  }
+}
+
+function addAlwaysRead(configPath: string, filePath: string): void {
+  const raw = readConfig(configPath);
+  const alwaysRead = readAlwaysRead(raw);
+
+  if (alwaysRead.includes(filePath)) {
+    console.log(`always_read already includes: ${filePath}`);
+    return;
+  }
+
+  raw['always_read'] = [...alwaysRead, filePath];
+  writeConfig(configPath, raw);
+  console.log(`✓ Added always_read file: ${filePath}`);
+}
+
+function removeAlwaysRead(configPath: string, filePath: string): void {
+  const raw = readConfig(configPath);
+  const alwaysRead = readAlwaysRead(raw);
+
+  if (!alwaysRead.includes(filePath)) {
+    console.log(`always_read does not include: ${filePath}`);
+    return;
+  }
+
+  raw['always_read'] = alwaysRead.filter((item) => item !== filePath);
+  writeConfig(configPath, raw);
+  console.log(`✓ Removed always_read file: ${filePath}`);
+}

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -25,6 +25,7 @@ export async function config(
   const normalizedAction = parseAction(action);
 
   if (normalizedAction === 'list') {
+    validateListArgs(section, filePath);
     listAlwaysRead(configPath);
     return;
   }
@@ -53,6 +54,18 @@ function parseAction(action: string): ConfigAction {
   }
   console.error('✗ Unsupported config action. Use list, add, or remove.');
   process.exit(1);
+}
+
+function validateListArgs(section: string | undefined, filePath: string | undefined): void {
+  if (section !== undefined && section !== 'always-read') {
+    console.error('✗ Unsupported config section. This command currently only supports always-read.');
+    process.exit(1);
+  }
+
+  if (filePath !== undefined) {
+    console.error('✗ The list action does not accept a path. Usage: spec config list [always-read] --repo <repo>');
+    process.exit(1);
+  }
 }
 
 function readConfig(configPath: string): Record<string, unknown> {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -40,6 +40,21 @@ program
     await validate(opts);
   });
 
+// config subcommand
+program
+  .command('config <action> [section] [path]')
+  .description('Manage .spec-injector/config.json settings')
+  .option('--repo <path>', 'Path to target repo (default: CWD)')
+  .action(async (
+    action: string,
+    section: string | undefined,
+    filePath: string | undefined,
+    opts: { repo?: string }
+  ) => {
+    const { config } = await import('./config.js');
+    await config(action, section, filePath, opts);
+  });
+
 // clean subcommand
 program
   .command('clean')


### PR DESCRIPTION
## Source of truth
Closes #30

## 修改內容
- Added `spec config list --repo <repo>` to display configured `always_read` files.
- Added `spec config add always-read <path> --repo <repo>` with duplicate detection.
- Added `spec config remove always-read <path> --repo <repo>` with missing-path messaging.
- Documented the minimal `spec config` usage in README.

## 不包含範圍
- No suggest always-read candidates.
- No changes to `spec init` default config.
- No changes to `spec plan`, discovery, classifier, template rendering, guardrails, YAML, prompts, TUI, LLM/API/local model, GitHub Actions, or full config editor behavior.

## 風險
- Low. The new command only reads/writes `.spec-injector/config.json` and only updates `always_read`. Existing config JSON is re-serialized using the project's current 2-space JSON style.

## 驗證方式
- `npm run build`
- `npm test` (not available: package has no `test` script)
- `spec init --repo /tmp/spec-injector-config-test`
- `spec config list --repo /tmp/spec-injector-config-test`
- `spec config add always-read docs/security.md --repo /tmp/spec-injector-config-test`
- `spec config add always-read docs/security.md --repo /tmp/spec-injector-config-test`
- `spec config remove always-read docs/security.md --repo /tmp/spec-injector-config-test`
- `spec config remove always-read docs/security.md --repo /tmp/spec-injector-config-test`
- `spec validate --repo /tmp/spec-injector-config-test`
- `spec config add always-read "docs/**/*.md" --repo /tmp/spec-injector-config-test`

## Implementation Evidence
- Issue comment: https://github.com/Erick52106/spec-injector/issues/30#issuecomment-4363136001
- Commit: b76b6d90f3bdf496ee2a215f1e533b6ee96e86e5

## Checklist
- [x] Branch created from latest `origin/main`
- [x] Scope limited to issue #30
- [x] Only allowed files changed
- [x] Ready-for-review PR (not draft)
- [x] No merge performed