### PR TITLE
feat(config): suggest always_read candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,14 @@ Validates `.spec-injector/config.json` against the v2 schema and prints project 
 
 ```bash
 spec config list --repo .
+spec config suggest always-read --repo .
 spec config add always-read docs/security.md --repo .
 spec config remove always-read AGENTS.md --repo .
 ```
 
-The `spec config` command currently only manages the `always_read` list in `.spec-injector/config.json`.
+The `suggest always-read` helper scans repo-level and common docs locations, then prints candidate files with reasons. It does not modify `.spec-injector/config.json`; to add a suggestion, run `spec config add always-read <path> --repo .`.
+
+The `spec config` command currently manages the `always_read` list in `.spec-injector/config.json` and can suggest likely `always_read` candidates.
 
 ### 5. Clean generated task packages
 
@@ -92,7 +95,7 @@ Removes only generated task package files matching `.spec-injector/out/issue-<nu
 1. **初始化**：在目標 repo 執行 `spec init`，建立 `.spec-injector/config.json` 設定檔與 `.gitignore`（自動忽略 `out/` 目錄）。
 2. **產生任務包**：執行 `spec plan <issue-url>`。工具會依序執行：抓取 Issue、關鍵字領域分類、比對風險護欄、載入文件（固定載入與自動探索）、探索相關原始碼，最後將結果寫入 `.spec-injector/out/issue-<number>-task-package.md`。
 3. **驗證設定**：執行 `spec validate` 確認 `config.json` 格式正確，並查看專案資訊、探索設定與護欄清單。
-4. **管理 always_read**：執行 `spec config list --repo .` 查看必讀文件，或用 `spec config add always-read docs/security.md --repo .` 與 `spec config remove always-read AGENTS.md --repo .` 更新清單。目前只支援管理 `always_read`。
+4. **管理 always_read**：執行 `spec config list --repo .` 查看必讀文件，或用 `spec config suggest always-read --repo .` 掃描候選文件與 reasons；suggest 不會修改 config，若要加入請再執行 `spec config add always-read <path> --repo .`。也可用 `spec config add always-read docs/security.md --repo .` 與 `spec config remove always-read AGENTS.md --repo .` 更新清單。目前只支援管理與建議 `always_read`。
 5. **清理任務包**：執行 `spec clean --repo .` 清理 `.spec-injector/out/` 中符合 `issue-<number>-task-package.md` 命名的 generated task packages；也可用 `--issue <number>` 只清理單一 issue。
 
 ---

--- a/src/cli/config-suggest.ts
+++ b/src/cli/config-suggest.ts
@@ -115,7 +115,11 @@ export function suggestAlwaysRead(repoPath: string): void {
 
 function fileExists(repoPath: string, relativePath: string): boolean {
   const absolutePath = path.join(repoPath, relativePath);
-  return fs.existsSync(absolutePath) && fs.statSync(absolutePath).isFile();
+  try {
+    return fs.statSync(absolutePath).isFile();
+  } catch {
+    return false;
+  }
 }
 
 function findIgnoredPaths(repoPath: string): IgnoredPath[] {
@@ -123,7 +127,11 @@ function findIgnoredPaths(repoPath: string): IgnoredPath[] {
 
   for (const [excludedPath, reason] of Object.entries(EXCLUDED_DIRS)) {
     const absolutePath = path.join(repoPath, excludedPath);
-    if (!fs.existsSync(absolutePath)) continue;
+    try {
+      fs.statSync(absolutePath);
+    } catch {
+      continue;
+    }
 
     ignored.push({
       filePath: excludedPath.endsWith('/') ? excludedPath : `${excludedPath}/`,

--- a/src/cli/config-suggest.ts
+++ b/src/cli/config-suggest.ts
@@ -1,0 +1,163 @@
+import fs from 'fs';
+import path from 'path';
+
+type Confidence = 'high' | 'medium';
+
+interface CandidateRule {
+  confidence: Confidence;
+  reason: string;
+}
+
+interface Suggestion {
+  filePath: string;
+  reason: string;
+}
+
+interface IgnoredPath {
+  filePath: string;
+  reason: string;
+}
+
+const CANDIDATE_RULES: Record<string, CandidateRule> = {
+  'CLAUDE.md': {
+    confidence: 'high',
+    reason: 'Claude Code repo-level instruction file',
+  },
+  'AGENTS.md': {
+    confidence: 'high',
+    reason: 'agent workflow instruction file',
+  },
+  'GEMINI.md': {
+    confidence: 'high',
+    reason: 'Gemini repo-level instruction file',
+  },
+  'CURSOR.md': {
+    confidence: 'high',
+    reason: 'Cursor repo-level instruction file',
+  },
+  'WINDSURF.md': {
+    confidence: 'high',
+    reason: 'Windsurf repo-level instruction file',
+  },
+  'docs/ai-guidelines.md': {
+    confidence: 'high',
+    reason: 'AI collaboration guidelines candidate',
+  },
+  'docs/security.md': {
+    confidence: 'high',
+    reason: 'security policy / guardrails candidate',
+  },
+  'docs/architecture.md': {
+    confidence: 'high',
+    reason: 'architecture overview candidate',
+  },
+  'README.md': {
+    confidence: 'medium',
+    reason: 'project overview candidate',
+  },
+  'docs/product-spec.md': {
+    confidence: 'medium',
+    reason: 'product specification candidate',
+  },
+  'docs/contributing.md': {
+    confidence: 'medium',
+    reason: 'contribution workflow candidate',
+  },
+  'docs/development.md': {
+    confidence: 'medium',
+    reason: 'development workflow candidate',
+  },
+};
+
+const EXCLUDED_DIRS: Record<string, string> = {
+  'docs/superpowers': 'superpowers planning docs are not always_read candidates',
+  'docs/archive': 'archived docs are not current always_read candidates',
+  '.spec-injector/out': 'generated task package output',
+  node_modules: 'dependency directory',
+  dist: 'build output directory',
+  build: 'build output directory',
+};
+
+export function suggestAlwaysRead(repoPath: string): void {
+  const high: Suggestion[] = [];
+  const medium: Suggestion[] = [];
+  const ignored = findIgnoredPaths(repoPath);
+
+  for (const [candidatePath, rule] of Object.entries(CANDIDATE_RULES)) {
+    if (!fileExists(repoPath, candidatePath)) continue;
+
+    const suggestion: Suggestion = {
+      filePath: candidatePath,
+      reason: rule.reason,
+    };
+
+    if (rule.confidence === 'high') {
+      high.push(suggestion);
+    } else {
+      medium.push(suggestion);
+    }
+  }
+
+  console.log(`always_read suggestions for ${repoPath}`);
+  console.log('No changes were made to .spec-injector/config.json.');
+  console.log('');
+
+  if (high.length === 0 && medium.length === 0) {
+    console.log('No always_read candidates found.');
+    console.log('Try adding repo-level instruction, security, architecture, or project overview docs first.');
+    console.log('');
+  }
+
+  printSuggestions('High confidence', high);
+  printSuggestions('Medium confidence', medium);
+  printIgnored(ignored);
+}
+
+function fileExists(repoPath: string, relativePath: string): boolean {
+  const absolutePath = path.join(repoPath, relativePath);
+  return fs.existsSync(absolutePath) && fs.statSync(absolutePath).isFile();
+}
+
+function findIgnoredPaths(repoPath: string): IgnoredPath[] {
+  const ignored: IgnoredPath[] = [];
+
+  for (const [excludedPath, reason] of Object.entries(EXCLUDED_DIRS)) {
+    const absolutePath = path.join(repoPath, excludedPath);
+    if (!fs.existsSync(absolutePath)) continue;
+
+    ignored.push({
+      filePath: excludedPath.endsWith('/') ? excludedPath : `${excludedPath}/`,
+      reason,
+    });
+  }
+
+  return ignored.sort((a, b) => a.filePath.localeCompare(b.filePath));
+}
+
+function printSuggestions(title: string, suggestions: Suggestion[]): void {
+  console.log(`${title}:`);
+
+  if (suggestions.length === 0) {
+    console.log('  (none)');
+    console.log('');
+    return;
+  }
+
+  for (const suggestion of suggestions) {
+    console.log(`  ${suggestion.filePath} — ${suggestion.reason}`);
+  }
+  console.log('');
+}
+
+function printIgnored(ignored: IgnoredPath[]): void {
+  console.log('Ignored / excluded:');
+
+  if (ignored.length === 0) {
+    console.log('  (none)');
+    return;
+  }
+
+  for (const item of ignored) {
+    console.log(`  ${item.filePath} — ${item.reason}`);
+  }
+}

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 
-type ConfigAction = 'list' | 'add' | 'remove';
+type ConfigAction = 'list' | 'add' | 'remove' | 'suggest';
 
 interface ConfigCommandOptions {
   repo?: string;
@@ -14,6 +14,14 @@ export async function config(
   opts: ConfigCommandOptions
 ): Promise<void> {
   const repoPath = path.resolve(opts.repo ?? process.cwd());
+
+  const normalizedAction = parseAction(action);
+
+  if (normalizedAction === 'suggest') {
+    await suggestConfig(repoPath, section, filePath);
+    return;
+  }
+
   const configPath = path.join(repoPath, '.spec-injector', 'config.json');
 
   if (!fs.existsSync(configPath)) {
@@ -21,8 +29,6 @@ export async function config(
     console.error(`  Run "spec init --repo ${repoPath}" first.`);
     process.exit(1);
   }
-
-  const normalizedAction = parseAction(action);
 
   if (normalizedAction === 'list') {
     validateListArgs(section, filePath);
@@ -49,11 +55,30 @@ export async function config(
 }
 
 function parseAction(action: string): ConfigAction {
-  if (action === 'list' || action === 'add' || action === 'remove') {
+  if (action === 'list' || action === 'add' || action === 'remove' || action === 'suggest') {
     return action;
   }
-  console.error('✗ Unsupported config action. Use list, add, or remove.');
+  console.error('✗ Unsupported config action. Use list, add, remove, or suggest.');
   process.exit(1);
+}
+
+async function suggestConfig(
+  repoPath: string,
+  section: string | undefined,
+  filePath: string | undefined
+): Promise<void> {
+  if (section !== 'always-read') {
+    console.error('✗ Unsupported suggest section. Usage: spec config suggest always-read --repo <repo>');
+    process.exit(1);
+  }
+
+  if (filePath !== undefined) {
+    console.error('✗ The suggest always-read command does not accept a path. Usage: spec config suggest always-read --repo <repo>');
+    process.exit(1);
+  }
+
+  const { suggestAlwaysRead } = await import('./config-suggest.js');
+  suggestAlwaysRead(repoPath);
 }
 
 function validateListArgs(section: string | undefined, filePath: string | undefined): void {


### PR DESCRIPTION
## Source of truth
Closes #34

## 修改內容
- Adds `spec config suggest always-read --repo <repo>` before config-file loading so it works during onboarding.
- Uses deterministic file-name heuristics for high/medium `always_read` candidates and prints short reasons.
- Prints an ignored/excluded group for generated and noisy directories without writing config.
- Adds a brief README usage note.

## 不包含範圍
- Does not modify `spec init` default config.
- Does not modify `spec plan`, discovery, classifier, template rendering, guardrails, or config editing beyond `always_read` suggest routing.
- Does not call LLM/API/local models, add GitHub Actions, prompts, TUI, or auto-write `.spec-injector/config.json`.

## 風險
- Heuristics are intentionally conservative and may miss project-specific docs outside the known candidate list.
- Existing `config list/add/remove` behavior should be unchanged because `suggest` exits before config loading.

## 驗證方式
- `npm run build`
- Fixture repo verification with `spec config suggest always-read --repo /tmp/spec-injector-suggest-test`
- Invalid argument checks:
  - `spec config suggest unknown --repo /tmp/spec-injector-suggest-test`
  - `spec config suggest always-read extra --repo /tmp/spec-injector-suggest-test`
- Confirmed suggest did not create `/tmp/spec-injector-suggest-test/.spec-injector/config.json`.
- `npm test` was attempted, but this package has no `test` script.

## Implementation Evidence
- Issue comment: https://github.com/Erick52106/spec-injector/issues/34#issuecomment-4363168877
- Commit: 69434b063b5218bc0c552a3c845ce90c2d1d8391

## Checklist
- [x] Branch created from latest `main`
- [x] Only issue #34 handled
- [x] Scope limited to allowed files
- [x] Deterministic suggest only; no config writes
- [x] Ready-for-review PR, not draft
