### PR TITLE
fix(classifier): reduce wallet false positives for generic transaction wording

### DIFF
--- a/src/classifier/domain.ts
+++ b/src/classifier/domain.ts
@@ -10,7 +10,7 @@ const DOMAIN_KEYWORDS: Record<string, string[]> = {
   'cloud-storage': ['s3', 'gcs', 'storage', 'bucket', 'upload', 'download', 'blob', 'cdn', 'file upload', 'asset', 'object storage'],
   blockchain: ['blockchain', 'chain', 'block', 'hash', 'ledger', 'consensus', 'miner', 'ethereum', 'solana', 'web3', 'nft', 'defi'],
   'smart-contract': ['smart contract', 'contract', 'solidity', 'abi', 'evm', 'vyper', 'bytecode', 'deploy contract'],
-  wallet: ['wallet', 'private key', 'public key', 'address', 'sign', 'transaction', 'send', 'receive', 'balance', 'seed phrase', 'mnemonic'],
+  wallet: ['wallet', 'connect wallet', 'wallet address', 'private key', 'public key', 'address', 'signature', 'signing', 'transaction hash', 'tx hash', 'token transfer', 'on-chain', 'send', 'receive', 'balance', 'seed phrase', 'mnemonic'],
   i18n: ['i18n', 'l10n', 'locale', 'translation', 'lang', 'language', 'localize', 'multilang'],
   testing: ['test', 'spec', 'unit', 'integration', 'e2e', 'mock', 'stub', 'coverage', 'jest', 'vitest', 'playwright', 'cypress', 'assert', 'fixture'],
   docs: ['docs', 'documentation', 'readme', 'guide', 'changelog', 'wiki', 'jsdoc', 'typedoc'],

--- a/tests/cli.integration.test.js
+++ b/tests/cli.integration.test.js
@@ -4,9 +4,64 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
 import { spawn } from 'node:child_process';
+import { classifyDomains } from '../dist/classifier/domain.js';
 
 const repoRoot = process.cwd();
 const cliPath = path.join(repoRoot, 'bin', 'spec.js');
+
+test('classifier does not treat dashboard transactions endpoint wording as wallet evidence', () => {
+  const domains = classifyDomains({
+    number: 77,
+    title: 'Dashboard frontend UI refine transactions/settings endpoint contract',
+    body: [
+      'Align the transactions endpoint and settings endpoint API contract.',
+      'Update the backend server route handler and controller for dashboard records.',
+      'Keep the frontend dashboard page and data provider response shape in sync.',
+    ].join('\n'),
+    labels: ['frontend', 'api', 'backend'],
+    url: 'https://github.com/Erick52106/spec-injector/issues/77',
+    state: 'open',
+  });
+
+  assert.ok(domains.includes('frontend'), `Expected frontend in ${domains.join(', ')}`);
+  assert.ok(domains.includes('api'), `Expected api in ${domains.join(', ')}`);
+  assert.ok(domains.includes('backend'), `Expected backend in ${domains.join(', ')}`);
+  assert.ok(!domains.includes('wallet'), `Expected wallet to be absent from ${domains.join(', ')}`);
+});
+
+test('classifier keeps wallet detection for explicit wallet and on-chain transaction evidence', () => {
+  const domains = classifyDomains({
+    number: 77,
+    title: 'Connect wallet token transfer transaction hash tracking',
+    body: [
+      'Record the connected wallet address after users connect wallet.',
+      'Show token transfer status, tx hash, transaction hash, and on-chain confirmation.',
+    ].join('\n'),
+    labels: ['wallet'],
+    url: 'https://github.com/Erick52106/spec-injector/issues/77',
+    state: 'open',
+  });
+
+  assert.ok(domains.includes('wallet'), `Expected wallet in ${domains.join(', ')}`);
+});
+
+test('classifier does not overfit product transaction records to wallet', () => {
+  const domains = classifyDomains({
+    number: 77,
+    title: 'Admin dashboard transaction history endpoint',
+    body: [
+      'Expose billing transaction records API for product support workflows.',
+      'The backend handler should read app records from database rows.',
+    ].join('\n'),
+    labels: ['api', 'backend'],
+    url: 'https://github.com/Erick52106/spec-injector/issues/77',
+    state: 'open',
+  });
+
+  assert.ok(domains.includes('api'), `Expected api in ${domains.join(', ')}`);
+  assert.ok(domains.includes('backend'), `Expected backend in ${domains.join(', ')}`);
+  assert.ok(!domains.includes('wallet'), `Expected wallet to be absent from ${domains.join(', ')}`);
+});
 
 test('spec --help lists deterministic CLI purpose and available commands', async () => {
   const result = await runSpec(['--help']);


### PR DESCRIPTION
## Source of truth

- Closes #77
- refs #77

## Summary

- Removed bare `transaction` as wallet domain evidence so generic product/API/database transaction wording does not classify as wallet by itself.
- Added stronger wallet/blockchain-specific wallet hints such as `transaction hash`, `tx hash`, `token transfer`, and `on-chain`.
- Added regression coverage for dashboard/API/backend transaction wording, generic product transaction records, and explicit wallet/on-chain wording.

## Tests / validation

```bash
npm run build
npm test
```

## Implementation Evidence

Issue comment URL: https://github.com/Erick52106/spec-injector/issues/77#issuecomment-4364235111
Commit hash: 52a4d69cd69e58b8cdfdef8497f4570721d83194

## Scope guard / non-goals confirmation

- Only #77 was handled.
- Did not handle #82 / #84 / #81 / #78 / #86 / #87 / #88 / #89 / #90 / #91.
- No classifier architecture rewrite.
- No custom domains.
- No config schema change.
- No new CLI command.
- No LLM / API / local model integration.
- Tests and implementation do not depend on real GitHub API or network.
- No package manager, Node version, JS-to-TS migration, or target repo runtime changes.

## Checklist

- [x] PR 只處理一個明確 scope
- [x] 已對應 issue（`refs #77` 已加入 commit message）
- [x] 已遵守 `presets/core/ai-collaboration.md`
- [x] 已執行必要 build/test
- [x] 沒有混入 unrelated refactor
- [x] 若有 breaking change，已明確標示或確認無 breaking change
- [x] 若有 config/schema/CLI 行為變更，已更新文件或確認無此類變更
- [x] 已在來源 issue 留下實作證據 comment，並將 URL 填入上方「實作證據」欄位
