### PR TITLE
feat(plan): include issue-mentioned file paths in references

### DIFF
--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -1,7 +1,13 @@
 import path from 'path';
 import { fetchIssue } from '../github/issue.js';
 import { loadConfig } from '../config/loader.js';
-import { loadExplicitDocs, discoverRelevantDocs, loadCorePreset, discoverSourceFiles } from '../docs/finder.js';
+import {
+  loadExplicitDocs,
+  discoverRelevantDocs,
+  loadCorePreset,
+  discoverSourceFiles,
+  extractExplicitIssueFileReferences,
+} from '../docs/finder.js';
 import { renderTemplate } from '../template/renderer.js';
 import { DEFAULT_TEMPLATE } from '../template/default-template.js';
 import { PROMPT_TEMPLATE } from '../template/prompt-template.js';
@@ -69,16 +75,40 @@ export async function plan(
   const sourcePaths = config.specConfig.discovery?.source ?? [];
   const maxSourceFiles = config.specConfig.discovery?.max_source_files ?? 5;
   const discoveredSources = await discoverSourceFiles(issue, repoPath, sourcePaths, maxSourceFiles);
+  const explicitReferences = await extractExplicitIssueFileReferences(issue, repoPath);
+  const explicitDocs = mergeReasonSignals(explicitReferences.docs, [...alwaysDocs, ...discoveryDocs, ...discoveredDocs]);
+  const explicitSources = mergeReasonSignals(explicitReferences.sources, discoveredSources);
+  const explicitDocPaths = new Set(explicitDocs.map((d) => d.filePath));
+  const explicitSourcePaths = new Set(explicitSources.map((d) => d.filePath));
+  const filteredAlwaysDocs = alwaysDocs.filter((d) => !explicitDocPaths.has(d.filePath));
+  const filteredDiscoveryDocs = discoveryDocs.filter((d) => !explicitDocPaths.has(d.filePath));
+  const filteredDiscoveredDocs = discoveredDocs.filter((d) => !explicitDocPaths.has(d.filePath));
+  const filteredDiscoveredSources = discoveredSources.filter((d) => !explicitSourcePaths.has(d.filePath));
+  const missingDocs = mergeMissingSections(
+    [...filteredAlwaysDocs, ...filteredDiscoveryDocs].filter((d) => !d.found),
+    explicitReferences.missing
+  );
+  const combinedDocReferences = [...explicitDocs, ...filteredDiscoveredDocs];
+  const combinedSourceReferences = [...explicitSources, ...filteredDiscoveredSources];
 
   // 7. Summarise
-  const missingDocs = [...alwaysDocs, ...discoveryDocs].filter((d) => !d.found);
-  console.log(`✓ Docs — always: ${alwaysDocs.filter(d => d.found).length}, discovered: ${discoveredDocs.length}, explicit: ${discoveryDocs.filter(d => d.found).length}, missing: ${missingDocs.length}, sources: ${discoveredSources.length}`);
+  console.log(`✓ Docs — always: ${filteredAlwaysDocs.filter(d => d.found).length}, discovered: ${filteredDiscoveredDocs.length}, explicit: ${explicitDocs.length + filteredDiscoveryDocs.filter(d => d.found).length}, missing: ${missingDocs.length}, sources: ${combinedSourceReferences.length}`);
   if (missingDocs.length > 0) {
     for (const d of missingDocs) console.warn(`  ⚠  Not found: ${d.filePath}`);
   }
 
   // 8. Build vars and render
-  const vars = buildTemplateVars(issue, domains, matchedGuardrails, alwaysDocs, discoveredDocs, discoveryDocs, missingDocs, repoPath, discoveredSources);
+  const vars = buildTemplateVars(
+    issue,
+    domains,
+    matchedGuardrails,
+    filteredAlwaysDocs,
+    combinedDocReferences,
+    filteredDiscoveryDocs,
+    missingDocs,
+    repoPath,
+    combinedSourceReferences
+  );
   const template = format === 'prompt' ? PROMPT_TEMPLATE : DEFAULT_TEMPLATE;
   const rendered = renderTemplate(template, vars);
 
@@ -96,13 +126,16 @@ export async function plan(
 function renderDocList(docs: DocSection[]): string {
   if (docs.length === 0) return '(none)';
   return docs
-    .map((d) => `### ${d.filePath}\n\n${d.content.trim()}`)
+    .map((d) => {
+      const reasonLine = renderReasonLine(d);
+      return `### ${d.filePath}\n\n${reasonLine}${d.content.trim()}`;
+    })
     .join('\n\n---\n\n');
 }
 
 function renderPathList(docs: DocSection[]): string {
   if (docs.length === 0) return '(none)';
-  return docs.map((d) => `- \`${d.filePath}\``).join('\n');
+  return docs.map((d) => `- \`${d.filePath}\`${renderReasonSuffix(d)}`).join('\n');
 }
 
 function renderImplementationConstraints(matchedGuardrails: Guardrail[]): string {
@@ -128,7 +161,7 @@ function buildTemplateVars(
     .join('\n') || '(none found)';
 
   const missingList = missingDocs.length > 0
-    ? missingDocs.map((d) => `- \`${d.filePath}\` — not found`).join('\n')
+    ? missingDocs.map((d) => `- \`${d.filePath}\` — not found${renderReasonSuffix(d, true)}`).join('\n')
     : '(none)';
 
   return {
@@ -160,4 +193,65 @@ function buildTemplateVars(
     repo_path: repoPath,
     generated_at: new Date().toISOString(),
   };
+}
+
+function mergeReasonSignals(primary: DocSection[], secondary: DocSection[]): DocSection[] {
+  const secondaryByPath = new Map(secondary.map((doc) => [doc.filePath, doc]));
+  return primary.map((doc) => {
+    const match = secondaryByPath.get(doc.filePath);
+    if (!match) return doc;
+
+    const reasons = new Set<string>(doc.reasons ?? []);
+    const mappedReason = reasonForKind(match.kind);
+    if (mappedReason) reasons.add(mappedReason);
+
+    return { ...doc, reasons: [...reasons] };
+  });
+}
+
+function mergeMissingSections(primary: DocSection[], secondary: DocSection[]): DocSection[] {
+  const merged = new Map<string, DocSection>();
+
+  for (const doc of [...primary, ...secondary]) {
+    const existing = merged.get(doc.filePath);
+    if (!existing) {
+      merged.set(doc.filePath, doc);
+      continue;
+    }
+
+    const reasons = new Set<string>([...(existing.reasons ?? []), ...(doc.reasons ?? [])]);
+    const mappedExisting = reasonForKind(existing.kind);
+    const mappedCurrent = reasonForKind(doc.kind);
+    if (mappedExisting) reasons.add(mappedExisting);
+    if (mappedCurrent) reasons.add(mappedCurrent);
+    merged.set(doc.filePath, { ...existing, reasons: [...reasons] });
+  }
+
+  return [...merged.values()];
+}
+
+function reasonForKind(kind: DocSection['kind']): string | null {
+  switch (kind) {
+    case 'always':
+      return 'always_read';
+    case 'rule':
+      return 'rule-matched';
+    case 'discovered':
+      return 'auto-discovered';
+    case 'source':
+      return 'auto-discovered';
+    default:
+      return null;
+  }
+}
+
+function renderReasonLine(doc: DocSection): string {
+  if (!doc.reasons || doc.reasons.length === 0) return '';
+  return `_${doc.reasons.join('; ')}_\n\n`;
+}
+
+function renderReasonSuffix(doc: DocSection, parenthetical: boolean = false): string {
+  if (!doc.reasons || doc.reasons.length === 0) return '';
+  const rendered = doc.reasons.join('; ');
+  return parenthetical ? ` (${rendered})` : ` — ${rendered}`;
 }

--- a/src/docs/finder.ts
+++ b/src/docs/finder.ts
@@ -5,6 +5,13 @@ import { safeReadFile } from '../utils/fs.js';
 import type { DocSection, DocSourceKind } from './types.js';
 import type { Issue } from '../github/types.js';
 
+const EXPLICIT_FILE_EXTENSIONS = new Set([
+  '.ts', '.tsx', '.js', '.jsx', '.go', '.md', '.json', '.yml', '.yaml', '.sql', '.css', '.html', '.sh',
+]);
+const EXPLICIT_ROOT_FILES = new Set(['README.md', 'AGENTS.md', 'CLAUDE.md', 'GEMINI.md']);
+const DOC_EXTENSIONS = new Set(['.md']);
+const ISSUE_MENTIONED_REASON = 'mentioned in issue';
+
 // Load explicitly listed doc paths with a given kind label.
 // Missing files get kind 'missing' and found: false.
 export async function loadExplicitDocs(
@@ -73,6 +80,50 @@ export async function discoverRelevantDocs(
   }));
 }
 
+export async function extractExplicitIssueFileReferences(
+  issue: Issue,
+  repoPath: string
+): Promise<{ docs: DocSection[]; sources: DocSection[]; missing: DocSection[] }> {
+  const candidates = collectExplicitPathCandidates(issue.body);
+  const docs: DocSection[] = [];
+  const sources: DocSection[] = [];
+  const missing: DocSection[] = [];
+
+  for (const filePath of candidates) {
+    validateDocPath(filePath, repoPath);
+    const absolute = path.resolve(repoPath, filePath);
+    const content = await safeReadFile(absolute);
+    const isDoc = isDocReferencePath(filePath);
+
+    if (content === null) {
+      missing.push({
+        filePath,
+        content: '',
+        found: false,
+        kind: 'missing',
+        reasons: [ISSUE_MENTIONED_REASON],
+      });
+      continue;
+    }
+
+    const section: DocSection = {
+      filePath,
+      content,
+      found: true,
+      kind: isDoc ? 'issue-doc' : 'issue-source',
+      reasons: [ISSUE_MENTIONED_REASON],
+    };
+
+    if (isDoc) {
+      docs.push(section);
+    } else {
+      sources.push(section);
+    }
+  }
+
+  return { docs, sources, missing };
+}
+
 // --- internals ---
 
 function validateDocPath(docPath: string, repoPath: string): void {
@@ -83,6 +134,56 @@ function validateDocPath(docPath: string, repoPath: string): void {
   if (!absolute.startsWith(path.resolve(repoPath) + path.sep)) {
     throw new Error(`Doc path is outside target repo: ${docPath}`);
   }
+}
+
+function collectExplicitPathCandidates(body: string): string[] {
+  const candidates = new Set<string>();
+
+  for (const match of body.matchAll(/`([^`\n]+)`/g)) {
+    const normalized = normalizeExplicitPathCandidate(match[1]);
+    if (normalized) candidates.add(normalized);
+  }
+
+  for (const line of body.split('\n')) {
+    const normalized = normalizeBulletPathCandidate(line);
+    if (normalized) candidates.add(normalized);
+  }
+
+  return [...candidates];
+}
+
+function normalizeBulletPathCandidate(line: string): string | null {
+  const match = line.match(/^\s*(?:[-*]|\d+\.)\s+([A-Za-z0-9._/-]+)\s*$/);
+  if (!match) return null;
+  return normalizeExplicitPathCandidate(match[1]);
+}
+
+function normalizeExplicitPathCandidate(candidate: string): string | null {
+  const trimmed = candidate.trim();
+  if (trimmed.length === 0) return null;
+  if (trimmed.includes('://')) return null;
+  if (trimmed.startsWith('/')) return null;
+  if (trimmed.includes('#')) return null;
+  if (!/^[A-Za-z0-9._/-]+$/.test(trimmed)) return null;
+
+  const normalized = path.posix.normalize(trimmed);
+  if (normalized === '.' || normalized === '..') return null;
+  if (normalized.startsWith('../')) return null;
+  if (path.posix.isAbsolute(normalized)) return null;
+  if (normalized.split('/').some((segment) => segment === '..' || segment.length === 0)) return null;
+  if (!hasRecognizedRepoFileShape(normalized)) return null;
+
+  return normalized;
+}
+
+function hasRecognizedRepoFileShape(filePath: string): boolean {
+  if (EXPLICIT_ROOT_FILES.has(filePath)) return true;
+  return EXPLICIT_FILE_EXTENSIONS.has(path.posix.extname(filePath).toLowerCase());
+}
+
+function isDocReferencePath(filePath: string): boolean {
+  if (EXPLICIT_ROOT_FILES.has(filePath)) return true;
+  return DOC_EXTENSIONS.has(path.posix.extname(filePath).toLowerCase());
 }
 
 async function gatherCandidates(repoPath: string, exclude: Set<string>): Promise<string[]> {

--- a/src/docs/types.ts
+++ b/src/docs/types.ts
@@ -1,8 +1,16 @@
-export type DocSourceKind = 'always' | 'discovered' | 'rule' | 'missing' | 'source';
+export type DocSourceKind =
+  | 'always'
+  | 'discovered'
+  | 'rule'
+  | 'missing'
+  | 'source'
+  | 'issue-doc'
+  | 'issue-source';
 
 export interface DocSection {
   filePath: string;         // relative path from repo root
   content: string;          // file content (empty string when missing)
   found: boolean;
   kind: DocSourceKind;
+  reasons?: string[];
 }

--- a/tests/cli.integration.test.js
+++ b/tests/cli.integration.test.js
@@ -621,6 +621,178 @@ test('spec plan fixture output stays deterministic across repeated runs', async 
   assert.equal(normalizePlanOutput(fullSecond.stdout), normalizePlanOutput(fullFirst.stdout));
 });
 
+test('spec plan includes issue-mentioned source file paths in prompt and full outputs', async (t) => {
+  const fixture = await createExplicitPathPlanFixture(t, {
+    issueNumber: 80,
+    title: 'Extract explicit repo source file paths from issue body',
+    bodyLines: [
+      'Relevant source files:',
+      '- `apps/dashboard/src/providers/dataProvider.ts`',
+      '- `apps/dashboard/src/providers/__tests__/dataProvider.test.ts`',
+      '- `services/api/internal/router/router.go`',
+    ],
+    repoFiles: {
+      'apps/dashboard/src/providers/dataProvider.ts': 'export const provider = "ISSUE_SOURCE_PROVIDER_SENTINEL";\n',
+      'apps/dashboard/src/providers/__tests__/dataProvider.test.ts': 'export const providerTest = "ISSUE_SOURCE_TEST_SENTINEL";\n',
+      'services/api/internal/router/router.go': 'package router\n\nconst RouterSentinel = "ISSUE_ROUTER_SOURCE_SENTINEL"\n',
+    },
+  });
+
+  const promptResult = await runSpec(['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'], { env: fixture.env });
+  const fullResult = await runSpec(['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run'], { env: fixture.env });
+
+  assert.equal(promptResult.code, 0, promptResult.stderr);
+  assert.equal(fullResult.code, 0, fullResult.stderr);
+  assert.match(promptResult.stdout, /apps\/dashboard\/src\/providers\/dataProvider\.ts/);
+  assert.match(promptResult.stdout, /apps\/dashboard\/src\/providers\/__tests__\/dataProvider\.test\.ts/);
+  assert.match(promptResult.stdout, /services\/api\/internal\/router\/router\.go/);
+  assert.match(promptResult.stdout, /mentioned in issue/i);
+  assert.match(fullResult.stdout, /### apps\/dashboard\/src\/providers\/dataProvider\.ts/);
+  assert.match(fullResult.stdout, /ISSUE_SOURCE_PROVIDER_SENTINEL/);
+  assert.match(fullResult.stdout, /### apps\/dashboard\/src\/providers\/__tests__\/dataProvider\.test\.ts/);
+  assert.match(fullResult.stdout, /ISSUE_SOURCE_TEST_SENTINEL/);
+  assert.match(fullResult.stdout, /### services\/api\/internal\/router\/router\.go/);
+  assert.match(fullResult.stdout, /ISSUE_ROUTER_SOURCE_SENTINEL/);
+  assert.match(fullResult.stdout, /sources:\s*3/);
+});
+
+test('spec plan includes issue-mentioned docs and de-dupes with always_read', async (t) => {
+  const fixture = await createExplicitPathPlanFixture(t, {
+    issueNumber: 81,
+    title: 'Extract explicit documentation paths from issue body',
+    config: {
+      always_read: ['AGENTS.md'],
+    },
+    bodyLines: [
+      'Relevant docs:',
+      '- `docs/architecture.md`',
+      '- `AGENTS.md`',
+    ],
+    repoFiles: {
+      'docs/architecture.md': '# Architecture\n\nISSUE_DOC_ARCHITECTURE_SENTINEL\n',
+      'AGENTS.md': '# Agents\n\nISSUE_DOC_AGENTS_SENTINEL\n',
+    },
+  });
+
+  const promptResult = await runSpec(['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'], { env: fixture.env });
+  const fullResult = await runSpec(['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run'], { env: fixture.env });
+
+  assert.equal(promptResult.code, 0, promptResult.stderr);
+  assert.equal(fullResult.code, 0, fullResult.stderr);
+  assert.match(promptResult.stdout, /docs\/architecture\.md/);
+  assert.match(promptResult.stdout, /AGENTS\.md/);
+  assert.match(promptResult.stdout, /mentioned in issue/i);
+  assert.equal(countOccurrences(promptResult.stdout, 'AGENTS.md'), 1);
+  assert.match(fullResult.stdout, /### docs\/architecture\.md/);
+  assert.match(fullResult.stdout, /ISSUE_DOC_ARCHITECTURE_SENTINEL/);
+  assert.match(fullResult.stdout, /### AGENTS\.md/);
+  assert.match(fullResult.stdout, /ISSUE_DOC_AGENTS_SENTINEL/);
+  assert.equal(countOccurrences(fullResult.stdout, '### AGENTS.md'), 1);
+});
+
+test('spec plan reports missing explicit issue-mentioned file paths without failing', async (t) => {
+  const fixture = await createExplicitPathPlanFixture(t, {
+    issueNumber: 82,
+    title: 'Report missing explicit file paths from issue body',
+    bodyLines: [
+      'Missing file to verify:',
+      '- `apps/dashboard/src/providers/missingProvider.ts`',
+    ],
+  });
+
+  const promptResult = await runSpec(['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'], { env: fixture.env });
+  const fullResult = await runSpec(['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run'], { env: fixture.env });
+
+  assert.equal(promptResult.code, 0, promptResult.stderr);
+  assert.equal(fullResult.code, 0, fullResult.stderr);
+  assert.match(promptResult.stdout, /## 5\. Missing Files/);
+  assert.match(promptResult.stdout, /apps\/dashboard\/src\/providers\/missingProvider\.ts/);
+  assert.match(fullResult.stdout, /## 7\. Missing Files/);
+  assert.match(fullResult.stdout, /apps\/dashboard\/src\/providers\/missingProvider\.ts/);
+});
+
+test('spec plan ignores API and route paths when extracting file references', async (t) => {
+  const fixture = await createExplicitPathPlanFixture(t, {
+    issueNumber: 83,
+    title: 'Ignore API route paths in issue body extraction',
+    bodyLines: [
+      'Do not treat these routes as files:',
+      '- `/api/v1/users/me/points/history`',
+      '- `/api/v1/dashboard/settings`',
+      '- `/transactions`',
+      '- `/dashboard/settings`',
+    ],
+  });
+
+  const promptResult = await runSpec(['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'], { env: fixture.env });
+  const fullResult = await runSpec(['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run'], { env: fixture.env });
+
+  assert.equal(promptResult.code, 0, promptResult.stderr);
+  assert.equal(fullResult.code, 0, fullResult.stderr);
+  assert.doesNotMatch(promptResult.stdout, /Relevant File References[\s\S]*\/api\/v1\/users\/me\/points\/history/);
+  assert.doesNotMatch(promptResult.stdout, /Missing Files[\s\S]*\/api\/v1\/dashboard\/settings/);
+  assert.doesNotMatch(fullResult.stdout, /Auto-Discovered Source Files[\s\S]*\/transactions/);
+  assert.doesNotMatch(fullResult.stdout, /Missing Files[\s\S]*\/dashboard\/settings/);
+});
+
+test('spec plan ignores URLs, traversal paths, and absolute paths', async (t) => {
+  const fixture = await createExplicitPathPlanFixture(t, {
+    issueNumber: 84,
+    title: 'Ignore unsafe or non-repo paths in issue body extraction',
+    bodyLines: [
+      'Unsafe references to ignore:',
+      '- `https://github.com/nurockplayer/tachigo/issues/467`',
+      '- `../secrets.env`',
+      '- `/absolute/path.ts`',
+    ],
+  });
+
+  const result = await runSpec(['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run'], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  const refsSection = sectionBetween(result.stdout, '## 3. Always-Read Files', '## 8. Suggested Verification Checklist');
+  assert.doesNotMatch(refsSection, /https:\/\/github\.com\/nurockplayer\/tachigo\/issues\/467/);
+  assert.doesNotMatch(refsSection, /\.\.\/secrets\.env/);
+  assert.doesNotMatch(refsSection, /\/absolute\/path\.ts/);
+});
+
+test('spec plan tachigo-like fixture extracts explicit source files without misclassifying API paths', async (t) => {
+  const fixture = await createExplicitPathPlanFixture(t, {
+    issueNumber: 467,
+    title: 'Support dashboard points history contract updates',
+    bodyLines: [
+      'Relevant files from issue body:',
+      '- `apps/dashboard/src/providers/dataProvider.ts`',
+      '- `apps/dashboard/src/providers/__tests__/dataProvider.test.ts`',
+      '- `services/api/internal/router/router.go`',
+      '- `services/api/internal/handlers/points_handler.go`',
+      '- `services/api/internal/handlers/agency_handler.go`',
+      '',
+      'Related API routes that are not files:',
+      '- `/api/v1/users/me/points/history`',
+      '- `/api/v1/dashboard/settings`',
+    ],
+    repoFiles: {
+      'apps/dashboard/src/providers/dataProvider.ts': 'export const tachigoProvider = "TACHIGO_PROVIDER_SENTINEL";\n',
+      'apps/dashboard/src/providers/__tests__/dataProvider.test.ts': 'export const tachigoProviderTest = "TACHIGO_PROVIDER_TEST_SENTINEL";\n',
+      'services/api/internal/router/router.go': 'package router\n\nconst TachigoRouterSentinel = "TACHIGO_ROUTER_SENTINEL"\n',
+      'services/api/internal/handlers/points_handler.go': 'package handlers\n\nconst PointsHandlerSentinel = "TACHIGO_POINTS_HANDLER_SENTINEL"\n',
+      'services/api/internal/handlers/agency_handler.go': 'package handlers\n\nconst AgencyHandlerSentinel = "TACHIGO_AGENCY_HANDLER_SENTINEL"\n',
+    },
+  });
+
+  const promptResult = await runSpec(['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'], { env: fixture.env });
+
+  assert.equal(promptResult.code, 0, promptResult.stderr);
+  assert.match(promptResult.stdout, /apps\/dashboard\/src\/providers\/dataProvider\.ts/);
+  assert.match(promptResult.stdout, /services\/api\/internal\/handlers\/points_handler\.go/);
+  assert.match(promptResult.stdout, /services\/api\/internal\/handlers\/agency_handler\.go/);
+  assert.match(promptResult.stdout, /mentioned in issue/i);
+  assert.doesNotMatch(promptResult.stdout, /Missing Files[\s\S]*\/api\/v1\/users\/me\/points\/history/);
+  assert.doesNotMatch(promptResult.stdout, /Missing Files[\s\S]*\/api\/v1\/dashboard\/settings/);
+  assert.match(promptResult.stdout, /sources:\s*5/);
+});
+
 async function createTempRepo(t, prefix = 'spec-injector-test-') {
   const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
   t.after(async () => {
@@ -703,6 +875,47 @@ async function createSpecPlanFixture(t) {
     ghLogPath: fakeGh.logPath,
     issueUrl: issue.url,
     taskPackagePath: path.join(repoDir, '.spec-injector', 'out', 'issue-57-task-package.md'),
+  };
+}
+
+async function createExplicitPathPlanFixture(t, options) {
+  const repoDir = await createTempRepo(t);
+  const issueNumber = options.issueNumber ?? 80;
+  const issueUrl = `https://github.com/Erick52106/spec-injector/issues/${issueNumber}`;
+  const config = {
+    version: 2,
+    always_read: options.config?.always_read ?? [],
+    discovery: {
+      docs: options.config?.discovery?.docs ?? [],
+      source: options.config?.discovery?.source ?? ['src', 'apps', 'services', 'packages'],
+      max_docs: options.config?.discovery?.max_docs ?? 5,
+      max_source_files: options.config?.discovery?.max_source_files ?? 5,
+    },
+    guardrails: options.config?.guardrails ?? [],
+  };
+
+  await writeRepoFiles(repoDir, {
+    '.spec-injector/config.json': `${JSON.stringify(config, null, 2)}\n`,
+    ...(options.repoFiles ?? {}),
+  });
+
+  const issue = {
+    number: issueNumber,
+    title: options.title,
+    body: options.bodyLines.join('\n'),
+    labels: options.labels ?? [{ name: 'plan' }],
+    url: issueUrl,
+    state: 'OPEN',
+  };
+  const fakeGh = await createFakeGh(t, issue);
+  fakeGh.env.FAKE_GH_EXPECT_REF = String(issueNumber);
+
+  return {
+    repoDir,
+    env: fakeGh.env,
+    ghLogPath: fakeGh.logPath,
+    issueUrl,
+    taskPackagePath: path.join(repoDir, '.spec-injector', 'out', `issue-${issueNumber}-task-package.md`),
   };
 }
 


### PR DESCRIPTION
## Source of truth

Closes #80

## Dogfood source

tachigo #467

## What changed

- extract repo-relative file paths explicitly mentioned in GitHub issue bodies
- classify found paths into documentation references, source references, or missing files
- surface issue-mentioned references in both prompt and full task package output with `mentioned in issue` labeling
- de-duplicate issue-mentioned paths against existing always-read and auto-discovered references while preserving higher-confidence reason text

## Out of scope

- no classifier behavior changes
- no config schema changes
- no new CLI commands
- no semantic code search or custom domain support
- no live GitHub API dependency in tests or feature implementation

## Path extraction strategy

- prefer backtick-wrapped candidates from the issue body, then scan markdown list items for bare repo-relative paths
- accept only normalized repo-relative paths with supported extensions or known root files
- classify `.md` and known root docs as documentation references; treat other supported file types as source references
- verify path existence inside the target repo before loading content, otherwise report it under Missing Files

## False positive prevention strategy

- reject URL schemes such as `https://`
- reject absolute paths and any path traversal such as `../`
- reject candidates that start with `/`, include fragment markers, or do not match the supported repo-file shape
- avoid treating API routes and dashboard paths as files by requiring a known file extension or known root filename

## Test strategy

- mocked `gh` fixture coverage for explicit source paths in prompt and full output
- explicit docs path coverage including de-dupe against `always_read`
- missing explicit path coverage with non-fatal exit behavior
- API route, URL, traversal, and absolute-path false-positive coverage
- tachigo-like regression fixture covering frontend files, backend contract files, and route noise together

## Verification

- `npm run build`
- `npm test`

## Implementation Evidence

- Issue evidence comment: https://github.com/Erick52106/spec-injector/issues/80#issuecomment-4363867887
- Commit: `e58bd8b9f38609746c88cfe37efde9ac9d793953`

## Checklist

- [x] explicit issue body file paths are extracted into references
- [x] missing explicit paths are reported without failing the command
- [x] issue-mentioned references are labeled in output
- [x] false positives for API paths, URLs, traversal, and absolute paths are covered by tests
- [x] `npm run build` and `npm test` pass
