### PR TITLE
docs: add architecture and core concepts documentation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,112 @@
+# Architecture
+
+## Purpose
+
+本文件說明 `spec-injector` 的核心架構。`spec-injector` 是 deterministic issue-to-context compiler：它把 GitHub issue、repo config、repo docs、source references 與 constraints 編譯成 AI 開工前可直接使用的 task package / prompt。
+
+它不是 autonomous agent、daemon、GitHub automation bot、hidden LLM wrapper、general-purpose RAG system，也不會自動修改 target repo code。
+
+## Pipeline
+
+目前 Layer 1 CLI 的核心 pipeline 是：
+
+```text
+GitHub Issue
+  -> Issue Loader via gh
+  -> Issue Parser
+  -> Domain Classifier
+  -> Guardrail Matcher
+  -> Reference Collector
+  -> Task Package Renderer
+  -> Markdown task package for Codex / Claude Code
+```
+
+### 1. GitHub Issue
+
+Issue 是 pipeline 的主要輸入。issue title、labels、body 會提供 task scope、domain signals、explicit file references、validation hints 與 human constraints。
+
+Issue body 是 source of truth。缺少 labels 不代表可以擴大 scope；labels 只提供輔助分類訊號。
+
+### 2. Issue Loader via gh
+
+`spec plan <issue>` 透過 GitHub CLI `gh` 讀取 issue。除了 `gh` 本身需要連到 GitHub，`spec-injector` core 不會呼叫 LLM、API 或 local model。
+
+這一步的責任是取得 normalized issue data，而不是替使用者做實作決策。
+
+### 3. Issue Parser
+
+Issue Parser 會把 issue 內容轉成後續步驟可使用的 deterministic signals，包括：
+
+- title / labels / body text
+- issue body 中明確提到的 repo-relative file paths
+- issue checklist 中的 `- [ ]` items
+
+Parser 不會推論 hidden requirements。若 issue 沒有明講，task package 應提醒 implementer 保守處理或回到 human 確認。
+
+### 4. Domain Classifier
+
+Domain Classifier 使用 deterministic keyword scoring 來判斷 issue 可能涉及哪些 built-in domains。它不是 LLM，也不是 architecture decision maker。
+
+目前 classifier 會依 title、labels、body 中的 keyword 命中加權，回傳最多 5 個 domains。詳細原則請見 [classifier.md](classifier.md)。
+
+### 5. Guardrail Matcher
+
+Guardrail Matcher 會依 detected domains 比對 `.spec-injector/config.json` 中 repo-defined guardrails。
+
+Guardrails 是 constraints / reminders，不是 approval。它們提醒 AI implementer 在開始前注意風險，但不授權擴 scope，也不代表可以跳過 human review。
+
+### 6. Reference Collector
+
+Reference Collector 會收集 task package 需要列出的 repo context。Reference taxonomy 詳見 [references.md](references.md)。
+
+目前來源包含：
+
+- built-in core preset reference
+- repo `always_read` references
+- configured discovery docs
+- issue-mentioned references
+- auto-discovered docs / source references
+
+Reference collection 是 deterministic context selection，不是 general-purpose RAG，也不會做 embedding search 或 semantic retrieval。
+
+### 7. Task Package Renderer
+
+Renderer 將 normalized issue、detected domains、references、guardrails、missing files 與 validation hints 輸出為 Markdown。
+
+目前支援：
+
+- full task package output
+- `--format prompt` 的 implementation plan prompt output
+
+Task package 是 AI 開工前的 structured context，不是 autonomous execution plan，也不包含 hidden LLM reasoning。詳細說明請見 [task-package.md](task-package.md)。
+
+## Determinism Boundaries
+
+Layer 1 deterministic CLI 的邊界：
+
+- 相同 issue content、相同 target repo files、相同 `.spec-injector/config.json`，應產生可重複的分類與 references selection。
+- CLI core 不呼叫 LLM / API / local model。
+- CLI core 不會自行修改 target repo source code。
+- Mutating commands 必須是明確 command 行為，例如 `spec init`、`spec config add/remove always-read`、`spec clean`。
+- `spec plan --dry-run` 不寫入 task package。
+
+## Relationship To Layers
+
+這份 architecture doc 聚焦目前可用的 Layer 1 deterministic CLI。
+
+Layer 2 AI workflow 與 Layer 3 future agent interface 的邊界請見 [design/layers.md](design/layers.md)。Layer 2 可以由 AI 使用 task package 產生 implementation plan，但那是 AI workflow，不是 `spec-injector` runtime 自己成為 autonomous agent。
+
+## Non-goals
+
+本 architecture 不包含：
+
+- autonomous code execution
+- target repo auto-editing
+- custom domains runtime
+- hidden LLM / API / local model integration
+- daemon / background sync
+- GitHub automation bot behavior
+- multi-agent runtime
+- classifier behavior changes
+- task package output behavior changes
+- config schema changes

--- a/docs/classifier.md
+++ b/docs/classifier.md
@@ -1,0 +1,104 @@
+# Classifier
+
+## Purpose
+
+Classifier 的責任是用 deterministic signals 從 issue 中選出 likely relevant domains，讓後續 guardrail matching 與 reference collection 更有方向。
+
+Classifier 不是 LLM、不是 architecture reviewer，也不是最終決策者。
+
+## Current Model
+
+目前 classifier 是 keyword-based scoring：
+
+- title keyword 命中權重最高
+- label keyword 命中次之
+- body keyword 命中提供輔助 evidence
+- 最多回傳 5 個 domains
+
+支援的 domains 由 runtime 內建，例如 `frontend`、`backend`、`api`、`auth`、`database`、`infra`、`cloud-storage`、`blockchain`、`smart-contract`、`wallet`、`i18n`、`testing`、`docs`、`ci`、`tooling`。
+
+目前沒有 repo-local custom domains runtime，也沒有 hidden LLM / API / local model classifier。
+
+## What Counts As Evidence
+
+Classifier evidence 是 deterministic signal，不是 model reasoning。常見 evidence 來源包含：
+
+- issue title 中的 domain keyword
+- GitHub labels 中的 domain keyword
+- issue body 中的 domain keyword
+- future-facing config-defined signals
+- future-facing path-based signals
+
+目前 task package 只列出 detected domains；detailed evidence visibility 尚未完整輸出。未來可以增加 visibility，但不應改變 classifier 的 deterministic core。
+
+## Generic Wording
+
+Generic product wording 需要小心處理。某些字在不同 domain 中都可能出現，不能單獨作為強 evidence。
+
+例如：
+
+- `transaction` 可以是 database transaction，也可以是 product wording。
+- `address` 可以是 wallet address，也可以是 shipping address、email address 或 UI copy。
+- `send` / `receive` 可以是 wallet 動作，也可以是 messaging 或 notification。
+
+原則是：generic wording 應弱於 legitimate domain evidence。
+
+## Wallet / Blockchain Evidence
+
+`wallet` / `blockchain` domain 應依賴更明確的 evidence，例如：
+
+- `wallet`
+- `connect wallet`
+- `wallet address`
+- `private key`
+- `public key`
+- `signature`
+- `seed phrase`
+- `mnemonic`
+- `on-chain`
+- `transaction hash` / `tx hash`
+- `token transfer`
+- `ethereum`
+- `solana`
+- `web3`
+
+Generic `transaction` 不應單獨代表 wallet。Legitimate wallet / blockchain evidence 應比 generic product wording 更強。
+
+## Classifier Output Is Advisory
+
+Detected domains 主要用於：
+
+- 選出 relevant guardrails
+- 協助 references selection
+- 提醒 AI implementer 可能涉及的風險區域
+
+Detected domains 不代表：
+
+- AI 可以修改該 domain 的所有檔案
+- issue scope 自動擴大
+- human approval 已經存在
+- classifier 做了 architecture decision
+
+## Future-facing Boundaries
+
+以下方向可以在未來設計，但目前不應被文件描述成已實作：
+
+- detailed classifier evidence section in task package
+- `spec classify --explain`
+- repo-local custom domains runtime
+- config-defined domain keywords
+- path-based classifier signals
+- JSON / agent-oriented classifier output
+
+任何 future classifier enhancement 都應維持 deterministic、testable、reviewable，且不應引入 hidden LLM calls。
+
+## Non-goals
+
+Classifier 不負責：
+
+- 自動產生 implementation plan
+- 自動選擇要修改的檔案
+- 自動判斷 PR 是否可 merge
+- 呼叫 LLM / API / local model
+- 取代 human review
+- 實作 custom domains runtime

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,155 @@
+# Core Concepts
+
+## Purpose
+
+本文件定義 `spec-injector` 文件與 issue 討論中常用的核心概念。目標是讓 contributor 與 AI coding agent 使用同一套語彙，避免把 deterministic context compiler 誤解成 autonomous agent。
+
+## Issue
+
+Issue 是 GitHub issue，也是 `spec plan <issue>` 的主要輸入。Issue title、labels、body 會提供 scope、keywords、file references、constraints 與 validation hints。
+
+Issue body 是 source of truth。若 conversation、labels 或 generated context 與 issue body 衝突，應回到 issue body 與 human decision。
+
+## Issue-scoped Context
+
+Issue-scoped context 是為單一 issue 收集的最小必要背景。它應幫助 AI implementer 開工前理解 scope，而不是替 issue 以外的工作創造理由。
+
+Issue-scoped context 可能包含：
+
+- issue summary
+- detected domains
+- guardrails
+- references
+- missing files
+- suggested validation checklist
+
+## Deterministic Compiler
+
+Deterministic compiler 指 `spec-injector` 的核心定位：把 issue 與 repo-defined context 編譯成 structured Markdown output。
+
+它的重點是 repeatable、config-driven、repo-safe：
+
+- 不呼叫 hidden LLM / API / local model
+- 不做 autonomous execution
+- 不修改 target repo code
+- 不把 suggestions 當成 approvals
+
+## Domain
+
+Domain 是 issue 可能涉及的技術或產品區域，例如 `frontend`、`backend`、`database`、`wallet`、`docs`、`ci`。
+
+目前 runtime 使用 built-in domains。Repo-local custom domains 是 future-facing design，尚未作為 runtime schema / classifier behavior 實作。
+
+## Domain Classifier
+
+Domain classifier 是 deterministic keyword / evidence based classifier。它根據 issue title、labels、body 中的 signals 選出 relevant domains。
+
+Classifier 的目標是協助 context selection 與 guardrail matching，不是替 human 或 architect 做最終設計決策。
+
+## Classifier Evidence
+
+Classifier evidence 指讓某個 domain 被判定 relevant 的 deterministic signals，例如：
+
+- title keyword
+- label keyword
+- body keyword
+- future path / config signals
+
+目前 CLI 會輸出 detected domains，但尚未在 task package 中完整揭露 detailed classifier evidence。更完整的 evidence visibility 屬於 future-facing work，不能在目前文件中假裝已完成。
+
+## Guardrail
+
+Guardrail 是 repo-defined constraint / reminder，設定於 `.spec-injector/config.json`。當 detected domains 命中 `when_detected`，相關 risk message 會進入 task package。
+
+Guardrail 不是 approval，也不授權 AI 擴大 scope。它的作用是提醒 implementer 在修改前注意風險。
+
+## Reference
+
+Reference 是 task package 中列出的 repo context。Reference 可以是 docs、source files、built-in preset 或 issue 明確提到的檔案。
+
+Reference 是 context，不是指令本身。AI implementer 仍必須遵守 issue scope、repo instructions 與 human approval。
+
+## Built-in Preset Reference
+
+Built-in preset reference 是 `spec-injector` package 內建的固定文件。目前 core preset 是 `presets/core/ai-collaboration.md`，會被加入 always-read context。
+
+Built-in preset 用來提供 AI collaboration baseline，不代表 target repo 可以被自動修改。
+
+## Repo Always-read Reference
+
+Repo `always_read` reference 是 target repo 在 `.spec-injector/config.json` 中明確設定每次都應讀取的文件。
+
+常見例子包含 `AGENTS.md`、`CLAUDE.md`、security docs、architecture docs 或 team workflow docs。
+
+## Issue-mentioned Reference
+
+Issue-mentioned reference 是 issue body 中明確提到的 repo-relative path，例如 ``src/cli/plan.ts`` 或 ``docs/security.md``。
+
+這類 references 通常比 auto-discovered references 更接近 issue intent，但仍不代表可以修改 scope 外檔案。
+
+## Auto-discovered Reference
+
+Auto-discovered reference 是 CLI 依 issue keywords 與 repo scan deterministic scoring 找到的 docs 或 source files。
+
+它是候選 context，不是完整 dependency graph，也不是 semantic RAG result。False positives / false negatives 應透過 follow-up issue 或 config 調整處理。
+
+## Task Package
+
+Task package 是 AI 開工前的 structured context。它可以包含 issue、classification、references、guardrails、missing files 與 validation hints。
+
+Task package 不是 autonomous execution plan，也不包含 hidden LLM reasoning。詳見 [task-package.md](task-package.md)。
+
+## Plan Output
+
+Plan output 是 `spec plan` 產生的 Markdown output。Full output 可寫入 `.spec-injector/out/issue-<number>-task-package.md`；prompt output 可用於 AI 先產生 implementation plan。
+
+Prompt output 不是 `/spec-plan` CLI command；`/spec-plan` 是 Layer 2 AI workflow shorthand。
+
+## Dogfood
+
+Dogfood 指用 `spec-injector` 處理真實 target repo issue，觀察 context selection 是否準確。
+
+Dogfood 不等於直接實作 target repo issue。若 target repo worktree dirty，應停下回報，不應自動 stash / clean / reset。
+
+## Target Repo
+
+Target repo 是 `spec plan --repo <path>` 指定要讀取 config、docs 與 source references 的 repository。
+
+`spec-injector` 可以讀取 target repo context，但不應自動修改 target repo code。
+
+## Implementation Evidence
+
+Implementation evidence 是 PR 開出後寫回 source issue 的 structured comment。它應記錄 summary、files changed、validation、commit hash、PR URL 與 scope boundaries。
+
+Evidence 讓 reviewer 能追蹤 issue 到 PR 的實作結果。
+
+## PR Body Backfill
+
+PR body backfill 指取得 issue implementation evidence comment 的永久連結後，回填到 PR body 的 Implementation Evidence section。
+
+PR body 必須重新讀取確認不是空的，且包含 issue link、evidence URL、commit hash 與 validation。
+
+## Scope Guard
+
+Scope guard 是 human、repo instructions、issue body、guardrails 與 PR process 共同形成的邊界。
+
+Scope guard 的核心原則：
+
+- 只處理 source issue
+- 不處理相鄰 issue
+- 不重構無關程式碼
+- 不修改未核准檔案
+- 發現需要擴 scope 時停下回報
+
+## Non-goals
+
+`spec-injector` 不是：
+
+- autonomous agent
+- daemon
+- hidden LLM wrapper
+- GitHub automation bot
+- custom domain runtime
+- general-purpose RAG system
+- target repo auto-editing system
+- multi-agent runtime

--- a/docs/dogfood.md
+++ b/docs/dogfood.md
@@ -1,0 +1,113 @@
+# Dogfood
+
+## Purpose
+
+Dogfood 是用 `spec-injector` 處理真實 target repo issue，以驗證 context selection、classifier domains、references 與 guardrails 是否對實際工作有幫助。
+
+Dogfood 不等於直接實作 target repo issue。它是一種觀察與校準流程。
+
+## What Dogfood Checks
+
+Dogfood report 應觀察：
+
+- detected domains 是否合理
+- guardrails 是否有幫助
+- `always_read` 是否提供必要 repo instructions
+- issue-mentioned references 是否被收集
+- auto-discovered references 是否 relevant
+- missing files 是否揭露 config 或 issue 問題
+- prompt output 是否足以支援 implementation planning
+
+## Safe Workflow
+
+建議流程：
+
+1. 確認 target repo。
+2. 檢查 target repo branch 與 worktree。
+3. 如果 target repo dirty，停下回報。
+4. 不自動 stash / clean / reset。
+5. 執行 `spec plan <issue> --repo <target-repo> --dry-run --format prompt --verbose`。
+6. 保存或摘要 output。
+7. 分析 observations、false positives、false negatives、follow-up issues。
+8. 不直接修改 target repo code，除非另有 approved implementation plan。
+
+## Dirty Worktree Rule
+
+若 target repo worktree 不是 clean：
+
+- 停下回報 current status。
+- 不自動 stash。
+- 不自動 clean。
+- 不自動 reset。
+- 不 checkout 覆蓋 local changes。
+
+這條規則保護 human 或其他 agent 的未提交變更。
+
+## Report Structure
+
+Dogfood report 建議包含：
+
+```markdown
+## Observations
+
+- ...
+
+## False positives
+
+- ...
+
+## False negatives
+
+- ...
+
+## Follow-up issues
+
+- ...
+
+## Scope boundary
+
+- This dogfood run did not implement the target repo issue.
+- No target repo code was modified.
+```
+
+## False Positives
+
+False positives 是 task package 納入了不相關或低價值 context。
+
+常見原因：
+
+- generic wording 命中太多 docs
+- filename 與 issue keyword 巧合相同
+- auto-discovery scan scope 太廣
+- classifier domain 太泛
+
+處理方式可以是調整 issue wording、調整 config exclude、改善 scoring，或開 follow-up issue。
+
+## False Negatives
+
+False negatives 是 task package 遺漏了重要 context。
+
+常見原因：
+
+- issue 沒有提到關鍵 path / domain wording
+- `always_read` config 不完整
+- discovery source paths 太少
+- max docs / max source files 太低
+- classifier keyword coverage 不足
+
+處理方式可以是補 issue references、更新 `always_read`、調整 discovery config，或提出 classifier / references follow-up。
+
+## Relationship To Implementation
+
+Dogfood 可以支援 implementation planning，但不取代 approved plan。若 dogfood 發現真正需要修改 runtime code、classifier behavior、task package output、config schema 或 CLI command，應另開或回到對應 issue，不應在 dogfood report 中順手實作。
+
+## Non-goals
+
+Dogfood 不是：
+
+- target repo auto-editing
+- GitHub automation bot
+- hidden LLM evaluation
+- full correctness proof
+- replacement for tests
+- merge approval

--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -1,0 +1,104 @@
+# Guardrails
+
+## Purpose
+
+Guardrails 是 repo-defined constraints / reminders。它們在 task package 中提醒 AI implementer：這個 issue 可能觸及某些高風險區域，開始實作前需要保守處理。
+
+Guardrails 不應被當成 approval，也不應讓 AI 自行擴大 scope。
+
+## Configuration
+
+Guardrails 設定於 target repo 的 `.spec-injector/config.json`：
+
+```json
+{
+  "guardrails": [
+    {
+      "id": "database-change",
+      "when_detected": ["database"],
+      "risk": "Database/schema changes require explicit issue scope and migration review."
+    }
+  ]
+}
+```
+
+欄位意義：
+
+- `id`: stable guardrail identifier
+- `when_detected`: detected domains 中任一 domain 命中時觸發
+- `risk`: 顯示在 task package 的 reminder
+
+## Matching Model
+
+目前 matching model 很單純：
+
+1. Domain Classifier 從 issue 取得 detected domains。
+2. Guardrail Matcher 讀取 repo config。
+3. 若 guardrail 的 `when_detected` 包含 detected domain，就加入 task package。
+
+這是 deterministic matching，不是 policy engine，也不是 LLM review。
+
+## How AI Implementers Should Use Guardrails
+
+AI implementer 應把 guardrails 視為開工前的風險提醒：
+
+- 檢查 issue 是否真的授權相關修改。
+- 若需要 migration、security review、breaking change 或 data handling change，先回報。
+- 在 implementation plan 中列出 guardrail impact。
+- 在 PR body / implementation evidence 中說明 scope boundaries。
+
+Guardrails 不應被解讀為：
+
+- 可以修改相關 domain 的所有檔案
+- human 已批准 risky change
+- 可以跳過 tests 或 review
+- 可以處理相鄰 issue
+
+## Examples
+
+Database guardrail：
+
+```json
+{
+  "id": "database-change",
+  "when_detected": ["database"],
+  "risk": "Database/schema changes require explicit issue scope and migration review."
+}
+```
+
+Auth guardrail：
+
+```json
+{
+  "id": "auth-sensitive",
+  "when_detected": ["auth"],
+  "risk": "Auth changes must preserve session and permission boundaries."
+}
+```
+
+Docs guardrail：
+
+```json
+{
+  "id": "docs-only",
+  "when_detected": ["docs"],
+  "risk": "Docs issues should not modify runtime behavior unless explicitly approved."
+}
+```
+
+## Relationship To Classifier
+
+Guardrails depend on detected domains, so classifier false positives can create extra reminders and false negatives can miss reminders.
+
+Extra guardrails should usually be treated as harmless caution. Missing guardrails should be handled through better issue wording, config updates, classifier improvements, or follow-up issues.
+
+## Non-goals
+
+Guardrails are not:
+
+- approval workflow
+- blocking policy engine
+- runtime permission system
+- replacement for code review
+- custom domains runtime
+- automatic task planner

--- a/docs/references.md
+++ b/docs/references.md
@@ -1,0 +1,113 @@
+# References
+
+## Purpose
+
+References 是 task package 中提供給 AI implementer 的 repo context。它們用來降低開工前的脈絡缺口，但不會取代 issue scope、repo instructions 或 human approval。
+
+Reference collection 是 deterministic context selection，不是 general-purpose RAG system。
+
+## Reference Taxonomy
+
+目前與 intended taxonomy 可分成四類：
+
+1. built-in preset references
+2. repo `always_read` references
+3. issue-mentioned references
+4. auto-discovered references
+
+部分 taxonomy 已在目前 CLI 中實作；與 future classifier evidence visibility、custom domains、agent output 相關的延伸能力仍是 planned / future-facing。
+
+## Built-in Preset References
+
+Built-in preset references 來自 `spec-injector` package 本身。
+
+目前 core preset：
+
+- `presets/core/ai-collaboration.md`
+
+它會被加入 always-read context，提供 AI collaboration baseline，例如 scope control、issue / PR rules 與 evidence expectations。
+
+Built-in preset 不代表 target repo 可以被自動修改。它只是 task package 的固定 context。
+
+## Repo Always-read References
+
+Repo `always_read` references 由 target repo 的 `.spec-injector/config.json` 明確設定。
+
+適合放入 `always_read` 的文件通常是：
+
+- repo-level AI instructions
+- architecture overview
+- security guidelines
+- coding standards
+- release or validation rules
+
+`spec config suggest always-read --repo .` 可以 deterministic 掃描候選文件，但只會建議，不會自動修改 config。
+
+Missing `always_read` files 會在 task package 的 Missing Files 中呈現。這是 config health signal，不一定是 fatal plan error。
+
+## Issue-mentioned References
+
+Issue-mentioned references 是 issue body 中明確提到的 repo-relative file paths。
+
+目前 parser 會辨識常見形式，例如：
+
+- inline code path：``docs/architecture.md``
+- bullet path：`- src/cli/plan.ts`
+
+Issue-mentioned references 會被標示 reason，例如 `mentioned in issue`。若檔案不存在，會進入 Missing Files。
+
+這類 references 通常是 strongest issue-local signal，但仍應遵守 scope guard：被提到不代表一定要修改。
+
+## Auto-discovered References
+
+Auto-discovered references 由 deterministic scan / scoring 產生。
+
+目前 auto-discovery 包含：
+
+- docs scan：固定 high-value files 與 `docs/**/*.md`
+- source scan：依 config `discovery.source` 指定的 directories
+- keyword scoring：issue title / body tokens 對 path、filename、file sample 的命中
+- max limits：`discovery.max_docs` 與 `discovery.max_source_files`
+
+Auto-discovered references 是 context candidates。它們可能有 false positives / false negatives，因此不應被視為完整 dependency graph。
+
+## Configured Discovery Docs
+
+`.spec-injector/config.json` 的 `discovery.docs` 可列出固定納入的 documentation paths。
+
+目前 task package 中這些 docs 會出現在 rule-matched / explicit documentation 相關區塊。它們是 config-driven references，不是 classifier 自動推論出的 approval。
+
+## Reference Ordering Principles
+
+實務上，AI implementer 應以以下優先順序理解 references：
+
+1. Issue body 與 human instructions
+2. Built-in preset 與 repo `always_read`
+3. Issue-mentioned references
+4. Configured discovery docs
+5. Auto-discovered docs / source candidates
+
+優先順序不等於修改權限。任何修改仍需符合 issue scope 與 approved plan。
+
+## Planned / Future-facing Ideas
+
+以下概念可以作為 future work，但目前不應假裝已完整實作：
+
+- classifier evidence driving visible reference reasons
+- custom domain path signals
+- richer reference scoring explanations
+- JSON / agent-oriented structured references
+- review UI for false positives / false negatives
+
+這些方向若要實作，應另開 issue，並包含 tests 與 docs update。
+
+## Non-goals
+
+References 不代表：
+
+- semantic embedding search
+- hidden model retrieval
+- target repo dependency graph
+- automatic file edit list
+- approval to modify referenced files
+- custom domains runtime

--- a/docs/task-package.md
+++ b/docs/task-package.md
@@ -1,0 +1,98 @@
+# Task Package
+
+## Purpose
+
+Task package 是 AI 開工前使用的 structured context。它把 issue、classification、references、guardrails、constraints 與 validation hints 放在同一份 Markdown output 中，讓 Codex / Claude Code 等 AI coding tools 可以先理解工作邊界。
+
+Task package 不是 autonomous execution plan，也不包含 hidden LLM reasoning。
+
+## Current Outputs
+
+目前 `spec plan` 支援兩種主要輸出：
+
+- full task package：預設 Markdown output，可寫入 `.spec-injector/out/issue-<number>-task-package.md`
+- prompt output：`--format prompt`，用於 AI 先產生 implementation plan
+
+`--dry-run` 會把 output 印到 stdout，不寫檔。
+
+## Expected Sections
+
+Full task package 目前包含：
+
+- Issue metadata and body
+- Classification / detected domains
+- Always-Read Files
+- Auto-Discovered Documentation
+- Auto-Discovered Source Files
+- Matched Guardrails
+- Rule-Matched Documentation
+- Missing Files
+- Suggested Verification Checklist
+
+Prompt output 目前包含：
+
+- Issue Summary
+- Detected Domains
+- Guardrails
+- Relevant File References
+- Missing Files
+- Instructions
+- Suggested verification checklist
+
+## Deterministic Output
+
+Task package 應是 deterministic output。給定相同 issue、target repo files 與 `.spec-injector/config.json`，pipeline 應產生穩定的 context selection 與 Markdown structure。
+
+時間戳等 metadata 可能反映當次生成時間；核心 classification、guardrail matching 與 reference selection 應保持 deterministic。
+
+## What It Is For
+
+Task package 適合用於：
+
+- AI implementation planning
+- human review of issue scope and context
+- identifying missing files
+- seeing matched guardrails
+- listing relevant references before coding
+- preserving repo-defined workflow constraints
+
+## What It Is Not
+
+Task package 不是：
+
+- autonomous execution plan
+- approval record
+- hidden LLM reasoning
+- target repo edit script
+- complete dependency graph
+- PR body replacement
+- CI result
+- custom domain runtime output
+
+## Plan Output And Human Approval
+
+在 Layer 2 AI workflow 中，常見流程是：
+
+1. AI 執行 `spec plan <issue> --repo . --dry-run --format prompt --verbose`。
+2. AI 根據 prompt output 草擬 implementation plan。
+3. Human review / approve plan。
+4. AI 才開始修改 target repo。
+
+這個 approval gate 不屬於 Layer 1 CLI 自動執行；它是 AI workflow 的 process rule。
+
+## Hidden Reasoning Boundary
+
+`spec-injector` core 不應把 hidden LLM reasoning 寫進 task package。若 AI 使用 task package 產生 plan，該 reasoning 屬於 AI tool 的 workflow，不是 `spec-injector` runtime output。
+
+未來若增加 JSON / agent-oriented output，也應保持 deterministic、inspectable、reviewable。
+
+## Non-goals
+
+Task package 不應：
+
+- 自動執行 issue
+- 自動建立 branch / commit / PR
+- 自動修改 source code
+- 自動補 labels
+- 自動新增 config schema
+- 自動呼叫 LLM / API / local model

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,109 @@
+# Workflow
+
+## Purpose
+
+本文件說明 `spec-injector` 在 issue-to-PR 流程中的位置。`spec-injector` 負責產生 deterministic task package；AI implementer 與 human review process 負責實作、驗證與 merge decision。
+
+## Standard Flow
+
+```text
+GitHub issue
+  -> spec plan / task package
+  -> AI implementation plan
+  -> human approval
+  -> AI implementation
+  -> validation
+  -> PR
+  -> source issue implementation evidence
+  -> PR body backfill
+  -> review / merge decision
+```
+
+## Step-by-step
+
+1. 確認 source issue。
+2. 同步 target repo branch state。
+3. 執行 `spec plan <issue> --repo . --dry-run --format prompt --verbose`。
+4. AI 依 task package 草擬 implementation plan。
+5. Human approve plan。
+6. AI 建立 feature branch。
+7. AI 只修改 approved scope 內檔案。
+8. AI 執行必要 validation。
+9. AI commit，commit message 包含 `refs #<issue-number>`。
+10. AI push feature branch。
+11. AI 建立 ready-for-review PR。
+12. AI 在 source issue 留下 implementation evidence comment。
+13. AI 將 evidence comment URL 回填 PR body。
+14. AI 用 `gh pr view` 或等價方式重新讀取 PR body，確認內容完整。
+15. Human / reviewer 決定 review、merge 或要求修改。
+
+## PR Requirements
+
+PR 應為 ready for review。除非 issue 特別要求，不要建立 draft PR。
+
+PR body 應包含：
+
+- `Closes #<issue-number>`
+- Summary
+- Docs / validation
+- Implementation Evidence section
+- issue evidence comment URL
+- commit hash
+- scope guard / non-goals confirmation
+
+若 PR template 有 checklist，且相關項目已驗證通過，應勾選，不要留下已完成項目的空 checkbox。
+
+## Implementation Evidence
+
+Implementation evidence comment 應寫回 source issue，讓 issue 讀者不用只靠 PR diff 才能知道實作結果。
+
+Evidence comment 應包含：
+
+- Summary
+- Files changed
+- Docs / validation
+- Commit hash
+- PR URL
+- Scope boundaries
+- explicit non-goals confirmations
+
+## PR Body Backfill
+
+取得 issue evidence comment 的永久連結後，應回填 PR body 的 Implementation Evidence section。
+
+回填後必須重新讀取 PR body，確認：
+
+- PR body 不是空的
+- 包含 `Closes #<issue-number>`
+- 包含 Implementation Evidence
+- 包含 issue evidence comment URL
+- 包含 commit hash
+- 包含 docs / validation
+
+## Scope Guard
+
+Workflow 中每一步都應維持 issue scope：
+
+- 不處理相鄰 issue
+- 不修改 runtime code，除非 issue 明確要求
+- 不修改 classifier behavior，除非 issue 明確要求
+- 不修改 task package output，除非 issue 明確要求
+- 不修改 config schema，除非 issue 明確要求
+- 不新增 CLI command，除非 issue 明確要求
+- 不新增 LLM / API / local model integration
+- 不自行 merge PR
+
+## Relationship To `spec-injector`
+
+`spec-injector` 只負責 deterministic context compiler 的部分。Branch、commit、PR、evidence comment、PR body backfill 與 merge decision 是 surrounding workflow，不是 CLI core 自動執行的 runtime behavior。
+
+## Non-goals
+
+本 workflow doc 不實作：
+
+- new CLI command
+- GitHub bot
+- PR automation daemon
+- hidden model integration
+- target repo auto-editing
+- CI workflow


### PR DESCRIPTION
## Source of truth

- Closes #90
- refs #90
- Related docs/specs:
  - docs/architecture.md
  - docs/concepts.md
  - docs/classifier.md
  - docs/references.md
  - docs/guardrails.md
  - docs/task-package.md
  - docs/workflow.md
  - docs/dogfood.md

## Summary

新增 spec-injector architecture 與 core concepts 文件，說明 deterministic issue-to-context compiler pipeline，並定義 domains、classifier、guardrails、references、task package、workflow、dogfood、implementation evidence 等核心概念。

## 不包含範圍

- 不處理 #89 README product narrative refresh。
- 不處理 #91 classifier evidence visibility。
- 不修改 runtime code、classifier behavior、task package output、config schema 或 CLI behavior。
- 不新增 LLM / API / local model integration、custom domains runtime 或 CI workflow。

## 風險

Docs-only change。沒有 breaking change，沒有 config/schema/CLI 行為變更。

## Docs / validation

```bash
rtk git diff --cached --check
rtk node markdown-structure-check-for-docs
rtk pnpm test
```

Result: local validation passed; pnpm test ran pnpm build and 37 integration tests, 37 pass / 0 fail.

## Implementation Evidence

Issue comment URL: https://github.com/Erick52106/spec-injector/issues/90#issuecomment-4364305172

Commit hash: 877e70060865015fc16a7a8f776cda184479ea2d

## Scope guard / non-goals confirmation

- Confirmed: no #89 work.
- Confirmed: no #91 work.
- Confirmed: no runtime code change.
- Confirmed: no classifier behavior change.
- Confirmed: no task package output change.
- Confirmed: no config schema change.
- Confirmed: no new CLI command.
- Confirmed: no package manager / Node / TS migration.
- Confirmed: no LLM / API / local model integration.
- Confirmed: no custom domains runtime.

## Checklist

- [x] PR 只處理一個明確 scope
- [x] 已對應 issue（`refs #<issue-number>` 已加入 commit message）
- [x] 已遵守 `presets/core/ai-collaboration.md`
- [x] 已執行必要 build/test
- [x] 沒有混入 unrelated refactor
- [x] 若有 breaking change，已明確標示
- [x] 若有 config/schema/CLI 行為變更，已更新文件
- [x] 已在來源 issue 留下實作證據 comment，並將 URL 填入上方「實作證據」欄位
