### PR TITLE
feat(config): enhance always_read suggestions with scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ spec config add always-read docs/security.md --repo .
 spec config remove always-read AGENTS.md --repo .
 ```
 
-The `suggest always-read` helper scans repo-level and common docs locations, then prints candidate files with reasons. It does not modify `.spec-injector/config.json`; to add a suggestion, run `spec config add always-read <path> --repo .`.
+The `suggest always-read` helper scans repo-level and common docs locations, then uses deterministic scoring to print candidate files with reasons. It does not modify `.spec-injector/config.json`; to add a suggestion, run `spec config add always-read <path> --repo .`. See [docs/always-read-suggestions.md](docs/always-read-suggestions.md) for the scan scope, exclusions, and confidence guidance.
 
 The `spec config` command currently manages the `always_read` list in `.spec-injector/config.json` and can suggest likely `always_read` candidates.
 
@@ -99,7 +99,7 @@ Removes only generated task package files matching `.spec-injector/out/issue-<nu
 1. **初始化**：在目標 repo 執行 `spec init`，建立 `.spec-injector/config.json` 設定檔與 `.gitignore`（自動忽略 `out/` 目錄）。
 2. **產生任務包**：執行 `spec plan <issue-url>`。工具會依序執行：抓取 Issue、關鍵字領域分類、比對風險護欄、載入文件（固定載入與自動探索）、探索相關原始碼，最後將結果寫入 `.spec-injector/out/issue-<number>-task-package.md`。
 3. **驗證設定**：執行 `spec validate` 確認 `config.json` 格式正確，並查看專案資訊、探索設定與護欄清單。
-4. **管理 always_read**：執行 `spec config list --repo .` 查看必讀文件，或用 `spec config suggest always-read --repo .` 掃描候選文件與 reasons；suggest 不會修改 config，若要加入請再執行 `spec config add always-read <path> --repo .`。也可用 `spec config add always-read docs/security.md --repo .` 與 `spec config remove always-read AGENTS.md --repo .` 更新清單。目前只支援管理與建議 `always_read`。
+4. **管理 always_read**：執行 `spec config list --repo .` 查看必讀文件，或用 `spec config suggest always-read --repo .` 以 deterministic scoring 掃描候選文件與 reasons；suggest 不會修改 config，若要加入請再執行 `spec config add always-read <path> --repo .`。也可用 `spec config add always-read docs/security.md --repo .` 與 `spec config remove always-read AGENTS.md --repo .` 更新清單。目前只支援管理與建議 `always_read`；掃描範圍與 confidence 說明請見 `docs/always-read-suggestions.md`。
 5. **清理任務包**：執行 `spec clean --repo .` 清理 `.spec-injector/out/` 中符合 `issue-<number>-task-package.md` 命名的 generated task packages；也可用 `--issue <number>` 只清理單一 issue。
 
 ---

--- a/docs/always-read-suggestions.md
+++ b/docs/always-read-suggestions.md
@@ -1,0 +1,67 @@
+# always_read suggestions
+
+## Purpose
+
+`spec config suggest always-read --repo .` is an onboarding helper that suggests likely `always_read` candidates for a repository.
+
+It only prints suggestions. It does not modify `.spec-injector/config.json` automatically.
+
+## Deterministic only
+
+The command uses deterministic scoring only.
+
+- No LLM
+- No API calls
+- No local model inference
+
+Fixed well-known filenames are still checked first, then additional candidates are scanned and scored.
+
+## Scan scope
+
+The first scoring implementation scans a limited set of repository locations:
+
+- repo root `*.md`
+- `docs/**/*.md`
+- `.github/*.md`
+- `.github/**/*.md`
+- `.cursor/rules/*`
+- `.windsurf/*`
+
+Common instruction paths such as `.github/copilot-instructions.md` are included through those scan rules.
+
+## Exclusions
+
+The scanner excludes locations that are typically generated, archived, or too noisy for `always_read`:
+
+- `node_modules`
+- `dist`
+- `build`
+- `.git`
+- `.spec-injector/out`
+- `docs/superpowers`
+- `docs/archive`
+- `archive`
+
+It also ignores obvious low-signal candidates such as changelog, meeting notes, temporary drafts, and unreadable or binary files.
+
+## Confidence meanings
+
+- High confidence: strong repo instruction, architecture, security, or AI workflow candidate
+- Medium confidence: likely useful project overview or guideline-like documentation
+- Lower-signal files may be skipped to keep output concise
+
+Every printed suggestion includes a short reason. Suggestions are sorted deterministically to keep output stable.
+
+## Adding a suggestion
+
+To add one of the suggested files into `always_read`, run:
+
+```bash
+spec config add always-read <path> --repo .
+```
+
+## AI implementer guidance
+
+- Do not automatically add suggestions unless the user approves.
+- Do not treat suggestions as mandatory.
+- Use the issue body and `.spec-injector/config.json` as the source of truth.

--- a/src/cli/config-suggest.ts
+++ b/src/cli/config-suggest.ts
@@ -10,12 +10,27 @@ interface CandidateRule {
 
 interface Suggestion {
   filePath: string;
+  confidence: Confidence;
   reason: string;
+  score: number;
 }
 
 interface IgnoredPath {
   filePath: string;
   reason: string;
+}
+
+interface ScanTarget {
+  basePath: string;
+  maxDepth: number;
+  include: (relativePath: string, entry: fs.Dirent) => boolean;
+}
+
+interface ScoredCandidate {
+  filePath: string;
+  confidence: Confidence;
+  reason: string;
+  score: number;
 }
 
 const CANDIDATE_RULES: Record<string, CandidateRule> = {
@@ -70,33 +85,71 @@ const CANDIDATE_RULES: Record<string, CandidateRule> = {
 };
 
 const EXCLUDED_DIRS: Record<string, string> = {
-  'docs/superpowers': 'superpowers planning docs are not always_read candidates',
-  'docs/archive': 'archived docs are not current always_read candidates',
   '.spec-injector/out': 'generated task package output',
-  node_modules: 'dependency directory',
-  dist: 'build output directory',
+  archive: 'archived docs are not current always_read candidates',
   build: 'build output directory',
+  dist: 'build output directory',
+  'docs/archive': 'archived docs are not current always_read candidates',
+  'docs/superpowers': 'superpowers planning docs are not always_read candidates',
+  node_modules: 'dependency directory',
 };
 
+const SKIP_DIR_NAMES = new Set([
+  '.git',
+  'archive',
+  'build',
+  'dist',
+  'node_modules',
+  'out',
+]);
+
+const MAX_SCANNED_CANDIDATES = 64;
+const MAX_CONTENT_LINES = 24;
+const MAX_CONTENT_BYTES = 4096;
+
+const SCAN_TARGETS: ScanTarget[] = [
+  {
+    basePath: '.',
+    maxDepth: 0,
+    include: (relativePath, entry) => entry.isFile() && isMarkdownFile(relativePath) && !relativePath.includes('/'),
+  },
+  {
+    basePath: 'docs',
+    maxDepth: 4,
+    include: (relativePath, entry) => entry.isFile() && isMarkdownFile(relativePath),
+  },
+  {
+    basePath: '.github',
+    maxDepth: 4,
+    include: (relativePath, entry) => entry.isFile() && isMarkdownFile(relativePath),
+  },
+  {
+    basePath: '.cursor/rules',
+    maxDepth: 3,
+    include: (_relativePath, entry) => entry.isFile(),
+  },
+  {
+    basePath: '.windsurf',
+    maxDepth: 3,
+    include: (_relativePath, entry) => entry.isFile(),
+  },
+];
+
+const HIGH_PRIORITY_KEYWORDS = [
+  'architecture',
+  'security',
+  'ai instructions',
+  'guidelines',
+  'workflow',
+  'conventions',
+  'policy',
+];
+
 export function suggestAlwaysRead(repoPath: string): void {
-  const high: Suggestion[] = [];
-  const medium: Suggestion[] = [];
+  const suggestions = collectSuggestions(repoPath);
+  const high = suggestions.filter((item) => item.confidence === 'high');
+  const medium = suggestions.filter((item) => item.confidence === 'medium');
   const ignored = findIgnoredPaths(repoPath);
-
-  for (const [candidatePath, rule] of Object.entries(CANDIDATE_RULES)) {
-    if (!fileExists(repoPath, candidatePath)) continue;
-
-    const suggestion: Suggestion = {
-      filePath: candidatePath,
-      reason: rule.reason,
-    };
-
-    if (rule.confidence === 'high') {
-      high.push(suggestion);
-    } else {
-      medium.push(suggestion);
-    }
-  }
 
   console.log(`always_read suggestions for ${repoPath}`);
   console.log('No changes were made to .spec-injector/config.json.');
@@ -113,10 +166,226 @@ export function suggestAlwaysRead(repoPath: string): void {
   printIgnored(ignored);
 }
 
+function collectSuggestions(repoPath: string): Suggestion[] {
+  const suggestions = new Map<string, Suggestion>();
+
+  for (const [candidatePath, rule] of Object.entries(CANDIDATE_RULES)) {
+    if (!fileExists(repoPath, candidatePath)) continue;
+    suggestions.set(candidatePath, {
+      filePath: candidatePath,
+      confidence: rule.confidence,
+      reason: rule.reason,
+      score: fixedRuleScore(rule.confidence),
+    });
+  }
+
+  for (const candidate of collectScoredCandidates(repoPath)) {
+    if (suggestions.has(candidate.filePath)) continue;
+    suggestions.set(candidate.filePath, candidate);
+  }
+
+  return [...suggestions.values()].sort(compareSuggestions);
+}
+
+function collectScoredCandidates(repoPath: string): Suggestion[] {
+  const candidates: ScoredCandidate[] = [];
+
+  for (const filePath of scanCandidatePaths(repoPath)) {
+    const candidate = scoreCandidate(repoPath, filePath);
+    if (!candidate) continue;
+    candidates.push(candidate);
+    if (candidates.length >= MAX_SCANNED_CANDIDATES) break;
+  }
+
+  return candidates;
+}
+
+function scanCandidatePaths(repoPath: string): string[] {
+  const found = new Set<string>();
+
+  for (const target of SCAN_TARGETS) {
+    const baseAbsolutePath = path.join(repoPath, target.basePath);
+    if (!directoryExists(baseAbsolutePath)) continue;
+
+    walkDirectory(baseAbsolutePath, target.basePath === '.' ? '' : target.basePath, 0, target.maxDepth, found, target);
+  }
+
+  return [...found].sort((a, b) => a.localeCompare(b));
+}
+
+function walkDirectory(
+  absolutePath: string,
+  relativePath: string,
+  depth: number,
+  maxDepth: number,
+  found: Set<string>,
+  target: ScanTarget,
+): void {
+  let entries: fs.Dirent[];
+
+  try {
+    entries = fs.readdirSync(absolutePath, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+
+  for (const entry of entries) {
+    const entryRelativePath = normalizePath(relativePath ? path.posix.join(relativePath, entry.name) : entry.name);
+    const entryAbsolutePath = path.join(absolutePath, entry.name);
+
+    if (entry.isDirectory()) {
+      if (shouldSkipDirectory(entryRelativePath, entry.name)) continue;
+      if (depth >= maxDepth) continue;
+      walkDirectory(entryAbsolutePath, entryRelativePath, depth + 1, maxDepth, found, target);
+      continue;
+    }
+
+    if (!target.include(entryRelativePath, entry)) continue;
+    if (isExcludedPath(entryRelativePath) || shouldIgnoreCandidatePath(entryRelativePath)) continue;
+    found.add(entryRelativePath);
+  }
+}
+
+function scoreCandidate(repoPath: string, filePath: string): ScoredCandidate | null {
+  if (shouldIgnoreCandidatePath(filePath)) return null;
+
+  const score = scorePath(filePath);
+  if (score < 6) return null;
+
+  const content = readCandidateContent(repoPath, filePath);
+  if (content === null) return null;
+
+  const contentScore = scoreContent(content);
+  const totalScore = score + contentScore;
+  const confidence = toConfidence(filePath, totalScore);
+
+  if (!confidence) return null;
+
+  return {
+    filePath,
+    confidence,
+    reason: buildReason(filePath, content),
+    score: totalScore,
+  };
+}
+
+function scorePath(filePath: string): number {
+  const normalizedPath = filePath.toLowerCase();
+  const basename = path.posix.basename(normalizedPath);
+  let score = 0;
+
+  if (normalizedPath.startsWith('docs/')) score += 2;
+  if (normalizedPath.startsWith('.github/')) score += 3;
+  if (normalizedPath.startsWith('.cursor/rules/')) score += 4;
+  if (normalizedPath.startsWith('.windsurf/')) score += 4;
+
+  if (containsAny(normalizedPath, ['architecture'])) score += 5;
+  if (containsAny(normalizedPath, ['security'])) score += 5;
+  if (containsAny(normalizedPath, ['ai', 'agent', 'agents', 'claude', 'gemini', 'cursor', 'windsurf', 'copilot'])) score += 5;
+  if (containsAny(normalizedPath, ['coding', 'contributing', 'development', 'guideline', 'guidelines', 'convention', 'conventions', 'policy', 'principle', 'principles', 'workflow'])) score += 4;
+
+  if (basename === 'readme.md') score += 1;
+
+  if (containsAny(normalizedPath, ['changelog'])) score -= 6;
+  if (containsAny(normalizedPath, ['meeting-notes', 'notes', 'temporary', 'tmp', 'draft'])) score -= 5;
+  if (containsAny(normalizedPath, ['generated'])) score -= 4;
+
+  return score;
+}
+
+function scoreContent(content: string): number {
+  const normalized = content.toLowerCase();
+  let score = 0;
+
+  if (containsAny(normalized, ['# architecture', '## architecture', '# security', '## security'])) score += 4;
+  if (containsAny(normalized, ['architecture', 'security'])) score += 2;
+  if (containsAny(normalized, ['# guidelines', '## guidelines', '# conventions', '## conventions'])) score += 3;
+  if (containsAny(normalized, ['# ai instructions', '## ai instructions', '# workflow', '## workflow'])) score += 3;
+  if (containsAny(normalized, ['development workflow', 'coding conventions', 'team conventions', 'guardrails'])) score += 3;
+  if (containsAny(normalized, ['must', 'should', 'do not', 'convention', 'workflow', 'policy', 'principles'])) score += 2;
+
+  return score;
+}
+
+function toConfidence(filePath: string, score: number): Confidence | null {
+  const basename = path.posix.basename(filePath).toLowerCase();
+
+  if (basename === 'readme.md') {
+    return 'medium';
+  }
+
+  if (score >= 14) return 'high';
+  if (score >= 7) return 'medium';
+  return null;
+}
+
+function buildReason(filePath: string, content: string): string {
+  const labels = new Set<string>();
+  const normalizedPath = filePath.toLowerCase();
+  const normalizedContent = content.toLowerCase();
+
+  if (containsAny(normalizedPath, ['architecture']) || containsAny(normalizedContent, ['architecture'])) {
+    labels.add('architecture overview candidate');
+  }
+  if (containsAny(normalizedPath, ['security']) || containsAny(normalizedContent, ['security', 'guardrails'])) {
+    labels.add('security policy / guardrails candidate');
+  }
+  if (containsAny(normalizedPath, ['ai', 'agent', 'agents', 'claude', 'gemini', 'cursor', 'windsurf', 'copilot'])
+    || containsAny(normalizedContent, ['ai instructions', 'copilot', 'claude', 'gemini', 'cursor', 'windsurf'])) {
+    labels.add('AI coding instruction candidate');
+  }
+  if (containsAny(normalizedPath, ['guideline', 'guidelines', 'convention', 'conventions', 'policy', 'principle', 'principles', 'workflow', 'development'])
+    || containsAny(normalizedContent, ['guidelines', 'conventions', 'policy', 'principles', 'workflow', 'development workflow'])) {
+    labels.add('guideline-like documentation candidate');
+  }
+
+  if (labels.size === 0 && path.posix.basename(filePath).toLowerCase() === 'readme.md') {
+    labels.add('project overview candidate');
+  }
+
+  const orderedLabels = [...labels].sort((a, b) => compareReasonLabels(a, b));
+  return orderedLabels.slice(0, 2).join('; ');
+}
+
+function compareReasonLabels(left: string, right: string): number {
+  return reasonPriority(left) - reasonPriority(right) || left.localeCompare(right);
+}
+
+function reasonPriority(label: string): number {
+  const normalizedLabel = label.toLowerCase();
+  const index = HIGH_PRIORITY_KEYWORDS.findIndex((keyword) => normalizedLabel.includes(keyword));
+  return index === -1 ? HIGH_PRIORITY_KEYWORDS.length : index;
+}
+
+function readCandidateContent(repoPath: string, filePath: string): string | null {
+  const absolutePath = path.join(repoPath, filePath);
+
+  try {
+    const buffer = fs.readFileSync(absolutePath);
+    if (buffer.includes(0)) return null;
+    return buffer.toString('utf8', 0, Math.min(buffer.length, MAX_CONTENT_BYTES))
+      .split(/\r?\n/)
+      .slice(0, MAX_CONTENT_LINES)
+      .join('\n');
+  } catch {
+    return null;
+  }
+}
+
 function fileExists(repoPath: string, relativePath: string): boolean {
   const absolutePath = path.join(repoPath, relativePath);
   try {
     return fs.statSync(absolutePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function directoryExists(directoryPath: string): boolean {
+  try {
+    return fs.statSync(directoryPath).isDirectory();
   } catch {
     return false;
   }
@@ -140,6 +409,47 @@ function findIgnoredPaths(repoPath: string): IgnoredPath[] {
   }
 
   return ignored.sort((a, b) => a.filePath.localeCompare(b.filePath));
+}
+
+function shouldSkipDirectory(relativePath: string, directoryName: string): boolean {
+  return SKIP_DIR_NAMES.has(directoryName) || isExcludedPath(relativePath);
+}
+
+function shouldIgnoreCandidatePath(filePath: string): boolean {
+  const normalizedPath = filePath.toLowerCase();
+
+  if (isExcludedPath(normalizedPath)) return true;
+
+  return containsAny(normalizedPath, [
+    'changelog',
+    'meeting-notes',
+    '/notes',
+    'temporary',
+    'tmp',
+    'draft',
+    'generated',
+  ]);
+}
+
+function isExcludedPath(filePath: string): boolean {
+  return Object.keys(EXCLUDED_DIRS).some((excludedPath) => {
+    const normalizedExcludedPath = excludedPath.toLowerCase();
+    return filePath === normalizedExcludedPath || filePath.startsWith(`${normalizedExcludedPath}/`);
+  });
+}
+
+function fixedRuleScore(confidence: Confidence): number {
+  return confidence === 'high' ? 100 : 50;
+}
+
+function compareSuggestions(left: Suggestion, right: Suggestion): number {
+  return confidenceRank(left.confidence) - confidenceRank(right.confidence)
+    || right.score - left.score
+    || left.filePath.localeCompare(right.filePath);
+}
+
+function confidenceRank(confidence: Confidence): number {
+  return confidence === 'high' ? 0 : 1;
 }
 
 function printSuggestions(title: string, suggestions: Suggestion[]): void {
@@ -168,4 +478,16 @@ function printIgnored(ignored: IgnoredPath[]): void {
   for (const item of ignored) {
     console.log(`  ${item.filePath} — ${item.reason}`);
   }
+}
+
+function normalizePath(filePath: string): string {
+  return filePath.split(path.sep).join(path.posix.sep).replace(/^\.\//, '');
+}
+
+function isMarkdownFile(filePath: string): boolean {
+  return filePath.toLowerCase().endsWith('.md');
+}
+
+function containsAny(value: string, patterns: string[]): boolean {
+  return patterns.some((pattern) => value.includes(pattern));
 }

--- a/tests/cli.integration.test.js
+++ b/tests/cli.integration.test.js
@@ -71,29 +71,45 @@ test('spec config list/add/remove always-read manages config entries idempotentl
   assert.match(duplicateRemove.stdout, /does not include: docs\/security\.md/);
 });
 
-test('spec config suggest always-read reports candidates and ignores excluded paths without mutating config', async (t) => {
+test('spec config suggest always-read scans fixed and scoring candidates with stable grouped output', async (t) => {
   const repoDir = await createTempRepo(t);
 
-  await writeFiles(repoDir, [
-    'CLAUDE.md',
-    'AGENTS.md',
-    'GEMINI.md',
-    'README.md',
-    'docs/security.md',
-    'docs/architecture.md',
-    'docs/superpowers/plans/test.md',
-    '.spec-injector/out/issue-1-task-package.md',
-    'node_modules/noise.md',
-    'dist/generated.md',
-    'build/generated.md',
-  ]);
+  await writeRepoFiles(repoDir, {
+    'CLAUDE.md': '# Claude\n',
+    'AGENTS.md': '# Agents\n',
+    'GEMINI.md': '# Gemini\n',
+    'README.md': '# Overview\n\nDevelopment workflow and project overview.\n',
+    'docs/security.md': '# Security\n\nDo not bypass guardrails.\n',
+    'docs/architecture.md': '# Architecture\n\nSystem architecture overview.\n',
+    'docs/engineering-guidelines.md': '# Engineering Guidelines\n\nDevelopers should follow conventions and workflow guidance.\n',
+    'docs/backend-principles.md': '# Backend Principles\n\nCoding conventions and policy notes.\n',
+    'docs/payment-architecture.md': '# Payment Architecture\n\nArchitecture and security constraints.\n',
+    'docs/team-conventions.md': '# Team Conventions\n\nTeam workflow and development conventions.\n',
+    '.github/copilot-instructions.md': '# AI Instructions\n\nCopilot should follow repository conventions.\n',
+    '.cursor/rules/spec-injector.md': 'Always follow workflow guardrails.\n',
+    '.windsurf/rules.md': '# Workflow\n\nDo not ignore policy.\n',
+    'docs/superpowers/plans/test.md': '# Plan\n',
+    'docs/archive/old-architecture.md': '# Architecture\n',
+    'archive/old-guidelines.md': '# Guidelines\n',
+    '.spec-injector/out/issue-1-task-package.md': '# Generated\n',
+    'node_modules/noise.md': '# Noise\n',
+    'dist/generated.md': '# Generated\n',
+    'build/generated.md': '# Generated\n',
+    'CHANGELOG.md': '# Changelog\n',
+    'docs/meeting-notes.md': '# Meeting Notes\n',
+    'docs/tmp-draft.md': '# Draft\n',
+  });
 
   const result = await runSpec(['config', 'suggest', 'always-read', '--repo', repoDir]);
+  const secondResult = await runSpec(['config', 'suggest', 'always-read', '--repo', repoDir]);
 
   assert.equal(result.code, 0, result.stderr);
+  assert.equal(secondResult.code, 0, secondResult.stderr);
+  assert.equal(secondResult.stdout, result.stdout);
   assert.match(result.stdout, /High confidence:/);
   assert.match(result.stdout, /Medium confidence:/);
   assert.match(result.stdout, /Ignored \/ excluded:/);
+  assert.match(result.stdout, /No changes were made to \.spec-injector\/config\.json\./);
 
   for (const file of [
     'CLAUDE.md',
@@ -102,21 +118,68 @@ test('spec config suggest always-read reports candidates and ignores excluded pa
     'README.md',
     'docs/security.md',
     'docs/architecture.md',
+    'docs/engineering-guidelines.md',
+    'docs/backend-principles.md',
+    'docs/payment-architecture.md',
+    'docs/team-conventions.md',
+    '.github/copilot-instructions.md',
+    '.cursor/rules/spec-injector.md',
+    '.windsurf/rules.md',
   ]) {
     assert.match(result.stdout, new RegExp(escapeRegExp(file)));
   }
 
   for (const file of [
     'docs/superpowers/plans/test.md',
+    'docs/archive/old-architecture.md',
+    'archive/old-guidelines.md',
     '.spec-injector/out/issue-1-task-package.md',
     'node_modules/noise.md',
     'dist/generated.md',
     'build/generated.md',
+    'CHANGELOG.md',
+    'docs/meeting-notes.md',
+    'docs/tmp-draft.md',
   ]) {
-    assert.doesNotMatch(result.stdout, new RegExp(escapeRegExp(file)));
+    assert.doesNotMatch(result.stdout, new RegExp(`\\n\\s*${escapeRegExp(file)}\\s+—`));
   }
 
+  assert.match(result.stdout, /\n\s*docs\/archive\/\s+—/);
+  assert.match(result.stdout, /\n\s*docs\/superpowers\/\s+—/);
+  assert.match(result.stdout, /\n\s*archive\/\s+—/);
+  assert.match(result.stdout, /\n\s*\.spec-injector\/out\/\s+—/);
+  assert.match(result.stdout, /\n\s*node_modules\/\s+—/);
+  assert.match(result.stdout, /\n\s*dist\/\s+—/);
+  assert.match(result.stdout, /\n\s*build\/\s+—/);
+
+  assert.equal(countOccurrences(result.stdout, 'README.md'), 1);
+  assert.equal(countOccurrences(result.stdout, 'docs/architecture.md'), 1);
+
+  const readmeIndex = result.stdout.indexOf('README.md');
+  const cursorIndex = result.stdout.indexOf('.cursor/rules/spec-injector.md');
+  assert.notEqual(readmeIndex, -1);
+  assert.notEqual(cursorIndex, -1);
+  assert.ok(cursorIndex < readmeIndex, result.stdout);
+
   await assert.rejects(fs.access(path.join(repoDir, '.spec-injector', 'config.json')));
+});
+
+test('spec config suggest always-read does not modify initialized config', async (t) => {
+  const repoDir = await createTempRepo(t);
+  await runSpec(['init', '--repo', repoDir]);
+  await writeRepoFiles(repoDir, {
+    'README.md': '# Overview\n',
+    'docs/payment-architecture.md': '# Payment Architecture\n\nArchitecture workflow.\n',
+  });
+
+  const configPath = path.join(repoDir, '.spec-injector', 'config.json');
+  const before = await fs.readFile(configPath, 'utf8');
+
+  const result = await runSpec(['config', 'suggest', 'always-read', '--repo', repoDir]);
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /docs\/payment-architecture\.md/);
+  assert.equal(await fs.readFile(configPath, 'utf8'), before);
 });
 
 test('spec clean removes generated task packages and preserves unrelated files', async (t) => {
@@ -212,6 +275,14 @@ async function writeFiles(repoDir, relativePaths) {
   }));
 }
 
+async function writeRepoFiles(repoDir, files) {
+  await Promise.all(Object.entries(files).map(async ([relativePath, content]) => {
+    const absolutePath = path.join(repoDir, relativePath);
+    await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+    await fs.writeFile(absolutePath, content, 'utf8');
+  }));
+}
+
 async function readFile(filePath) {
   return fs.readFile(filePath, 'utf8');
 }
@@ -226,4 +297,8 @@ async function assertFileMissing(filePath) {
 
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function countOccurrences(value, needle) {
+  return value.split(needle).length - 1;
 }


### PR DESCRIPTION
Source of truth: Closes #43

## Summary
- enhance `spec config suggest always-read --repo .` with deterministic repo document scanning and scoring
- keep fixed filename suggestions, then merge scored candidates with stable sorting and de-duplication
- add docs and integration coverage for scoring candidates, exclusions, and config non-mutation behavior

## Out of Scope
- no config schema changes
- no automatic writes to `.spec-injector/config.json`
- no `spec config add always-read` replacement
- no `spec plan` changes
- no LLM, API, local model, or database usage

## Risk
- deterministic thresholds may need future tuning on repos with unusual doc layouts
- first-pass path/content heuristics intentionally favor precision over broad recall

## Verification
- `npm run build`
- `npm test`

## Implementation Evidence
- Issue evidence comment: https://github.com/Erick52106/spec-injector/issues/43#issuecomment-4363564345
- Commit: d550d1a9885842973cca3f4821d875c3ad58cc77

## Checklist
- [x] deterministic scoring only
- [x] fixed filename suggestions preserved
- [x] stable confidence grouping, score ordering, and de-duplication
- [x] suggest command does not modify config
- [x] tests updated for scoring candidates and exclusions
