### PR TITLE
feat(classifier): expose domain evidence and rejected reasons

### DIFF
--- a/src/classifier/domain.ts
+++ b/src/classifier/domain.ts
@@ -1,5 +1,26 @@
 import type { Issue } from '../github/types.js';
 
+export type DomainEvidenceSource = 'title' | 'labels' | 'body';
+
+export interface DomainEvidence {
+  domain: string;
+  term: string;
+  source: DomainEvidenceSource;
+}
+
+export interface RejectedDomainReason {
+  domain: string;
+  signal: string;
+  source: DomainEvidenceSource;
+  reason: string;
+}
+
+export interface DomainClassificationResult {
+  domains: string[];
+  evidence: DomainEvidence[];
+  rejected: RejectedDomainReason[];
+}
+
 const DOMAIN_KEYWORDS: Record<string, string[]> = {
   frontend: ['ui', 'component', 'render', 'css', 'style', 'react', 'vue', 'angular', 'svelte', 'button', 'form', 'page', 'layout', 'responsive', 'animation', 'dom', 'html', 'tailwind', 'visual', 'design'],
   backend: ['server', 'service', 'handler', 'controller', 'middleware', 'worker', 'daemon', 'queue', 'job', 'cron', 'scheduler', 'grpc', 'rpc'],
@@ -19,13 +40,25 @@ const DOMAIN_KEYWORDS: Record<string, string[]> = {
 };
 
 const MAX_DOMAINS = 5;
+const GENERIC_WALLET_SIGNALS = ['transactions', 'transaction'];
+const GENERIC_WALLET_REASON = 'generic product transaction wording';
 
 export function classifyDomains(issue: Issue): string[] {
+  return classifyDomainsWithEvidence(issue).domains;
+}
+
+export function classifyDomainsWithEvidence(issue: Issue): DomainClassificationResult {
   const title = issue.title.toLowerCase();
   const body = issue.body.toLowerCase();
   const labels = issue.labels.join(' ').toLowerCase();
+  const fields: Array<{ source: DomainEvidenceSource; value: string }> = [
+    { source: 'title', value: title },
+    { source: 'labels', value: labels },
+    { source: 'body', value: body },
+  ];
 
   const scores: Record<string, number> = {};
+  const evidenceByDomain = new Map<string, DomainEvidence[]>();
 
   for (const [domain, keywords] of Object.entries(DOMAIN_KEYWORDS)) {
     let score = 0;
@@ -34,11 +67,58 @@ export function classifyDomains(issue: Issue): string[] {
       if (labels.includes(kw)) score += 2;
       if (body.includes(kw)) score += 1;
     }
-    if (score > 0) scores[domain] = score;
+    if (score > 0) {
+      scores[domain] = score;
+      evidenceByDomain.set(domain, collectEvidence(domain, keywords, fields));
+    }
   }
 
-  return Object.entries(scores)
+  const domains = Object.entries(scores)
     .sort((a, b) => b[1] - a[1])
     .slice(0, MAX_DOMAINS)
     .map(([domain]) => domain);
+
+  const detected = new Set(domains);
+  const evidence = domains.flatMap((domain) => evidenceByDomain.get(domain) ?? []);
+  const rejected = buildRejectedDomainReasons(fields, detected);
+
+  return { domains, evidence, rejected };
+}
+
+function collectEvidence(
+  domain: string,
+  keywords: string[],
+  fields: Array<{ source: DomainEvidenceSource; value: string }>
+): DomainEvidence[] {
+  const evidence: DomainEvidence[] = [];
+
+  for (const { source, value } of fields) {
+    for (const term of keywords) {
+      if (value.includes(term)) evidence.push({ domain, term, source });
+    }
+  }
+
+  return evidence;
+}
+
+function buildRejectedDomainReasons(
+  fields: Array<{ source: DomainEvidenceSource; value: string }>,
+  detected: Set<string>
+): RejectedDomainReason[] {
+  if (detected.has('wallet')) return [];
+
+  for (const { source, value } of fields) {
+    for (const signal of GENERIC_WALLET_SIGNALS) {
+      if (value.includes(signal)) {
+        return [{
+          domain: 'wallet',
+          signal,
+          source,
+          reason: GENERIC_WALLET_REASON,
+        }];
+      }
+    }
+  }
+
+  return [];
 }

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -13,11 +13,12 @@ import { renderTemplate } from '../template/renderer.js';
 import { DEFAULT_TEMPLATE } from '../template/default-template.js';
 import { PROMPT_TEMPLATE } from '../template/prompt-template.js';
 import { writePackage } from '../output/writer.js';
-import { classifyDomains } from '../classifier/domain.js';
+import { classifyDomainsWithEvidence } from '../classifier/domain.js';
 import type { TemplateVars } from '../template/types.js';
 import type { Guardrail } from '../config/types.js';
 import type { Issue } from '../github/types.js';
 import type { DocSection } from '../docs/types.js';
+import type { DomainClassificationResult } from '../classifier/domain.js';
 
 export async function plan(
   issueRef: string,
@@ -35,8 +36,10 @@ export async function plan(
   if (opts.verbose) console.log('→ Fetching issue...');
   const issue = await fetchIssue(issueRef, repoPath);
   console.log(`✓ Issue #${issue.number} fetched: ${issue.title}${issue.state === 'closed' ? ' [CLOSED]' : ''}`);
-  const domains = classifyDomains(issue);
+  const classification = classifyDomainsWithEvidence(issue);
+  const domains = classification.domains;
   console.log(`✓ Detected domains: ${domains.join(', ') || '(none)'}`);
+  if (opts.verbose) renderClassificationDiagnostics(classification);
 
   // 2. Load config
   if (opts.verbose) console.log('→ Loading config...');
@@ -143,6 +146,27 @@ function renderImplementationConstraints(matchedGuardrails: Guardrail[]): string
   const constraints = matchedGuardrails.map((g) => `- ${g.id}: ${g.risk}`);
   constraints.push('- Stay within the source issue scope and referenced files.');
   return constraints.join('\n');
+}
+
+function renderClassificationDiagnostics(classification: DomainClassificationResult): void {
+  console.log('→ Detected domain evidence:');
+  if (classification.evidence.length === 0) {
+    console.log('  - (none)');
+  } else {
+    for (const evidence of classification.evidence) {
+      console.log(`  - ${evidence.domain}: ${evidence.source} matched "${evidence.term}"`);
+    }
+  }
+
+  console.log('→ Rejected domain signals:');
+  if (classification.rejected.length === 0) {
+    console.log('  - (none)');
+    return;
+  }
+
+  for (const rejected of classification.rejected) {
+    console.log(`  - ${rejected.domain}: ${rejected.source} signal "${rejected.signal}" suppressed as ${rejected.reason}`);
+  }
 }
 
 function buildTemplateVars(

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
 import { spawn } from 'node:child_process';
-import { classifyDomains } from '../dist/classifier/domain.js';
+import { classifyDomains, classifyDomainsWithEvidence } from '../dist/classifier/domain.js';
 
 const repoRoot = process.cwd();
 const cliPath = path.join(repoRoot, 'bin', 'spec.js');
@@ -61,6 +61,107 @@ test('classifier does not overfit product transaction records to wallet', () => 
   assert.ok(domains.includes('api'), `Expected api in ${domains.join(', ')}`);
   assert.ok(domains.includes('backend'), `Expected backend in ${domains.join(', ')}`);
   assert.ok(!domains.includes('wallet'), `Expected wallet to be absent from ${domains.join(', ')}`);
+});
+
+test('classifier reports deterministic evidence for detected domains', () => {
+  const result = classifyDomainsWithEvidence({
+    number: 91,
+    title: 'Dashboard endpoint route refine',
+    body: [
+      'Update the backend handler for route consistency.',
+      'Keep the frontend dashboard page in sync.',
+    ].join('\n'),
+    labels: ['api'],
+    url: 'https://github.com/Erick52106/spec-injector/issues/91',
+    state: 'open',
+  });
+
+  assert.ok(result.domains.includes('api'), `Expected api in ${result.domains.join(', ')}`);
+  assert.ok(result.domains.includes('frontend'), `Expected frontend in ${result.domains.join(', ')}`);
+  assert.ok(result.domains.includes('backend'), `Expected backend in ${result.domains.join(', ')}`);
+  assert.deepEqual(result.evidence.filter((e) => e.domain === 'api')[0], {
+    domain: 'api',
+    term: 'endpoint',
+    source: 'title',
+  });
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'frontend' && e.term === 'page' && e.source === 'body'
+  ));
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'backend' && e.term === 'handler' && e.source === 'body'
+  ));
+});
+
+test('classifier reports wallet evidence for explicit on-chain signals', () => {
+  const result = classifyDomainsWithEvidence({
+    number: 91,
+    title: 'Connect wallet token transfer transaction hash tracking',
+    body: [
+      'Record the connected wallet address after users connect wallet.',
+      'Show token transfer status, tx hash, transaction hash, and on-chain confirmation.',
+    ].join('\n'),
+    labels: ['wallet'],
+    url: 'https://github.com/Erick52106/spec-injector/issues/91',
+    state: 'open',
+  });
+
+  assert.ok(result.domains.includes('wallet'), `Expected wallet in ${result.domains.join(', ')}`);
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'wallet' && e.term === 'wallet address' && e.source === 'body'
+  ));
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'wallet' && e.term === 'tx hash' && e.source === 'body'
+  ));
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'wallet' && e.term === 'transaction hash' && e.source === 'title'
+  ));
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'wallet' && e.term === 'token transfer' && e.source === 'title'
+  ));
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'wallet' && e.term === 'on-chain' && e.source === 'body'
+  ));
+  assert.ok(!result.rejected.some((r) => r.domain === 'wallet'));
+});
+
+test('classifier reports wallet rejected reason for generic product transaction wording only', () => {
+  const result = classifyDomainsWithEvidence({
+    number: 91,
+    title: 'Admin dashboard billing transactions endpoint',
+    body: [
+      'Expose product transaction records API for support workflows.',
+      'The backend handler should read app records from database rows.',
+    ].join('\n'),
+    labels: ['api', 'backend'],
+    url: 'https://github.com/Erick52106/spec-injector/issues/91',
+    state: 'open',
+  });
+
+  assert.ok(result.domains.includes('api'), `Expected api in ${result.domains.join(', ')}`);
+  assert.ok(result.domains.includes('backend'), `Expected backend in ${result.domains.join(', ')}`);
+  assert.ok(!result.domains.includes('wallet'), `Expected wallet to be absent from ${result.domains.join(', ')}`);
+  assert.deepEqual(result.rejected, [{
+    domain: 'wallet',
+    signal: 'transactions',
+    source: 'title',
+    reason: 'generic product transaction wording',
+  }]);
+});
+
+test('classifier evidence result is deterministic across repeated calls', () => {
+  const issue = {
+    number: 91,
+    title: 'Dashboard endpoint route transaction review',
+    body: [
+      'Update backend handler behavior for product transaction records.',
+      'Keep frontend dashboard response rendering stable.',
+    ].join('\n'),
+    labels: ['api', 'backend'],
+    url: 'https://github.com/Erick52106/spec-injector/issues/91',
+    state: 'open' as const,
+  };
+
+  assert.deepEqual(classifyDomainsWithEvidence(issue), classifyDomainsWithEvidence(issue));
 });
 
 test('spec --help lists deterministic CLI purpose and available commands', async () => {
@@ -576,6 +677,44 @@ test('spec plan dry-run prompt output stays compact and omits long inline docs',
   assert.doesNotMatch(result.stdout, /DISCOVERED_DOC_LONG_BODY_SENTINEL/);
   assert.doesNotMatch(result.stdout, /SOURCE_SNIPPET_BODY_SENTINEL/);
   await assertFileMissing(fixture.taskPackagePath);
+});
+
+test('spec plan verbose output shows classifier diagnostics without changing rendered prompt', async (t) => {
+  const fixture = await createExplicitPathPlanFixture(t, {
+    issueNumber: 91,
+    title: 'Admin dashboard billing transactions endpoint',
+    bodyLines: [
+      'Expose product transaction records API for support workflows.',
+      'The backend handler should read app records from database rows.',
+    ],
+    labels: [{ name: 'api' }, { name: 'backend' }],
+  });
+
+  const result = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt', '--verbose'],
+    { env: fixture.env }
+  );
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /→ Detected domain evidence:/);
+  assert.match(result.stdout, /- api: title matched "endpoint"/);
+  assert.match(result.stdout, /→ Rejected domain signals:/);
+  assert.match(result.stdout, /- wallet: title signal "transactions" suppressed as generic product transaction wording/);
+
+  const renderedPrompt = result.stdout.slice(result.stdout.indexOf('# Implementation Plan Prompt:'));
+  assert.match(renderedPrompt, /## 2\. Detected Domains/);
+  assert.doesNotMatch(renderedPrompt, /Domain Evidence/);
+  assert.doesNotMatch(renderedPrompt, /Detected domain evidence/);
+  assert.doesNotMatch(renderedPrompt, /Rejected domain signals/);
+
+  const nonVerbose = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'],
+    { env: fixture.env }
+  );
+
+  assert.equal(nonVerbose.code, 0, nonVerbose.stderr);
+  assert.doesNotMatch(nonVerbose.stdout, /Detected domain evidence/);
+  assert.doesNotMatch(nonVerbose.stdout, /Rejected domain signals/);
 });
 
 test('spec plan non-dry-run writes task package file with mocked gh data', async (t) => {


### PR DESCRIPTION
Closes #91

## Summary
- Add `classifyDomainsWithEvidence(issue)` with deterministic detected-domain evidence and rejected-domain reasons.
- Keep `classifyDomains(issue): string[]` compatible by returning only the detected domains from the new classifier result.
- Surface evidence and rejected signals only through existing `spec plan --verbose` diagnostics, without changing default task package or prompt rendering.

## Tests / validation
- `pnpm build`
- `pnpm test`

## Implementation Evidence
- Issue evidence comment: https://github.com/Erick52106/spec-injector/issues/91#issuecomment-4364350199
- Commit: e902d975fc43086950d56af8b72c3641530e94bd

## Scope guard / non-goals confirmation
- No default task package output change.
- No prompt output change.
- No new CLI command or flag.
- No config schema change.
- No custom domains runtime.
- No LLM / API / local model integration.
- No CI change.
- No target repo code change.
