### PR TITLE
fix(discovery): exclude superpowers docs from plan auto-discovery

### DIFF
--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -8,6 +8,7 @@ import {
   discoverSourceFiles,
   extractExplicitIssueFileReferences,
 } from '../docs/finder.js';
+import { getPlanDiscoveryExcludePaths } from '../docs/exclusions.js';
 import { renderTemplate } from '../template/renderer.js';
 import { DEFAULT_TEMPLATE } from '../template/default-template.js';
 import { PROMPT_TEMPLATE } from '../template/prompt-template.js';
@@ -66,7 +67,7 @@ export async function plan(
   const excludeSet = new Set<string>([
     ...alwaysDocs.map((d) => d.filePath),
     ...discoveryDocs.map((d) => d.filePath),
-    ...(config.specConfig.discovery?.exclude ?? []),
+    ...getPlanDiscoveryExcludePaths(config.specConfig.discovery?.exclude ?? []),
   ]);
   const maxDocs = config.specConfig.discovery?.max_docs ?? 5;
   const discoveredDocs = await discoverRelevantDocs(issue, repoPath, excludeSet, maxDocs);

--- a/src/docs/exclusions.ts
+++ b/src/docs/exclusions.ts
@@ -1,0 +1,30 @@
+import path from 'path';
+
+const DEFAULT_PLAN_DISCOVERY_EXCLUDES = [
+  'docs/superpowers',
+];
+
+function normalizeDiscoveryPath(filePath: string): string {
+  return filePath.split(path.sep).join(path.posix.sep).replace(/^\.\//, '');
+}
+
+export function getPlanDiscoveryExcludePaths(configuredPaths: string[] = []): string[] {
+  return [...new Set(
+    [...DEFAULT_PLAN_DISCOVERY_EXCLUDES, ...configuredPaths]
+      .map((filePath) => normalizeDiscoveryPath(filePath))
+      .filter((filePath) => filePath.length > 0)
+  )];
+}
+
+export function isPlanDiscoveryExcluded(filePath: string, excludePaths: Iterable<string>): boolean {
+  const normalizedPath = normalizeDiscoveryPath(filePath).toLowerCase();
+
+  for (const excludedPath of excludePaths) {
+    const normalizedExcludedPath = normalizeDiscoveryPath(excludedPath).toLowerCase();
+    if (normalizedPath === normalizedExcludedPath || normalizedPath.startsWith(`${normalizedExcludedPath}/`)) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/src/docs/finder.ts
+++ b/src/docs/finder.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
 import { safeReadFile } from '../utils/fs.js';
+import { isPlanDiscoveryExcluded } from './exclusions.js';
 import type { DocSection, DocSourceKind } from './types.js';
 import type { Issue } from '../github/types.js';
 
@@ -191,7 +192,7 @@ async function gatherCandidates(repoPath: string, exclude: Set<string>): Promise
 
   // Fixed high-value files
   for (const fixed of ['README.md', 'CLAUDE.md', 'AGENTS.md']) {
-    if (!exclude.has(fixed) && fs.existsSync(path.join(repoPath, fixed))) {
+    if (!isPlanDiscoveryExcluded(fixed, exclude) && fs.existsSync(path.join(repoPath, fixed))) {
       candidates.push(fixed);
     }
   }
@@ -214,10 +215,12 @@ function walkMarkdown(
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) {
+      const relDir = path.relative(repoPath, full);
+      if (isPlanDiscoveryExcluded(relDir, exclude)) continue;
       walkMarkdown(full, repoPath, exclude, results);
     } else if (entry.isFile() && entry.name.endsWith('.md')) {
       const rel = path.relative(repoPath, full);
-      if (!exclude.has(rel)) results.push(rel);
+      if (!isPlanDiscoveryExcluded(rel, exclude)) results.push(rel);
     }
   }
 }

--- a/tests/cli.integration.test.js
+++ b/tests/cli.integration.test.js
@@ -690,6 +690,96 @@ test('spec plan includes issue-mentioned docs and de-dupes with always_read', as
   assert.equal(countOccurrences(fullResult.stdout, '### AGENTS.md'), 1);
 });
 
+test('spec plan excludes docs/superpowers from auto-discovered docs by default', async (t) => {
+  const fixture = await createExplicitPathPlanFixture(t, {
+    issueNumber: 79,
+    title: 'Refine dashboard endpoint contract planning docs',
+    bodyLines: [
+      'Need plan discovery for dashboard refine endpoint contract updates.',
+      '',
+      'The old migration plan mentions dashboard refine endpoint contract wording too,',
+      'but the task package should prefer current dashboard docs over legacy planning docs.',
+    ],
+    repoFiles: {
+      'docs/superpowers/plans/old-plan.md': '# Old Plan\n\nLegacy dashboard refine endpoint contract migration plan.\nSUPERPOWERS_OLD_PLAN_SENTINEL\n',
+      'docs/dashboard-stack-evaluation.md': '# Dashboard Stack Evaluation\n\nCurrent dashboard refine endpoint contract notes.\nDASHBOARD_STACK_SENTINEL\n',
+    },
+  });
+
+  const promptResult = await runSpec(['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'], { env: fixture.env });
+  const fullResult = await runSpec(['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run'], { env: fixture.env });
+
+  assert.equal(promptResult.code, 0, promptResult.stderr);
+  assert.equal(fullResult.code, 0, fullResult.stderr);
+  assert.match(promptResult.stdout, /docs\/dashboard-stack-evaluation\.md/);
+  assert.doesNotMatch(promptResult.stdout, /docs\/superpowers\/plans\/old-plan\.md/);
+  assert.match(fullResult.stdout, /### docs\/dashboard-stack-evaluation\.md/);
+  assert.match(fullResult.stdout, /DASHBOARD_STACK_SENTINEL/);
+  assert.doesNotMatch(fullResult.stdout, /docs\/superpowers\/plans\/old-plan\.md/);
+  assert.doesNotMatch(fullResult.stdout, /SUPERPOWERS_OLD_PLAN_SENTINEL/);
+});
+
+test('spec plan auto-discovery exclusion stays consistent with config suggest always-read ignored dirs', async (t) => {
+  const fixture = await createExplicitPathPlanFixture(t, {
+    issueNumber: 179,
+    title: 'Refine dashboard endpoint contract planning docs',
+    bodyLines: [
+      'Need plan discovery for dashboard refine endpoint contract updates.',
+      'Avoid pulling legacy migration plans when current dashboard docs exist.',
+    ],
+    repoFiles: {
+      'docs/superpowers/plans/old-plan.md': '# Old Plan\n\nLegacy dashboard refine endpoint contract migration plan.\n',
+      'docs/dashboard-stack-evaluation.md': '# Dashboard Stack Evaluation\n\nCurrent dashboard refine endpoint contract notes.\n',
+    },
+  });
+
+  const suggestResult = await runSpec(['config', 'suggest', 'always-read', '--repo', fixture.repoDir], { env: fixture.env });
+  const planResult = await runSpec(['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'], { env: fixture.env });
+
+  assert.equal(suggestResult.code, 0, suggestResult.stderr);
+  assert.equal(planResult.code, 0, planResult.stderr);
+  assert.match(suggestResult.stdout, /Ignored \/ excluded:/);
+  assert.match(suggestResult.stdout, /docs\/superpowers\/\s+— superpowers planning docs are not always_read candidates/);
+  assert.match(planResult.stdout, /docs\/dashboard-stack-evaluation\.md/);
+  assert.doesNotMatch(planResult.stdout, /docs\/superpowers\/plans\/old-plan\.md/);
+});
+
+test('spec plan keeps explicit superpowers docs issue-mentioned without reintroducing them via auto-discovery', async (t) => {
+  const fixture = await createExplicitPathPlanFixture(t, {
+    issueNumber: 180,
+    title: 'Review explicit dashboard planning references from issue body',
+    bodyLines: [
+      'Relevant docs and source files:',
+      '- `docs/superpowers/plans/old-plan.md`',
+      '- `docs/architecture.md`',
+      '- `apps/dashboard/src/providers/dataProvider.ts`',
+    ],
+    repoFiles: {
+      'docs/superpowers/plans/old-plan.md': '# Old Plan\n\nSUPERPOWERS_EXPLICIT_SENTINEL\n',
+      'docs/architecture.md': '# Architecture\n\nEXPLICIT_ARCHITECTURE_SENTINEL\n',
+      'apps/dashboard/src/providers/dataProvider.ts': 'export const provider = "EXPLICIT_SOURCE_SENTINEL";\n',
+    },
+  });
+
+  const promptResult = await runSpec(['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'], { env: fixture.env });
+  const fullResult = await runSpec(['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run'], { env: fixture.env });
+
+  assert.equal(promptResult.code, 0, promptResult.stderr);
+  assert.equal(fullResult.code, 0, fullResult.stderr);
+  assert.match(promptResult.stdout, /`docs\/superpowers\/plans\/old-plan\.md` — mentioned in issue/);
+  assert.doesNotMatch(promptResult.stdout, /`docs\/superpowers\/plans\/old-plan\.md` — [^\n]*auto-discovered/);
+  assert.match(promptResult.stdout, /`docs\/architecture\.md` — mentioned in issue/);
+  assert.match(promptResult.stdout, /`apps\/dashboard\/src\/providers\/dataProvider\.ts` — mentioned in issue/);
+  assert.equal(countOccurrences(promptResult.stdout, 'docs/superpowers/plans/old-plan.md'), 1);
+  assert.match(fullResult.stdout, /### docs\/superpowers\/plans\/old-plan\.md\n\n_mentioned in issue_/);
+  assert.doesNotMatch(fullResult.stdout, /### docs\/superpowers\/plans\/old-plan\.md\n\n_[^\n]*auto-discovered_/);
+  assert.match(fullResult.stdout, /SUPERPOWERS_EXPLICIT_SENTINEL/);
+  assert.match(fullResult.stdout, /### docs\/architecture\.md/);
+  assert.match(fullResult.stdout, /EXPLICIT_ARCHITECTURE_SENTINEL/);
+  assert.match(fullResult.stdout, /### apps\/dashboard\/src\/providers\/dataProvider\.ts/);
+  assert.match(fullResult.stdout, /EXPLICIT_SOURCE_SENTINEL/);
+});
+
 test('spec plan reports missing explicit issue-mentioned file paths without failing', async (t) => {
   const fixture = await createExplicitPathPlanFixture(t, {
     issueNumber: 82,


### PR DESCRIPTION
## Source of truth

Closes #79

## Dogfood source

- tachigo #467
- Dogfood issue: https://github.com/nurockplayer/tachigo/issues/467

## 修改內容

- 將 `spec plan` docs auto-discovery 的 default exclude policy 與 `spec config suggest always-read` 的 superpowers exclusion 對齊。
- 新增共用的 plan discovery exclusion helper，統一處理預設排除與路徑正規化。
- 讓 `docs/superpowers/**` 不會被 `spec plan` auto-discovery 自動抓入 task package。
- 保留 explicit issue-mentioned path extraction；issue body 若明確提到 `docs/superpowers/**`，仍可作為 issue-mentioned docs 輸出。
- 補上 integration tests，覆蓋 auto-discovery 排除、一致性，以及 explicit path 行為。

## 不包含範圍

- 不修改 classifier behavior
- 不修改 config schema
- 不新增 CLI command
- 不新增 LLM / API / local model integration
- 不重寫整個 discovery pipeline
- 不修改 template output 結構
- 不修改 GitHub Actions workflow

## exclusion strategy

- `spec plan` 會先合併 plan discovery 預設排除與 `config.discovery.exclude`。
- exclusion 判斷採用 `exact match or descendant path` 規則，因此 `docs/superpowers` 會一致地排除 `docs/superpowers/plans/old-plan.md` 這類子路徑。
- 這次只把最小必要邏輯抽到 docs discovery helper，沒有擴大成整體 pipeline 重構。

## explicit issue-mentioned superpowers path behavior

- 採用 preferred strategy。
- `docs/superpowers/**` 不參與 auto-discovery。
- 若 issue body 明確寫到 `docs/superpowers/plans/foo.md` 且檔案存在，仍會被保留為 issue-mentioned docs。
- 在這種情況下，該 path 不會再同時帶上 `auto-discovered` reason。

## 測試策略

- 使用 mocked `gh` fixture 驗證 `spec plan --dry-run --format prompt` 與 full output。
- 驗證 `docs/superpowers/plans/old-plan.md` 不會由 auto-discovery 進入輸出。
- 驗證 `spec config suggest always-read` 仍將 `docs/superpowers/` 列為 ignored / excluded，且 `spec plan` 保持一致。
- 驗證 explicit issue-mentioned `docs/superpowers/**` path 仍會以 `mentioned in issue` 出現。
- 驗證一般 explicit docs path 與 source path extraction 不回歸。
- 測試本身不打真 GitHub API。

## 驗證方式

- `npm run build`
- `npm test`

## Implementation Evidence

- Commit: `8c81d36e36965ab1091e5a62db3880efd9333bcd`
- Issue evidence comment: https://github.com/Erick52106/spec-injector/issues/79#issuecomment-4363949951

## Checklist

- [x] `docs/superpowers/**` 預設不進入 `spec plan` auto-discovered docs
- [x] `spec config suggest always-read` 與 `spec plan` exclusion policy 對齊
- [x] explicit issue-mentioned superpowers path 保持可讀
- [x] integration tests 使用 mocked `gh` fixture
- [x] `npm run build` 通過
- [x] `npm test` 通過
