### PR TITLE
docs(workflow): add AI workflow guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Requires: Node.js 20+, [`gh`](https://cli.github.com/) authenticated.
 - Conventions: [docs/conventions.md](docs/conventions.md)
 - Release strategy: [docs/release.md](docs/release.md)
 - `always_read` suggestions: [docs/always-read-suggestions.md](docs/always-read-suggestions.md)
+- AI workflow guides: [docs/workflows/README.md](docs/workflows/README.md)
 
 ---
 

--- a/docs/workflows/README.md
+++ b/docs/workflows/README.md
@@ -1,0 +1,61 @@
+# AI Workflow Guides
+
+## Purpose
+
+These guides define how AI coding tools should use `spec-injector` when preparing and implementing GitHub issue work.
+
+The goals are to make sure:
+
+- AI tools do not need to remember every CLI detail.
+- AI tools can install, initialize, and generate implementation prompts consistently.
+- AI tools preserve human approval and implementation evidence workflows.
+- AI tools call the Layer 1 CLI instead of inventing a parallel workflow.
+
+## Available guides
+
+- Codex: [docs/workflows/codex.md](codex.md)
+- Claude Code: [docs/workflows/claude-code.md](claude-code.md)
+- Cursor: [docs/workflows/cursor.md](cursor.md)
+
+## Shared workflow
+
+1. Check whether the `spec` CLI is installed.
+2. If missing, follow [docs/release.md](../release.md) local install guidance.
+3. Confirm the target repo path.
+4. Check whether `.spec-injector/config.json` exists.
+5. If missing, ask before running `spec init`.
+6. Run `spec config suggest always-read --repo .` when onboarding or when the user asks for a rescan.
+7. Do not add suggestions automatically unless the user approves.
+8. Run `spec plan <issue> --repo . --dry-run --format prompt --verbose`.
+9. Present the implementation plan.
+10. Wait for human approval before implementation when requested.
+11. Implement within issue scope.
+12. Run build/test.
+13. Leave implementation evidence on the source issue.
+14. Open a ready-for-review PR.
+15. Do not merge unless the user explicitly asks.
+
+## Shared rules
+
+- The issue body is the source of truth.
+- The repo config is the source of truth.
+- Suggestions are not approvals.
+- Missing labels are not permission to expand scope.
+- Use Conventional Commits PR titles.
+- Use labels according to [docs/conventions.md](../conventions.md).
+- Prefer dry-run prompt generation before implementation.
+- Do not call an LLM/API from `spec-injector` core.
+- Do not modify target repo config without approval.
+- Do not open a draft PR unless explicitly asked.
+- Verify the PR body after writing it.
+- Verify CI result before asking the user to merge.
+
+## Non-goals
+
+These documents do not implement:
+
+- CLI commands.
+- Slash command plugins.
+- Skill packages.
+- MCP.
+- Subagent orchestration.

--- a/docs/workflows/claude-code.md
+++ b/docs/workflows/claude-code.md
@@ -1,0 +1,44 @@
+# Claude Code Workflow
+
+## Purpose
+
+This guide defines how Claude Code should use `spec-injector` without guessing scope directly from conversation context. Claude Code should call the deterministic Layer 1 CLI, use generated prompt output as planning context, and preserve approval and evidence workflows.
+
+## Recommended usage
+
+- Use `spec plan` dry-run prompt mode before implementation.
+- Read [docs/conventions.md](../conventions.md).
+- Read [docs/design/layers.md](../design/layers.md).
+- Use [docs/release.md](../release.md) if the `spec` CLI is missing.
+- Ask before `spec init`.
+- Ask before adding `always_read` suggestions.
+
+## Standard flow
+
+1. Confirm repo and branch state.
+2. Check `spec` CLI availability.
+3. If `spec` is unavailable, follow [docs/release.md](../release.md) local install.
+4. Check `.spec-injector/config.json`.
+5. Ask before `spec init` if config is missing.
+6. Do not rely only on `CLAUDE.md` or `AGENTS.md`.
+7. If the repo has no `CLAUDE.md`, this is not an error.
+8. Use `spec config suggest always-read --repo .` to discover likely instruction docs.
+9. Do not auto-add suggestions without user approval.
+10. Run `spec plan <issue> --repo . --dry-run --format prompt --verbose`.
+11. Summarize the plan and wait for user approval when requested.
+12. If asked to use `/spec-plan <issue>`, interpret it as workflow shorthand, not a literal CLI slash command unless implemented later.
+13. Create a branch from latest `main`.
+14. Implement only issue scope.
+15. Run build/test.
+16. Leave implementation evidence on the source issue.
+17. Create a ready-for-review PR.
+18. Update the PR body and verify it after writing.
+19. Do not merge unless explicitly asked.
+
+## Safeguards
+
+- Do not edit config automatically.
+- Do not perform broad refactors unless the issue says so.
+- Do not merge PR.
+- Do not skip evidence comment.
+- Do not update PR body without verifying it.

--- a/docs/workflows/codex.md
+++ b/docs/workflows/codex.md
@@ -1,0 +1,64 @@
+# Codex Workflow
+
+## Purpose
+
+This guide defines how Codex should use `spec-injector` when handling GitHub issues. Codex should use the deterministic Layer 1 CLI to produce implementation context, then preserve human approval, issue scope, validation, evidence, and PR review workflows.
+
+## Preconditions
+
+- The user has confirmed the target repo.
+- The `gh` CLI is authenticated if issue fetching is needed.
+- The `spec` CLI is installed or local install is approved.
+- An issue URL or issue number is provided.
+
+## Recommended commands
+
+    spec --help
+    spec validate --repo .
+    spec config suggest always-read --repo .
+    spec plan <issue-number> --repo . --dry-run --format prompt --verbose
+
+## Standard flow
+
+1. Confirm repo and branch state.
+2. Check `spec` CLI availability.
+3. If `spec` is unavailable, follow [docs/release.md](../release.md) local install.
+4. Check `.spec-injector/config.json`.
+5. Ask before `spec init` if config is missing.
+6. Run `suggest always-read` only as suggestions.
+7. Run `spec plan` in dry-run prompt mode.
+8. Summarize the plan and wait for user approval when requested.
+9. Create a branch from latest `main`.
+10. Implement only issue scope.
+11. Run `npm run build` and `npm test` when available.
+12. Leave implementation evidence comment.
+13. Create a ready-for-review PR.
+14. Update PR body and verify it with `gh pr view <PR_NUMBER> --json body --jq .body`.
+15. Report PR URL, branch, commit hash, test result, CI result, draft state, and uncommitted files.
+16. Do not merge unless explicitly asked.
+
+## Required safeguards
+
+- Do not treat missing labels as scope permission.
+- Do not modify files outside allowed scope.
+- Do not create draft PR unless explicitly asked.
+- Do not claim PR body was updated without verifying.
+- Do not silently proceed if `gh`, `spec`, `npm`, or repo path fails.
+- Stop and report if branch protection or CI required checks are misconfigured.
+
+## Output checklist
+
+Codex final report should include:
+
+- Issue URL.
+- PR URL.
+- Branch.
+- Commit hash.
+- Changed files.
+- Build result.
+- Test result.
+- CI result.
+- PR body verification result.
+- Draft PR state.
+- Uncommitted files.
+- Explicit out-of-scope confirmation.

--- a/docs/workflows/cursor.md
+++ b/docs/workflows/cursor.md
@@ -1,0 +1,33 @@
+# Cursor Workflow
+
+## Purpose
+
+This guide defines how Cursor and AI IDE workflows should use `spec-injector`. Cursor should run the deterministic CLI in the terminal, use the generated prompt output as implementation context, and keep code edits scoped to the source issue.
+
+## Recommended usage
+
+- Use the terminal to run the `spec` CLI.
+- Use generated prompt output as implementation context.
+- Keep edits inside issue scope.
+- Use Cursor rules only as additional project guidance, not as a replacement for the issue body.
+- If `.cursor/rules` exists, `spec config suggest always-read` may recommend it.
+
+## Standard flow
+
+1. Open the target repo.
+2. Confirm terminal cwd.
+3. Run `spec validate --repo .`.
+4. Run `spec config suggest always-read --repo .`.
+5. Ask the user before adding suggested docs.
+6. Run `spec plan <issue> --repo . --dry-run --format prompt --verbose`.
+7. Use output as the implementation guide.
+8. Make scoped edits.
+9. Run build/test.
+10. Leave evidence comment and open PR.
+
+## Safeguards
+
+- Do not rely on opened editor tabs as full context.
+- Do not change unrelated files.
+- Do not skip terminal verification.
+- Do not use suggestions as automatic approvals.


### PR DESCRIPTION
## Source of truth

Closes #44

## 修改內容

- Added AI workflow docs index under docs/workflows/README.md.
- Added Codex, Claude Code, and Cursor workflow guides.
- Added a short README entry linking to the workflow docs.

## 不包含範圍

- No runtime code changes.
- No src/** changes.
- No package.json or package-lock.json changes.
- No GitHub Actions changes.
- No CLI command, workflow install, skill package, MCP server, subagent orchestration, or --format json implementation.

## 風險

- Documentation-only change; main risk is workflow wording ambiguity.

## 驗證方式

- npm run build
- npm test

## Implementation Evidence

- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/44#issuecomment-4363587926
- Commit: 6d519a9b7dceaaf2786e7762b3ef4fc23e33c5e7

## Checklist

- [x] README only has a short workflow docs entry.
- [x] Added docs/workflows index and tool-specific guides.
- [x] Kept changes inside README.md and docs/**.
- [x] Did not implement runtime workflow features.
- [x] Ran build and tests.
