### PR TITLE
docs(cli): audit help text and command UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Requires: Node.js 20+, [`gh`](https://cli.github.com/) authenticated.
 - Layer model: [docs/design/layers.md](docs/design/layers.md)
 - Custom domains and AI-assisted suggestions: [docs/design/custom-domains.md](docs/design/custom-domains.md)
 - Optional user repo CI scaffold: [docs/design/user-repo-ci-scaffold.md](docs/design/user-repo-ci-scaffold.md)
+- CLI help and UX audit: [docs/cli-help-ux-audit.md](docs/cli-help-ux-audit.md)
 - Conventions: [docs/conventions.md](docs/conventions.md)
 - Release strategy: [docs/release.md](docs/release.md)
 - `always_read` suggestions: [docs/always-read-suggestions.md](docs/always-read-suggestions.md)

--- a/docs/cli-help-ux-audit.md
+++ b/docs/cli-help-ux-audit.md
@@ -1,0 +1,157 @@
+# CLI Help and UX Audit
+
+## Purpose
+
+This document audits Layer 1 CLI help text and command UX so that both human operators and AI implementers can understand `spec` usage without guessing.
+
+## Scope
+
+- `spec --help`
+- `spec init --help`
+- `spec validate --help`
+- `spec plan --help`
+- `spec config --help`
+- `spec clean --help`
+- common invalid command / argument cases
+- config missing / invalid config behavior
+- command safety wording
+
+## Findings
+
+### `spec --help`
+
+Current state after this pass:
+- clearly describes `spec-injector` as a deterministic CLI
+- lists `init`, `validate`, `plan`, `config`, and `clean`
+- points users to `spec <command> --help` for command-specific guidance
+
+Finding:
+- the command list was already visible before this pass, but the root help did not explicitly guide users toward subcommand help
+
+### `spec init --help`
+
+Current state after this pass:
+- states that `init` creates `.spec-injector/config.json`
+- states that `init` creates `.spec-injector/.gitignore`
+- states that it does not create GitHub Actions workflow files
+- states that it does not modify runtime code
+- keeps `--repo` scoped to selecting the target repo
+
+Finding:
+- prior help text only mentioned scaffolding `config.json`, which left `.gitignore` and non-goals implicit
+
+### `spec validate --help`
+
+Current state after this pass:
+- states that `validate` checks `.spec-injector/config.json`
+- states that invalid config exits non-zero
+- states that missing config should be resolved by running `spec init`
+
+Finding:
+- runtime validation errors were already reasonably clear, but help text did not explain the missing-config path up front
+
+### `spec plan --help`
+
+Current state after this pass:
+- states that `plan` reads a GitHub issue via `gh` CLI
+- states that `gh` authentication is required
+- states that `--dry-run` prints output without writing a task package
+- states that `--format prompt` emits a compact AI planning prompt
+- states that `--verbose` shows pipeline steps
+- states that non-dry-run output is written to `.spec-injector/out/issue-<number>-task-package.md`
+
+Finding:
+- this command had the largest UX gap before the pass because the help text did not explain `gh` dependency, prompt-mode intent, or output location
+
+### `spec config --help`
+
+Current state after this pass:
+- states that the command currently supports only `always-read`
+- explains the difference between `list`, `add`, `remove`, and `suggest`
+- states that `suggest` does not modify config
+- states that `add` and `remove` modify config
+
+Finding:
+- the original signature was technically correct but too terse for AI tools to infer mutation behavior safely
+
+### `spec clean --help`
+
+Current state after this pass:
+- states that `clean` removes only generated task package files
+- states the exact generated file pattern: `.spec-injector/out/issue-<number>-task-package.md`
+- states that it does not remove `.spec-injector/config.json`
+- states that it does not remove `.spec-injector/.gitignore`
+- states that it does not remove unrelated files
+- keeps `--issue` clearly scoped to a single generated task package
+
+Finding:
+- the runtime behavior was already safe, but the help text did not make the safety boundary explicit enough
+
+### Invalid command / argument cases
+
+Current state after this pass:
+- unknown root commands now show Commander error output plus post-error help guidance
+- invalid config subcommands and missing path cases still exit non-zero with explicit usage-oriented wording
+- invalid `clean --issue` input still exits non-zero with a direct issue-number message
+
+Finding:
+- unsupported top-level commands were previously terse and did not point users back to help
+
+### Config missing / invalid config behavior
+
+Current state:
+- missing `.spec-injector/` already reports that `spec init` should be run
+- invalid JSON and schema violations already exit non-zero and avoid raw stack traces in tested paths
+
+Finding:
+- this area was already acceptable for Layer 1 and did not require runtime behavior changes in this pass
+
+### Command safety wording
+
+Current state after this pass:
+- `clean` help makes destructive scope explicit
+- `config suggest` help makes non-mutation explicit
+- `init` help makes non-goals explicit
+
+Finding:
+- safety boundaries existed in implementation but were under-documented in terminal help
+
+## Changes made
+
+- improved root help text so it identifies `spec` as a deterministic CLI and points to subcommand help
+- improved `plan` help text for `gh` dependency, `--dry-run`, `--format prompt`, `--verbose`, and output path
+- improved `config` help text so `always-read` support and mutation behavior are explicit
+- improved `clean` help text so generated-file-only scope and safety boundaries are explicit
+- improved `init` help text so created files and non-goals are explicit
+- improved `validate` help text so non-zero behavior and missing-config next step are explicit
+- improved unsupported root command UX by showing help guidance after errors
+
+## AI implementer notes
+
+- Prefer `spec <command> --help` before guessing command syntax.
+- Treat command error output as source of truth.
+- Do not assume `spec config suggest always-read` mutates config.
+- Do not assume `spec init` creates CI workflow files.
+- Use `spec plan --dry-run --format prompt --verbose` before implementation planning.
+- Do not run destructive commands unless the user asked for them.
+- `spec clean` only cleans generated task packages, but still confirm intent before running it.
+
+## Follow-up candidates
+
+- add help text tests
+- add examples to each subcommand help
+- add command UX docs
+- add shell completion
+- improve error message consistency
+- add optional `spec doctor`
+
+## Non-goals
+
+- do not add CLI commands
+- do not add shell completion
+- do not add manpage
+- do not modify config schema
+- do not modify classifier behavior
+- do not modify the plan template
+- do not modify GitHub workflow
+- do not change runtime behavior except for minimal help and error wording clarification

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,17 +4,31 @@ const program = new Command();
 
 program
   .name('spec')
-  .description('Deterministic task package generator from GitHub issues')
+  .description('Deterministic CLI that turns GitHub issues into task packages')
+  .showSuggestionAfterError()
+  .showHelpAfterError('\nRun `spec --help` to see available commands.')
+  .addHelpText('after', '\nUse `spec <command> --help` for command-specific usage and safety notes.\n')
   .version('0.1.0');
 
 // plan subcommand
 program
   .command('plan <issue>')
-  .description('Generate a task package for a GitHub issue')
+  .description('Read a GitHub issue via gh CLI and generate a task package')
   .option('--repo <path>', 'Path to target repo (default: CWD)')
-  .option('--dry-run', 'Print output to stdout, do not write file')
-  .option('--verbose', 'Show detailed matching steps')
-  .option('--format <format>', 'Output format: full or prompt (default: full)')
+  .option('--dry-run', 'Print output to stdout only; do not write a task package file')
+  .option('--verbose', 'Show detailed pipeline steps while planning')
+  .option('--format <format>', 'Output format: "full" task package or "prompt" compact AI planning prompt (default: full)')
+  .addHelpText('after', `
+Requires gh CLI with authentication to read the source issue.
+
+Non-dry-run output:
+  Writes .spec-injector/out/issue-<number>-task-package.md
+
+Notes:
+  --dry-run        Preview output without writing files
+  --format prompt  Emit a compact AI planning prompt instead of the full package
+  --verbose        Print fetch / config / discovery pipeline steps
+`)
   .action(async (issue: string, opts: { repo?: string; dryRun?: boolean; verbose?: boolean; format?: string }) => {
     const { plan } = await import('./plan.js');
     await plan(issue, opts);
@@ -23,8 +37,15 @@ program
 // init subcommand
 program
   .command('init')
-  .description('Scaffold .spec-injector/config.json in target repo')
+  .description('Create .spec-injector/config.json and .spec-injector/.gitignore in a repo')
   .option('--repo <path>', 'Path to target repo (default: CWD)')
+  .addHelpText('after', `
+Creates:
+  .spec-injector/config.json
+  .spec-injector/.gitignore
+
+This command does not create GitHub Actions workflow files and does not modify runtime code.
+`)
   .action(async (opts: { repo?: string }) => {
     const { init } = await import('./init.js');
     await init(opts);
@@ -33,8 +54,13 @@ program
 // validate subcommand
 program
   .command('validate')
-  .description('Validate .spec-injector/config.json against schema v2')
+  .description('Validate .spec-injector/config.json and exit non-zero for invalid config')
   .option('--repo <path>', 'Path to target repo (default: CWD)')
+  .addHelpText('after', `
+Checks .spec-injector/config.json against schema v2.
+
+If config is missing, run \`spec init\` first.
+`)
   .action(async (opts: { repo?: string }) => {
     const { validate } = await import('./validate.js');
     await validate(opts);
@@ -43,8 +69,23 @@ program
 // config subcommand
 program
   .command('config <action> [section] [path]')
-  .description('Manage .spec-injector/config.json settings')
+  .description('Manage .spec-injector/config.json settings (currently always-read only)')
   .option('--repo <path>', 'Path to target repo (default: CWD)')
+  .addHelpText('after', `
+Supported section:
+  always-read
+
+Mutation rules:
+  add/remove modify config.json
+  suggest always-read does not modify config.json
+
+Actions:
+  list                    Print configured always-read entries
+  add always-read <path>  Modify config.json by adding one path
+  remove always-read <path>
+                          Modify config.json by removing one path
+  suggest always-read     Print deterministic suggestions only
+`)
   .action(async (
     action: string,
     section: string | undefined,
@@ -58,9 +99,14 @@ program
 // clean subcommand
 program
   .command('clean')
-  .description('Remove generated task package files from .spec-injector/out')
+  .description('Remove generated task package files from .spec-injector/out only')
   .option('--repo <path>', 'Path to target repo (default: CWD)')
-  .option('--issue <number>', 'Only remove the generated task package for one issue')
+  .option('--issue <number>', 'Only remove .spec-injector/out/issue-<number>-task-package.md for one issue')
+  .addHelpText('after', `
+Safety:
+  Removes only generated files matching .spec-injector/out/issue-<number>-task-package.md
+  Does not remove .spec-injector/config.json, .spec-injector/.gitignore, or unrelated files
+`)
   .action(async (opts: { repo?: string; issue?: string }) => {
     const { clean } = await import('./clean.js');
     await clean(opts);

--- a/tests/cli.integration.test.js
+++ b/tests/cli.integration.test.js
@@ -8,6 +8,65 @@ import { spawn } from 'node:child_process';
 const repoRoot = process.cwd();
 const cliPath = path.join(repoRoot, 'bin', 'spec.js');
 
+test('spec --help lists deterministic CLI purpose and available commands', async () => {
+  const result = await runSpec(['--help']);
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /deterministic/i);
+  assert.match(result.stdout, /\binit\b/);
+  assert.match(result.stdout, /\bvalidate\b/);
+  assert.match(result.stdout, /\bplan\b/);
+  assert.match(result.stdout, /\bconfig\b/);
+  assert.match(result.stdout, /\bclean\b/);
+  assert.match(result.stdout, /help \[command\]/i);
+});
+
+test('spec init and validate help explain created config files and validation expectations', async () => {
+  const initHelp = await runSpec(['init', '--help']);
+  assert.equal(initHelp.code, 0, initHelp.stderr);
+  assert.match(initHelp.stdout, /\.spec-injector\/config\.json/);
+  assert.match(initHelp.stdout, /\.spec-injector\/\.gitignore/);
+  assert.match(initHelp.stdout, /does not create github actions workflow files/i);
+  assert.match(initHelp.stdout, /does not modify runtime code/i);
+
+  const validateHelp = await runSpec(['validate', '--help']);
+  assert.equal(validateHelp.code, 0, validateHelp.stderr);
+  assert.match(validateHelp.stdout, /\.spec-injector\/config\.json/);
+  assert.match(validateHelp.stdout, /non-zero/i);
+  assert.match(validateHelp.stdout, /spec init/i);
+});
+
+test('spec plan/config/clean help describe AI-facing usage and safety constraints', async () => {
+  const planHelp = await runSpec(['plan', '--help']);
+  assert.equal(planHelp.code, 0, planHelp.stderr);
+  assert.match(planHelp.stdout, /gh cli/i);
+  assert.match(planHelp.stdout, /dry-run/i);
+  assert.match(planHelp.stdout, /do not write/i);
+  assert.match(planHelp.stdout, /format prompt/i);
+  assert.match(planHelp.stdout, /compact ai planning prompt/i);
+  assert.match(planHelp.stdout, /verbose/i);
+  assert.match(planHelp.stdout, /pipeline steps/i);
+  assert.match(planHelp.stdout, /\.spec-injector\/out\/issue-<number>-task-package\.md/);
+
+  const configHelp = await runSpec(['config', '--help']);
+  assert.equal(configHelp.code, 0, configHelp.stderr);
+  assert.match(configHelp.stdout, /always-read/i);
+  assert.match(configHelp.stdout, /\blist\b/);
+  assert.match(configHelp.stdout, /\badd\b/);
+  assert.match(configHelp.stdout, /\bremove\b/);
+  assert.match(configHelp.stdout, /\bsuggest\b/);
+  assert.match(configHelp.stdout, /does not modify config/i);
+  assert.match(configHelp.stdout, /add\/remove.*modify config/i);
+
+  const cleanHelp = await runSpec(['clean', '--help']);
+  assert.equal(cleanHelp.code, 0, cleanHelp.stderr);
+  assert.match(cleanHelp.stdout, /generated task package/i);
+  assert.match(cleanHelp.stdout, /issue-<number>-task-package\.md/);
+  assert.match(cleanHelp.stdout, /does not remove .*config\.json/i);
+  assert.match(cleanHelp.stdout, /unrelated files/i);
+  assert.match(cleanHelp.stdout, /--issue <number>/);
+});
+
 test('spec init scaffolds config files with default discovery settings', async (t) => {
   const repoDir = await createTempRepo(t);
 


### PR DESCRIPTION
Closes #64

## 修改內容
- 新增 `docs/cli-help-ux-audit.md`，整理 Layer 1 CLI help 與 command UX audit 結果
- 補強 `spec`, `spec init`, `spec validate`, `spec plan`, `spec config`, `spec clean` 的 help text 與安全/用途說明
- 補最小 help text smoke tests，覆蓋 root 與重點子命令 UX 文案
- 在 README Design Docs 區塊加入 audit 文件連結

## 不包含範圍
- 不新增 CLI command
- 不修改 config schema
- 不修改 classifier behavior
- 不修改 template output 結構
- 不修改 spec plan pipeline
- 不新增 GitHub API calls、LLM / API / local model integration、shell completion、manpage

## Audit Findings Summary
- `spec plan --help` 原本最需要補強，缺少 `gh` 依賴、`--dry-run`、`--format prompt`、`--verbose`、輸出路徑等說明
- `spec config --help` 原本未明講目前只支援 `always-read`，以及 `suggest` 不改 config、`add/remove` 會改 config
- `spec clean --help` 原本未明講只清 generated task package，且不會刪 config 或 unrelated files
- `spec init --help` 原本未完整說明建立的檔案與非目標
- unsupported command UX 原本過於精簡，現在會補出回到 `spec --help` 的指引

## Help Text / Runtime 修正摘要
- Clarified CLI help text and command safety wording in `src/cli/index.ts`
- Added post-error help guidance for unsupported top-level commands
- No CLI feature or behavior changes beyond minimal help/error wording updates

## 驗證方式
- `npm run build`
- `npm test`

## Implementation Evidence
- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/64#issuecomment-4363732157
- Commit: `7a191ca641a513c4a69fefa28c3a4b38cd9d498c`

## Checklist
- [x] Scope limited to issue #64
- [x] No new CLI commands or config schema changes
- [x] Audit document added
- [x] Required verification commands run
- [x] Issue evidence comment permalink added to this PR body