### PR TITLE
fix(references): distinguish built-in presets from repo always_read references

### DIFF
--- a/docs/references.md
+++ b/docs/references.md
@@ -29,6 +29,8 @@ Built-in preset references 來自 `spec-injector` package 本身。
 
 Built-in preset 不代表 target repo 可以被自動修改。它只是 task package 的固定 context。
 
+在 `spec plan` output 中，built-in preset references 會標示為 `built-in preset`，避免被誤讀成 target repo config 的 `always_read`。
+
 ## Repo Always-read References
 
 Repo `always_read` references 由 target repo 的 `.spec-injector/config.json` 明確設定。
@@ -44,6 +46,8 @@ Repo `always_read` references 由 target repo 的 `.spec-injector/config.json` �
 `spec config suggest always-read --repo .` 可以 deterministic 掃描候選文件，但只會建議，不會自動修改 config。
 
 Missing `always_read` files 會在 task package 的 Missing Files 中呈現。這是 config health signal，不一定是 fatal plan error。
+
+在 `spec plan` output 中，repo `always_read` references 會標示為 `repo always_read`，與 built-in preset references 分開。
 
 ## Issue-mentioned References
 

--- a/docs/task-package.md
+++ b/docs/task-package.md
@@ -39,6 +39,8 @@ Prompt output 目前包含：
 - Instructions
 - Suggested verification checklist
 
+Always-Read Files 會標示 reference source，讓 built-in preset references 與 repo `always_read` references 不會被混淆。Prompt output 以 compact path list 顯示 source label；full task package 會在每個 inline reference content 前加入 source metadata。
+
 ## Deterministic Output
 
 Task package 應是 deterministic output。給定相同 issue、target repo files 與 `.spec-injector/config.json`，pipeline 應產生穩定的 context selection 與 Markdown structure。

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -96,7 +96,10 @@ export async function plan(
   const combinedSourceReferences = [...explicitSources, ...filteredDiscoveredSources];
 
   // 7. Summarise
-  console.log(`✓ Docs — always: ${filteredAlwaysDocs.filter(d => d.found).length}, discovered: ${filteredDiscoveredDocs.length}, explicit: ${explicitDocs.length + filteredDiscoveryDocs.filter(d => d.found).length}, missing: ${missingDocs.length}, sources: ${combinedSourceReferences.length}`);
+  const foundAlwaysDocs = filteredAlwaysDocs.filter((d) => d.found);
+  const repoAlwaysReadCount = foundAlwaysDocs.filter((d) => d.kind === 'always').length;
+  const builtInPresetCount = foundAlwaysDocs.filter((d) => d.kind === 'built-in-preset').length;
+  console.log(`✓ Docs — repo always_read: ${repoAlwaysReadCount}, built-in presets: ${builtInPresetCount}, discovered: ${filteredDiscoveredDocs.length}, explicit: ${explicitDocs.length + filteredDiscoveryDocs.filter(d => d.found).length}, missing: ${missingDocs.length}, sources: ${combinedSourceReferences.length}`);
   if (missingDocs.length > 0) {
     for (const d of missingDocs) console.warn(`  ⚠  Not found: ${d.filePath}`);
   }
@@ -131,15 +134,15 @@ function renderDocList(docs: DocSection[]): string {
   if (docs.length === 0) return '(none)';
   return docs
     .map((d) => {
-      const reasonLine = renderReasonLine(d);
-      return `### ${d.filePath}\n\n${reasonLine}${d.content.trim()}`;
+      const metadataLine = renderMetadataLine(d);
+      return `### ${d.filePath}\n\n${metadataLine}${d.content.trim()}`;
     })
     .join('\n\n---\n\n');
 }
 
 function renderPathList(docs: DocSection[]): string {
   if (docs.length === 0) return '(none)';
-  return docs.map((d) => `- \`${d.filePath}\`${renderReasonSuffix(d)}`).join('\n');
+  return docs.map((d) => `- \`${d.filePath}\`${renderMetadataSuffix(d)}`).join('\n');
 }
 
 function renderImplementationConstraints(matchedGuardrails: Guardrail[]): string {
@@ -186,7 +189,7 @@ function buildTemplateVars(
     .join('\n') || '(none found)';
 
   const missingList = missingDocs.length > 0
-    ? missingDocs.map((d) => `- \`${d.filePath}\` — not found${renderReasonSuffix(d, true)}`).join('\n')
+    ? missingDocs.map((d) => `- \`${d.filePath}\` — not found${renderMetadataSuffix(d, true)}`).join('\n')
     : '(none)';
 
   return {
@@ -259,6 +262,8 @@ function reasonForKind(kind: DocSection['kind']): string | null {
   switch (kind) {
     case 'always':
       return 'always_read';
+    case 'built-in-preset':
+      return 'built-in preset';
     case 'rule':
       return 'rule-matched';
     case 'discovered':
@@ -270,13 +275,39 @@ function reasonForKind(kind: DocSection['kind']): string | null {
   }
 }
 
-function renderReasonLine(doc: DocSection): string {
-  if (!doc.reasons || doc.reasons.length === 0) return '';
-  return `_${doc.reasons.join('; ')}_\n\n`;
+function renderMetadataLine(doc: DocSection): string {
+  const metadata = renderDocMetadata(doc, { includeSourcePrefix: true });
+  if (metadata.length === 0) return '';
+  return `_${metadata.join('; ')}_\n\n`;
 }
 
-function renderReasonSuffix(doc: DocSection, parenthetical: boolean = false): string {
-  if (!doc.reasons || doc.reasons.length === 0) return '';
-  const rendered = doc.reasons.join('; ');
+function renderMetadataSuffix(doc: DocSection, parenthetical: boolean = false): string {
+  const metadata = renderDocMetadata(doc);
+  if (metadata.length === 0) return '';
+  const rendered = metadata.join('; ');
   return parenthetical ? ` (${rendered})` : ` — ${rendered}`;
+}
+
+function renderDocMetadata(
+  doc: DocSection,
+  opts: { includeSourcePrefix?: boolean } = {}
+): string[] {
+  const metadata: string[] = [];
+  const sourceLabel = referenceSourceLabel(doc);
+  if (sourceLabel) {
+    metadata.push(opts.includeSourcePrefix ? `source: ${sourceLabel}` : sourceLabel);
+  }
+  metadata.push(...(doc.reasons ?? []));
+  return metadata;
+}
+
+function referenceSourceLabel(doc: DocSection): string | null {
+  switch (doc.kind) {
+    case 'always':
+      return 'repo always_read';
+    case 'built-in-preset':
+      return 'built-in preset';
+    default:
+      return null;
+  }
 }

--- a/src/docs/finder.ts
+++ b/src/docs/finder.ts
@@ -45,7 +45,7 @@ export async function loadCorePreset(): Promise<DocSection> {
     filePath: 'presets/core/ai-collaboration.md',
     content,
     found: true,
-    kind: 'always',
+    kind: 'built-in-preset',
   };
 }
 

--- a/src/docs/types.ts
+++ b/src/docs/types.ts
@@ -1,5 +1,6 @@
 export type DocSourceKind =
   | 'always'
+  | 'built-in-preset'
   | 'discovered'
   | 'rule'
   | 'missing'

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -679,6 +679,38 @@ test('spec plan dry-run prompt output stays compact and omits long inline docs',
   await assertFileMissing(fixture.taskPackagePath);
 });
 
+test('spec plan distinguishes built-in preset references from repo always_read references', async (t) => {
+  const fixture = await createSpecPlanFixture(t);
+
+  const promptResult = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'],
+    { env: fixture.env }
+  );
+  const fullResult = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run'],
+    { env: fixture.env }
+  );
+
+  assert.equal(promptResult.code, 0, promptResult.stderr);
+  assert.equal(fullResult.code, 0, fullResult.stderr);
+
+  const promptAlwaysReadSection = sectionBetween(promptResult.stdout, '### Always-Read Files', '### Discovered Docs');
+  assertOrderedSubstrings(promptAlwaysReadSection, [
+    '- `docs/always-read.md` — repo always_read',
+    '- `presets/core/ai-collaboration.md` — built-in preset',
+  ]);
+  assert.doesNotMatch(promptAlwaysReadSection, /docs\/always-read\.md` — built-in preset/);
+  assert.doesNotMatch(promptAlwaysReadSection, /presets\/core\/ai-collaboration\.md` — repo always_read/);
+
+  const fullAlwaysReadSection = sectionBetween(fullResult.stdout, '## 3. Always-Read Files', '## 4. Auto-Discovered Documentation');
+  assertOrderedSubstrings(fullAlwaysReadSection, [
+    '### docs/always-read.md\n\n_source: repo always_read_',
+    '### presets/core/ai-collaboration.md\n\n_source: built-in preset_',
+  ]);
+  assert.doesNotMatch(fullAlwaysReadSection, /### docs\/always-read\.md\n\n_source: built-in preset_/);
+  assert.doesNotMatch(fullAlwaysReadSection, /### presets\/core\/ai-collaboration\.md\n\n_source: repo always_read_/);
+});
+
 test('spec plan verbose output shows classifier diagnostics without changing rendered prompt', async (t) => {
   const fixture = await createExplicitPathPlanFixture(t, {
     issueNumber: 91,


### PR DESCRIPTION
Closes #82

## Summary
- Add an explicit built-in preset reference kind for the packaged core preset.
- Render repo always_read references and built-in preset references with distinct source labels in prompt and full task package output.
- Keep reference ordering deterministic and document the visible source taxonomy.

## Tests / validation
- pnpm build
- pnpm test

## Implementation Evidence
- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/82#issuecomment-4364390371
- Commit hash: c974175e42a8afe75160d1769d303e2c759dfd4b

## Scope guard / non-goals confirmation
- Did not handle #84 / #78 / #81.
- No config schema change.
- No new CLI command or flag.
- No classifier behavior change.
- No custom domains runtime.
- No LLM / API / local model integration.
- No CI change.
- No target repo code change.
