### PR TITLE
test(template): add output stability tests for plan templates

### DIFF
--- a/src/template/default-template.ts
+++ b/src/template/default-template.ts
@@ -6,7 +6,7 @@ export const DEFAULT_TEMPLATE = `# Task Package: {{issue_title}}
 
 ---
 
-## 1. Source Issue
+## 1. Issue
 
 **Labels:** {{issue_labels}}
 
@@ -14,7 +14,7 @@ export const DEFAULT_TEMPLATE = `# Task Package: {{issue_title}}
 
 ---
 
-## 2. Detected Domains
+## 2. Classification
 
 {{detected_domains}}
 

--- a/src/template/prompt-template.ts
+++ b/src/template/prompt-template.ts
@@ -1,6 +1,6 @@
 export const PROMPT_TEMPLATE = `# Implementation Plan Prompt: {{issue_title}}
 
-## 1. Source Issue
+## 1. Issue Summary
 
 - Issue: #{{issue_number}}
 - Title: {{issue_title}}
@@ -11,7 +11,7 @@ export const PROMPT_TEMPLATE = `# Implementation Plan Prompt: {{issue_title}}
 
 {{detected_domains}}
 
-## 3. Matched Guardrails
+## 3. Guardrails
 
 {{matched_guardrails}}
 
@@ -37,15 +37,13 @@ export const PROMPT_TEMPLATE = `# Implementation Plan Prompt: {{issue_title}}
 
 {{missing_docs}}
 
-## 6. Implementation Constraints
+## 6. Instructions
 
 {{prompt_implementation_constraints}}
 
-## 7. Suggested Verification Checklist
+Suggested verification checklist:
 
 {{issue_checklist}}
-
-## 8. Final Implementation Prompt
 
 Read the referenced files as needed, then propose an implementation plan for this issue. List the files you intend to modify, wait for human approval before editing, and do not modify out-of-scope files.
 `;

--- a/tests/cli.integration.test.js
+++ b/tests/cli.integration.test.js
@@ -401,16 +401,21 @@ test('spec plan dry-run full output uses mocked gh data and keeps task package o
   assert.match(result.stdout, /Detected domains: .*database/);
   assert.match(result.stdout, /Guardrails matched: auth-review, db-migration/);
   assert.match(result.stdout, /# Task Package: Add backend auth database fixture plan coverage/);
-  assert.match(result.stdout, /## 3\. Always-Read Files/);
+  assertOrderedSubstrings(result.stdout, [
+    '# Task Package:',
+    '## 1. Issue',
+    '## 2. Classification',
+    '## 3. Always-Read Files',
+    '## 4. Auto-Discovered Documentation',
+    '## 5. Auto-Discovered Source Files',
+    '## 6. Matched Guardrails',
+    '## 7. Missing Files',
+  ]);
   assert.match(result.stdout, /### docs\/always-read\.md/);
   assert.match(result.stdout, /### presets\/core\/ai-collaboration\.md/);
-  assert.match(result.stdout, /## 4\. Auto-Discovered Documentation/);
   assert.match(result.stdout, /### docs\/auth-runbook\.md/);
-  assert.match(result.stdout, /## 5\. Auto-Discovered Source Files/);
   assert.match(result.stdout, /### src\/auth-handler\.ts/);
-  assert.match(result.stdout, /## 6\. Matched Guardrails/);
   assert.match(result.stdout, /\*\*auth-review\*\*: Require auth reviewer before changing login or permission flows\./);
-  assert.match(result.stdout, /## 7\. Missing Files/);
   assert.match(result.stdout, /- `docs\/missing-handbook\.md` — not found/);
   assert.doesNotMatch(result.stdout, /issue-57-task-package\.md/);
   await assertFileMissing(fixture.taskPackagePath);
@@ -423,28 +428,37 @@ test('spec plan dry-run prompt output stays compact and omits long inline docs',
   const fixture = await createSpecPlanFixture(t);
 
   const result = await runSpec(
-    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'],
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt', '--verbose'],
     { env: fixture.env }
   );
 
   assert.equal(result.code, 0, result.stderr);
   assert.match(result.stdout, /# Implementation Plan Prompt: Add backend auth database fixture plan coverage/);
-  assert.match(result.stdout, /## 4\. Relevant File References/);
-  assert.match(result.stdout, /### Always-Read Files/);
+  assertOrderedSubstrings(result.stdout, [
+    '# Implementation Plan Prompt:',
+    '## 1. Issue Summary',
+    '## 2. Detected Domains',
+    '## 3. Guardrails',
+    '## 4. Relevant File References',
+    '### Always-Read Files',
+    '### Discovered Docs',
+    '### Rule-Matched Docs',
+    '### Discovered Source Files',
+    '## 5. Missing Files',
+    '## 6. Instructions',
+  ]);
   assert.match(result.stdout, /- `docs\/always-read\.md`/);
   assert.match(result.stdout, /- `presets\/core\/ai-collaboration\.md`/);
-  assert.match(result.stdout, /### Discovered Docs/);
   assert.match(result.stdout, /- `docs\/auth-runbook\.md`/);
-  assert.match(result.stdout, /### Rule-Matched Docs/);
   assert.match(result.stdout, /- `docs\/database-guardrail\.md`/);
-  assert.match(result.stdout, /### Discovered Source Files/);
   assert.match(result.stdout, /- `src\/auth-handler\.ts`/);
-  assert.match(result.stdout, /## 5\. Missing Files/);
   assert.match(result.stdout, /- `docs\/missing-handbook\.md` — not found/);
   assert.doesNotMatch(result.stdout, /# Task Package:/);
+  assert.doesNotMatch(result.stdout, /## 3\. Always-Read Files/);
   assert.doesNotMatch(result.stdout, /### docs\/always-read\.md/);
-  assert.doesNotMatch(result.stdout, /Always read instructions for deterministic planning\./);
-  assert.doesNotMatch(result.stdout, /Auth handler for login, permission, session, and token checks\./);
+  assert.doesNotMatch(result.stdout, /ALWAYS_READ_LONG_BODY_SENTINEL/);
+  assert.doesNotMatch(result.stdout, /DISCOVERED_DOC_LONG_BODY_SENTINEL/);
+  assert.doesNotMatch(result.stdout, /SOURCE_SNIPPET_BODY_SENTINEL/);
   await assertFileMissing(fixture.taskPackagePath);
 });
 
@@ -462,12 +476,24 @@ test('spec plan non-dry-run writes task package file with mocked gh data', async
 
   const written = await readFile(fixture.taskPackagePath);
   assert.match(written, /# Task Package: Add backend auth database fixture plan coverage/);
-  assert.match(written, /## 6\. Matched Guardrails/);
-  assert.match(written, /## 4\. Auto-Discovered Documentation/);
+  assertOrderedSubstrings(written, [
+    '# Task Package:',
+    '## 1. Issue',
+    '## 2. Classification',
+    '## 3. Always-Read Files',
+    '## 4. Auto-Discovered Documentation',
+    '## 5. Auto-Discovered Source Files',
+    '## 6. Matched Guardrails',
+    '## 7. Missing Files',
+  ]);
   assert.match(written, /### docs\/database-guardrail\.md/);
   assert.match(written, /## 5\. Auto-Discovered Source Files/);
   assert.match(written, /### src\/database-auth-service\.ts/);
-  assert.match(written, /## 7\. Missing Files/);
+  assert.match(written, /ALWAYS_READ_LONG_BODY_SENTINEL/);
+  assert.match(written, /DISCOVERED_DOC_LONG_BODY_SENTINEL/);
+  assert.match(written, /SOURCE_SNIPPET_BODY_SENTINEL/);
+  assert.match(written, /Review schema and migration blast radius before changing auth data persistence\./);
+  assert.match(written, /- `docs\/missing-handbook\.md` — not found/);
 });
 
 test('spec plan keeps missing always_read files non-fatal and reports found vs missing references', async (t) => {
@@ -528,8 +554,8 @@ test('spec plan fixture output stays deterministic across repeated runs', async 
   assert.equal(promptSecond.code, 0, promptSecond.stderr);
   assert.equal(fullFirst.code, 0, fullFirst.stderr);
   assert.equal(fullSecond.code, 0, fullSecond.stderr);
-  assert.equal(promptSecond.stdout, promptFirst.stdout);
-  assert.equal(normalizeFullPlanOutput(fullSecond.stdout), normalizeFullPlanOutput(fullFirst.stdout));
+  assert.equal(normalizePlanOutput(promptSecond.stdout), normalizePlanOutput(promptFirst.stdout));
+  assert.equal(normalizePlanOutput(fullSecond.stdout), normalizePlanOutput(fullFirst.stdout));
 });
 
 async function createTempRepo(t, prefix = 'spec-injector-test-') {
@@ -546,6 +572,19 @@ function createMissingPath() {
 
 async function createSpecPlanFixture(t) {
   const repoDir = await createTempRepo(t);
+  const alwaysReadLongBody = [
+    'ALWAYS_READ_LONG_BODY_SENTINEL',
+    'Always read instructions for deterministic planning.',
+    'Keep references compact in prompt mode.',
+    'Inline full content only in full task package mode.',
+  ].join('\n\n');
+  const discoveredDocLongBody = [
+    'DISCOVERED_DOC_LONG_BODY_SENTINEL',
+    'Authentication checklist for backend login and session review.',
+    'This content should be referenced in prompt mode rather than inlined.',
+  ].join('\n\n');
+  const sourceSnippetBody = 'SOURCE_SNIPPET_BODY_SENTINEL: Auth handler for login, permission, session, and token checks.';
+
   await writeRepoFiles(repoDir, {
     '.spec-injector/config.json': JSON.stringify({
       version: 2,
@@ -569,11 +608,11 @@ async function createSpecPlanFixture(t) {
         },
       ],
     }, null, 2) + '\n',
-    'docs/always-read.md': '# Always Read\n\nAlways read instructions for deterministic planning.\n',
-    'docs/auth-runbook.md': '# Auth Runbook\n\nAuthentication checklist for backend login and session review.\n',
+    'docs/always-read.md': `# Always Read\n\n${alwaysReadLongBody}\n`,
+    'docs/auth-runbook.md': `# Auth Runbook\n\n${discoveredDocLongBody}\n`,
     'docs/database-guardrail.md': '# Database Guardrail\n\nDatabase migration review steps for auth schema updates.\n',
     'docs/testing-fixtures.md': '# Testing Fixtures\n\nFixture notes for spec plan tests.\n',
-    'src/auth-handler.ts': 'export function authHandler() { return "Auth handler for login, permission, session, and token checks."; }\n',
+    'src/auth-handler.ts': `export function authHandler() { return "${sourceSnippetBody}"; }\n`,
     'src/database-auth-service.ts': 'export function databaseAuthService() { return "Database service for schema migration and auth persistence."; }\n',
     'README.md': '# Spec Injector Fixture\n\nBackend auth database planning notes.\n',
   });
@@ -745,11 +784,24 @@ function countOccurrences(value, needle) {
   return value.split(needle).length - 1;
 }
 
-function normalizeFullPlanOutput(value) {
+function normalizePlanOutput(value) {
   return value
     .replace(/\*\*Generated:\*\* .+/g, '**Generated:** <normalized>')
     .replace(/spec-injector-test-[^/]+/g, 'spec-injector-test-normalized')
     .replace(/spec-injector-gh-[^/]+/g, 'spec-injector-gh-normalized');
+}
+
+function assertOrderedSubstrings(value, substrings) {
+  let previousIndex = -1;
+  for (const substring of substrings) {
+    const currentIndex = value.indexOf(substring);
+    assert.notEqual(currentIndex, -1, `Missing substring: ${substring}`);
+    assert.ok(
+      currentIndex > previousIndex,
+      `Expected "${substring}" to appear after "${substrings[substrings.indexOf(substring) - 1] ?? '<start>'}"`
+    );
+    previousIndex = currentIndex;
+  }
 }
 
 function sectionBetween(value, startMarker, endMarker) {


### PR DESCRIPTION
## Source of truth

Closes #62

## 修改內容

- 為 `spec plan --dry-run` full task package output 補上 major section 存在與順序穩定性測試。
- 為 `spec plan --dry-run --format prompt --verbose` prompt output 補上 major section、順序與 compact behavior 穩定性測試。
- 補上 full vs prompt 對 inline content / file references 的行為保護。
- 補上 missing files section 與 deterministic repeated-run output 的穩定性測試 helper。

## 不包含範圍

- 不修改 classifier behavior。
- 不修改 discovery behavior。
- 不修改 config schema。
- 不新增 GitHub API calls 到產品程式碼。
- 不重寫 template 系統。
- 不新增 CLI command。

## 測試策略

- 重用既有 `spec plan` fixture 與 fake `gh` helper。
- 以 integration tests 驗證 major sections 是否存在且順序固定。
- 驗證 prompt output 維持 compact，只保留 references、不 inline 長內容。
- 驗證 full task package 仍 inline 預期內容。
- 驗證 missing files section 在 full / prompt 都穩定且非 fatal。
- 驗證 repeated runs 經最小 normalization 後 deterministic。

## Template / Runtime 修正摘要

- Template 最小修正：將 full / prompt template 的 section 標題調整為 Layer 2 依賴的穩定命名。
- 未修改 runtime behavior；`src/cli/plan.ts` 無變更。

## 驗證方式

- `npm run build`
- `npm test`

## Implementation Evidence

- Issue evidence comment: https://github.com/Erick52106/spec-injector/issues/62#issuecomment-4363711738
- Commit: `59bfadb44963c692ddc73ff091e25e9a022b9235`
- 測試中的 GitHub issue input 來自 fake `gh` / mocked output，未讓 `spec plan` 測試打真 GitHub API。

## Checklist

- [x] 僅修改 issue #62 scope 內檔案
- [x] 測試使用 fake `gh` / mocked GitHub output
- [x] 未讓測試打真 GitHub API
- [x] `npm run build` 通過
- [x] `npm test` 通過
- [x] GitHub Actions CI 通過

