### PR TITLE
fix(template): remove dead matched_hints section from task package

### DIFF
--- a/src/template/default-template.ts
+++ b/src/template/default-template.ts
@@ -54,13 +54,7 @@ export const DEFAULT_TEMPLATE = `# Task Package: {{issue_title}}
 
 ---
 
-## 8. Implementation Constraints
-
-{{matched_hints}}
-
----
-
-## 9. Suggested Verification Checklist
+## 8. Suggested Verification Checklist
 
 > Auto-extracted from issue body (edit as needed)
 

--- a/tests/cli.integration.test.js
+++ b/tests/cli.integration.test.js
@@ -476,6 +476,8 @@ test('spec plan dry-run full output uses mocked gh data and keeps task package o
   assert.match(result.stdout, /### src\/auth-handler\.ts/);
   assert.match(result.stdout, /\*\*auth-review\*\*: Require auth reviewer before changing login or permission flows\./);
   assert.match(result.stdout, /- `docs\/missing-handbook\.md` — not found/);
+  assert.doesNotMatch(result.stdout, /## 8\. Implementation Constraints/);
+  assert.doesNotMatch(result.stdout, /Implementation Constraints:\s*\(none\)/);
   assert.doesNotMatch(result.stdout, /issue-57-task-package\.md/);
   await assertFileMissing(fixture.taskPackagePath);
   assert.deepEqual(await readGhLog(fixture.ghLogPath), [
@@ -553,6 +555,8 @@ test('spec plan non-dry-run writes task package file with mocked gh data', async
   assert.match(written, /SOURCE_SNIPPET_BODY_SENTINEL/);
   assert.match(written, /Review schema and migration blast radius before changing auth data persistence\./);
   assert.match(written, /- `docs\/missing-handbook\.md` — not found/);
+  assert.doesNotMatch(written, /## 8\. Implementation Constraints/);
+  assert.doesNotMatch(written, /Implementation Constraints:\s*\(none\)/);
 });
 
 test('spec plan keeps missing always_read files non-fatal and reports found vs missing references', async (t) => {


### PR DESCRIPTION
## Source of truth

Closes #69

## Review source

- https://github.com/Erick52106/spec-injector/issues/59#issuecomment-4363772863

## 修改內容

- 移除 `DEFAULT_TEMPLATE` 中 dead `matched_hints` / `Implementation Constraints` section
- 將 full task package 的 verification checklist section 重新編號為 `## 8`
- 補 integration tests，確認 dry-run full output 與寫入檔案版本都不再出現矛盾的 `(none)` constraints
- 保留 `## 6. Matched Guardrails` 既有輸出與風險文字
- 保留 prompt output 既有行為不變

## 不包含範圍

- 不處理 P1-2 / P1-3 / P1-4
- 不處理任何 P2 issue
- 不處理 #60 / #61 / #63
- 不修改 classifier behavior
- 不修改 discovery behavior
- 不修改 config schema
- 不新增 CLI command
- 不重寫 template system

## 測試策略

- 以既有 `tests/cli.integration.test.js` fixture 覆蓋 full task package dry-run output
- 驗證 non-dry-run 寫出的 task package 檔案內容
- 確認 matched guardrails risk text 仍存在
- 依既有測試保護 prompt output 不回歸

## 驗證方式

- `npm run build`
- `npm test`

## Implementation Evidence

- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/69#issuecomment-4363806804
- Commit: `9a5a4fc88503e8083cb00445774b790ef0e40718`

## Checklist

- [x] Removed dead `matched_hints` section from default task package
- [x] Kept matched guardrails output intact
- [x] Added regression coverage for contradictory `(none)` constraints output
- [x] Ran `npm run build`
- [x] Ran `npm test`
- [x] Added issue implementation evidence comment
- [x] Backfilled issue evidence permalink into PR body
