### PR TITLE
fix(plan): separate issue-mentioned references from auto-discovered references

### DIFF
--- a/docs/references.md
+++ b/docs/references.md
@@ -15,7 +15,7 @@ Reference collection 是 deterministic context selection，不是 general-purpos
 3. issue-mentioned references
 4. auto-discovered references
 
-部分 taxonomy 已在目前 CLI 中實作；與 future classifier evidence visibility、custom domains、agent output 相關的延伸能力仍是 planned / future-facing。
+這四類會在目前 `spec plan` output 中以 source label 或獨立 section 呈現；與 future classifier evidence visibility、custom domains、agent output 相關的延伸能力仍是 planned / future-facing。
 
 ## Built-in Preset References
 
@@ -58,7 +58,7 @@ Issue-mentioned references 是 issue body 中明確提到的 repo-relative file 
 - inline code path：``docs/architecture.md``
 - bullet path：`- src/cli/plan.ts`
 
-Issue-mentioned references 會被標示 reason，例如 `mentioned in issue`。若檔案不存在，會進入 Missing Files。
+Issue-mentioned references 會在 prompt output 與 full task package 中獨立呈現，並標示 source `issue-mentioned` 與 reason `mentioned in issue`。若檔案不存在，會進入 Missing Files。
 
 這類 references 通常是 strongest issue-local signal，但仍應遵守 scope guard：被提到不代表一定要修改。
 
@@ -75,6 +75,8 @@ Auto-discovered references 由 deterministic scan / scoring 產生。
 
 Auto-discovered references 是 context candidates。它們可能有 false positives / false negatives，因此不應被視為完整 dependency graph。
 
+在 `spec plan` output 中，auto-discovered docs/source references 會標示為 `auto-discovered`，並與 issue-mentioned references 分開，避免 inferred context 被誤讀成 issue author 明確指定的檔案。
+
 ## Configured Discovery Docs
 
 `.spec-injector/config.json` 的 `discovery.docs` 可列出固定納入的 documentation paths。
@@ -86,8 +88,8 @@ Auto-discovered references 是 context candidates。它們可能有 false positi
 實務上，AI implementer 應以以下優先順序理解 references：
 
 1. Issue body 與 human instructions
-2. Built-in preset 與 repo `always_read`
-3. Issue-mentioned references
+2. Issue-mentioned references
+3. Built-in preset 與 repo `always_read`
 4. Configured discovery docs
 5. Auto-discovered docs / source candidates
 

--- a/docs/task-package.md
+++ b/docs/task-package.md
@@ -22,6 +22,8 @@ Full task package 目前包含：
 - Issue metadata and body
 - Classification / detected domains
 - Always-Read Files
+- Issue-Mentioned Documentation
+- Issue-Mentioned Source Files
 - Auto-Discovered Documentation
 - Auto-Discovered Source Files
 - Matched Guardrails
@@ -35,11 +37,19 @@ Prompt output 目前包含：
 - Detected Domains
 - Guardrails
 - Relevant File References
+  - Always-Read Files
+  - Issue-Mentioned Docs
+  - Issue-Mentioned Source Files
+  - Auto-Discovered Docs
+  - Rule-Matched Docs
+  - Auto-Discovered Source Files
 - Missing Files
 - Instructions
 - Suggested verification checklist
 
 Always-Read Files 會標示 reference source，讓 built-in preset references 與 repo `always_read` references 不會被混淆。Prompt output 以 compact path list 顯示 source label；full task package 會在每個 inline reference content 前加入 source metadata。
+
+Issue-mentioned references 會和 auto-discovered references 分開呈現。Issue-mentioned docs/source files 標示為 `issue-mentioned`，auto-discovered docs/source files 標示為 `auto-discovered`，讓 explicit issue signal 與 inferred discovery signal 不會混在同一個 section。
 
 ## Deterministic Output
 

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -92,7 +92,6 @@ export async function plan(
     [...filteredAlwaysDocs, ...filteredDiscoveryDocs].filter((d) => !d.found),
     explicitReferences.missing
   );
-  const combinedDocReferences = [...explicitDocs, ...filteredDiscoveredDocs];
   const combinedSourceReferences = [...explicitSources, ...filteredDiscoveredSources];
 
   // 7. Summarise
@@ -110,11 +109,13 @@ export async function plan(
     domains,
     matchedGuardrails,
     filteredAlwaysDocs,
-    combinedDocReferences,
+    explicitDocs,
+    filteredDiscoveredDocs,
     filteredDiscoveryDocs,
     missingDocs,
     repoPath,
-    combinedSourceReferences
+    explicitSources,
+    filteredDiscoveredSources
   );
   const template = format === 'prompt' ? PROMPT_TEMPLATE : DEFAULT_TEMPLATE;
   const rendered = renderTemplate(template, vars);
@@ -177,10 +178,12 @@ function buildTemplateVars(
   domains: string[],
   matchedGuardrails: Guardrail[],
   alwaysDocs: DocSection[],
+  issueDocs: DocSection[],
   discoveredDocs: DocSection[],
   discoveryDocs: DocSection[],
   missingDocs: DocSection[],
   repoPath: string,
+  issueSources: DocSection[],
   discoveredSources: DocSection[]
 ): TemplateVars {
   const checklist = issue.body
@@ -209,11 +212,15 @@ function buildTemplateVars(
       : '(none matched)',
     matched_hints: '(none)',
     prompt_always_files: renderPathList(alwaysDocs.filter((d) => d.found)),
+    prompt_issue_docs: renderPathList(issueDocs),
+    prompt_issue_sources: renderPathList(issueSources),
     prompt_discovered_docs: renderPathList(discoveredDocs),
     prompt_rule_docs: renderPathList(discoveryDocs.filter((d) => d.found)),
     prompt_discovered_sources: renderPathList(discoveredSources),
     prompt_implementation_constraints: renderImplementationConstraints(matchedGuardrails),
     always_docs: renderDocList(alwaysDocs.filter((d) => d.found)),
+    issue_docs: renderDocList(issueDocs),
+    issue_sources: renderDocList(issueSources),
     discovered_docs: renderDocList(discoveredDocs),
     rule_docs: renderDocList(discoveryDocs.filter((d) => d.found)),
     missing_docs: missingList,
@@ -267,9 +274,8 @@ function reasonForKind(kind: DocSection['kind']): string | null {
     case 'rule':
       return 'rule-matched';
     case 'discovered':
-      return 'auto-discovered';
     case 'source':
-      return 'auto-discovered';
+      return null;
     default:
       return null;
   }
@@ -307,6 +313,12 @@ function referenceSourceLabel(doc: DocSection): string | null {
       return 'repo always_read';
     case 'built-in-preset':
       return 'built-in preset';
+    case 'issue-doc':
+    case 'issue-source':
+      return 'issue-mentioned';
+    case 'discovered':
+    case 'source':
+      return 'auto-discovered';
     default:
       return null;
   }

--- a/src/template/default-template.ts
+++ b/src/template/default-template.ts
@@ -26,19 +26,31 @@ export const DEFAULT_TEMPLATE = `# Task Package: {{issue_title}}
 
 ---
 
-## 4. Auto-Discovered Documentation
+## 4. Issue-Mentioned Documentation
+
+{{issue_docs}}
+
+---
+
+## 5. Issue-Mentioned Source Files
+
+{{issue_sources}}
+
+---
+
+## 6. Auto-Discovered Documentation
 
 {{discovered_docs}}
 
 ---
 
-## 5. Auto-Discovered Source Files
+## 7. Auto-Discovered Source Files
 
 {{discovered_sources}}
 
 ---
 
-## 6. Matched Guardrails
+## 8. Matched Guardrails
 
 {{matched_guardrails}}
 
@@ -48,13 +60,13 @@ export const DEFAULT_TEMPLATE = `# Task Package: {{issue_title}}
 
 ---
 
-## 7. Missing Files
+## 9. Missing Files
 
 {{missing_docs}}
 
 ---
 
-## 8. Suggested Verification Checklist
+## 10. Suggested Verification Checklist
 
 > Auto-extracted from issue body (edit as needed)
 

--- a/src/template/prompt-template.ts
+++ b/src/template/prompt-template.ts
@@ -21,7 +21,15 @@ export const PROMPT_TEMPLATE = `# Implementation Plan Prompt: {{issue_title}}
 
 {{prompt_always_files}}
 
-### Discovered Docs
+### Issue-Mentioned Docs
+
+{{prompt_issue_docs}}
+
+### Issue-Mentioned Source Files
+
+{{prompt_issue_sources}}
+
+### Auto-Discovered Docs
 
 {{prompt_discovered_docs}}
 
@@ -29,7 +37,7 @@ export const PROMPT_TEMPLATE = `# Implementation Plan Prompt: {{issue_title}}
 
 {{prompt_rule_docs}}
 
-### Discovered Source Files
+### Auto-Discovered Source Files
 
 {{prompt_discovered_sources}}
 

--- a/src/template/types.ts
+++ b/src/template/types.ts
@@ -11,11 +11,15 @@ export interface TemplateVars {
   matched_guardrails: string;
   matched_hints: string;
   prompt_always_files: string;
+  prompt_issue_docs: string;
+  prompt_issue_sources: string;
   prompt_discovered_docs: string;
   prompt_rule_docs: string;
   prompt_discovered_sources: string;
   prompt_implementation_constraints: string;
   always_docs: string;
+  issue_docs: string;
+  issue_sources: string;
   discovered_docs: string;
   rule_docs: string;
   missing_docs: string;

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -621,10 +621,12 @@ test('spec plan dry-run full output uses mocked gh data and keeps task package o
     '## 1. Issue',
     '## 2. Classification',
     '## 3. Always-Read Files',
-    '## 4. Auto-Discovered Documentation',
-    '## 5. Auto-Discovered Source Files',
-    '## 6. Matched Guardrails',
-    '## 7. Missing Files',
+    '## 4. Issue-Mentioned Documentation',
+    '## 5. Issue-Mentioned Source Files',
+    '## 6. Auto-Discovered Documentation',
+    '## 7. Auto-Discovered Source Files',
+    '## 8. Matched Guardrails',
+    '## 9. Missing Files',
   ]);
   assert.match(result.stdout, /### docs\/always-read\.md/);
   assert.match(result.stdout, /### presets\/core\/ai-collaboration\.md/);
@@ -658,9 +660,11 @@ test('spec plan dry-run prompt output stays compact and omits long inline docs',
     '## 3. Guardrails',
     '## 4. Relevant File References',
     '### Always-Read Files',
-    '### Discovered Docs',
+    '### Issue-Mentioned Docs',
+    '### Issue-Mentioned Source Files',
+    '### Auto-Discovered Docs',
     '### Rule-Matched Docs',
-    '### Discovered Source Files',
+    '### Auto-Discovered Source Files',
     '## 5. Missing Files',
     '## 6. Instructions',
   ]);
@@ -694,7 +698,7 @@ test('spec plan distinguishes built-in preset references from repo always_read r
   assert.equal(promptResult.code, 0, promptResult.stderr);
   assert.equal(fullResult.code, 0, fullResult.stderr);
 
-  const promptAlwaysReadSection = sectionBetween(promptResult.stdout, '### Always-Read Files', '### Discovered Docs');
+  const promptAlwaysReadSection = sectionBetween(promptResult.stdout, '### Always-Read Files', '### Issue-Mentioned Docs');
   assertOrderedSubstrings(promptAlwaysReadSection, [
     '- `docs/always-read.md` — repo always_read',
     '- `presets/core/ai-collaboration.md` — built-in preset',
@@ -702,13 +706,95 @@ test('spec plan distinguishes built-in preset references from repo always_read r
   assert.doesNotMatch(promptAlwaysReadSection, /docs\/always-read\.md` — built-in preset/);
   assert.doesNotMatch(promptAlwaysReadSection, /presets\/core\/ai-collaboration\.md` — repo always_read/);
 
-  const fullAlwaysReadSection = sectionBetween(fullResult.stdout, '## 3. Always-Read Files', '## 4. Auto-Discovered Documentation');
+  const fullAlwaysReadSection = sectionBetween(fullResult.stdout, '## 3. Always-Read Files', '## 4. Issue-Mentioned Documentation');
   assertOrderedSubstrings(fullAlwaysReadSection, [
     '### docs/always-read.md\n\n_source: repo always_read_',
     '### presets/core/ai-collaboration.md\n\n_source: built-in preset_',
   ]);
   assert.doesNotMatch(fullAlwaysReadSection, /### docs\/always-read\.md\n\n_source: built-in preset_/);
   assert.doesNotMatch(fullAlwaysReadSection, /### presets\/core\/ai-collaboration\.md\n\n_source: repo always_read_/);
+});
+
+test('spec plan separates issue-mentioned references from auto-discovered references deterministically', async (t) => {
+  const fixture = await createExplicitPathPlanFixture(t, {
+    issueNumber: 84,
+    title: 'Separate payment refund issue references from auto discovery',
+    bodyLines: [
+      'Payment refund work needs explicit issue references and supporting auto discovery.',
+      'Relevant files:',
+      '- `docs/issue-contract.md`',
+      '- `src/issue-handler.ts`',
+      '- `docs/duplicate-ref.md`',
+    ],
+    repoFiles: {
+      'docs/issue-contract.md': '# Issue Contract\n\nISSUE_MENTIONED_DOC_SENTINEL payment refund\n',
+      'docs/payment-runbook.md': '# Payment Runbook\n\nAUTO_DISCOVERED_DOC_SENTINEL payment refund operations\n',
+      'docs/duplicate-ref.md': '# Duplicate Ref\n\nDUPLICATE_ISSUE_DOC_SENTINEL payment refund\n',
+      'src/issue-handler.ts': 'export const issueHandler = "ISSUE_MENTIONED_SOURCE_SENTINEL payment refund";\n',
+      'src/payment-worker.ts': 'export const paymentWorker = "AUTO_DISCOVERED_SOURCE_SENTINEL payment refund";\n',
+    },
+  });
+
+  const promptFirst = await runSpec(['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'], { env: fixture.env });
+  const promptSecond = await runSpec(['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'], { env: fixture.env });
+  const fullFirst = await runSpec(['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run'], { env: fixture.env });
+  const fullSecond = await runSpec(['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run'], { env: fixture.env });
+
+  assert.equal(promptFirst.code, 0, promptFirst.stderr);
+  assert.equal(promptSecond.code, 0, promptSecond.stderr);
+  assert.equal(fullFirst.code, 0, fullFirst.stderr);
+  assert.equal(fullSecond.code, 0, fullSecond.stderr);
+  assert.equal(normalizePlanOutput(promptSecond.stdout), normalizePlanOutput(promptFirst.stdout));
+  assert.equal(normalizePlanOutput(fullSecond.stdout), normalizePlanOutput(fullFirst.stdout));
+
+  assertOrderedSubstrings(promptFirst.stdout, [
+    '### Always-Read Files',
+    '### Issue-Mentioned Docs',
+    '### Issue-Mentioned Source Files',
+    '### Auto-Discovered Docs',
+    '### Rule-Matched Docs',
+    '### Auto-Discovered Source Files',
+  ]);
+  const promptIssueDocs = sectionBetween(promptFirst.stdout, '### Issue-Mentioned Docs', '### Issue-Mentioned Source Files');
+  const promptIssueSources = sectionBetween(promptFirst.stdout, '### Issue-Mentioned Source Files', '### Auto-Discovered Docs');
+  const promptAutoDocs = sectionBetween(promptFirst.stdout, '### Auto-Discovered Docs', '### Rule-Matched Docs');
+  const promptAutoSources = sectionBetween(promptFirst.stdout, '### Auto-Discovered Source Files', '## 5. Missing Files');
+
+  assert.match(promptIssueDocs, /`docs\/issue-contract\.md` — issue-mentioned; mentioned in issue/);
+  assert.match(promptIssueDocs, /`docs\/duplicate-ref\.md` — issue-mentioned; mentioned in issue/);
+  assert.doesNotMatch(promptIssueDocs, /auto-discovered/);
+  assert.match(promptIssueSources, /`src\/issue-handler\.ts` — issue-mentioned; mentioned in issue/);
+  assert.doesNotMatch(promptIssueSources, /auto-discovered/);
+  assert.match(promptAutoDocs, /`docs\/payment-runbook\.md` — auto-discovered/);
+  assert.doesNotMatch(promptAutoDocs, /issue-mentioned|mentioned in issue|docs\/issue-contract\.md|docs\/duplicate-ref\.md/);
+  assert.match(promptAutoSources, /`src\/payment-worker\.ts` — auto-discovered/);
+  assert.doesNotMatch(promptAutoSources, /issue-mentioned|mentioned in issue|src\/issue-handler\.ts/);
+
+  assertOrderedSubstrings(fullFirst.stdout, [
+    '## 3. Always-Read Files',
+    '## 4. Issue-Mentioned Documentation',
+    '## 5. Issue-Mentioned Source Files',
+    '## 6. Auto-Discovered Documentation',
+    '## 7. Auto-Discovered Source Files',
+    '## 8. Matched Guardrails',
+    '## 9. Missing Files',
+  ]);
+  const fullIssueDocs = sectionBetween(fullFirst.stdout, '## 4. Issue-Mentioned Documentation', '## 5. Issue-Mentioned Source Files');
+  const fullIssueSources = sectionBetween(fullFirst.stdout, '## 5. Issue-Mentioned Source Files', '## 6. Auto-Discovered Documentation');
+  const fullAutoDocs = sectionBetween(fullFirst.stdout, '## 6. Auto-Discovered Documentation', '## 7. Auto-Discovered Source Files');
+  const fullAutoSources = sectionBetween(fullFirst.stdout, '## 7. Auto-Discovered Source Files', '## 8. Matched Guardrails');
+
+  assert.match(fullIssueDocs, /### docs\/issue-contract\.md\n\n_source: issue-mentioned; mentioned in issue_/);
+  assert.match(fullIssueDocs, /### docs\/duplicate-ref\.md\n\n_source: issue-mentioned; mentioned in issue_/);
+  assert.doesNotMatch(fullIssueDocs, /auto-discovered/);
+  assert.match(fullIssueSources, /### src\/issue-handler\.ts\n\n_source: issue-mentioned; mentioned in issue_/);
+  assert.doesNotMatch(fullIssueSources, /auto-discovered/);
+  assert.match(fullAutoDocs, /### docs\/payment-runbook\.md\n\n_source: auto-discovered_/);
+  assert.doesNotMatch(fullAutoDocs, /issue-mentioned|mentioned in issue|docs\/issue-contract\.md|docs\/duplicate-ref\.md/);
+  assert.match(fullAutoSources, /### src\/payment-worker\.ts\n\n_source: auto-discovered_/);
+  assert.doesNotMatch(fullAutoSources, /issue-mentioned|mentioned in issue|src\/issue-handler\.ts/);
+  assert.equal(countOccurrences(promptFirst.stdout, 'docs/duplicate-ref.md'), 1);
+  assert.equal(countOccurrences(fullFirst.stdout, '### docs/duplicate-ref.md'), 1);
 });
 
 test('spec plan verbose output shows classifier diagnostics without changing rendered prompt', async (t) => {
@@ -768,13 +854,15 @@ test('spec plan non-dry-run writes task package file with mocked gh data', async
     '## 1. Issue',
     '## 2. Classification',
     '## 3. Always-Read Files',
-    '## 4. Auto-Discovered Documentation',
-    '## 5. Auto-Discovered Source Files',
-    '## 6. Matched Guardrails',
-    '## 7. Missing Files',
+    '## 4. Issue-Mentioned Documentation',
+    '## 5. Issue-Mentioned Source Files',
+    '## 6. Auto-Discovered Documentation',
+    '## 7. Auto-Discovered Source Files',
+    '## 8. Matched Guardrails',
+    '## 9. Missing Files',
   ]);
   assert.match(written, /### docs\/database-guardrail\.md/);
-  assert.match(written, /## 5\. Auto-Discovered Source Files/);
+  assert.match(written, /## 7\. Auto-Discovered Source Files/);
   assert.match(written, /### src\/database-auth-service\.ts/);
   assert.match(written, /ALWAYS_READ_LONG_BODY_SENTINEL/);
   assert.match(written, /DISCOVERED_DOC_LONG_BODY_SENTINEL/);
@@ -794,7 +882,7 @@ test('spec plan keeps missing always_read files non-fatal and reports found vs m
   );
 
   assert.equal(result.code, 0, result.stderr);
-  const alwaysReadSection = sectionBetween(result.stdout, '### Always-Read Files', '### Discovered Docs');
+  const alwaysReadSection = sectionBetween(result.stdout, '### Always-Read Files', '### Issue-Mentioned Docs');
   assert.match(alwaysReadSection, /- `docs\/always-read\.md`/);
   assert.doesNotMatch(alwaysReadSection, /docs\/missing-handbook\.md/);
   assert.match(result.stdout, /## 5\. Missing Files/);
@@ -992,12 +1080,12 @@ test('spec plan keeps explicit superpowers docs issue-mentioned without reintrod
 
   assert.equal(promptResult.code, 0, promptResult.stderr);
   assert.equal(fullResult.code, 0, fullResult.stderr);
-  assert.match(promptResult.stdout, /`docs\/superpowers\/plans\/old-plan\.md` — mentioned in issue/);
+  assert.match(promptResult.stdout, /`docs\/superpowers\/plans\/old-plan\.md` — issue-mentioned; mentioned in issue/);
   assert.doesNotMatch(promptResult.stdout, /`docs\/superpowers\/plans\/old-plan\.md` — [^\n]*auto-discovered/);
-  assert.match(promptResult.stdout, /`docs\/architecture\.md` — mentioned in issue/);
-  assert.match(promptResult.stdout, /`apps\/dashboard\/src\/providers\/dataProvider\.ts` — mentioned in issue/);
+  assert.match(promptResult.stdout, /`docs\/architecture\.md` — issue-mentioned; mentioned in issue/);
+  assert.match(promptResult.stdout, /`apps\/dashboard\/src\/providers\/dataProvider\.ts` — issue-mentioned; mentioned in issue/);
   assert.equal(countOccurrences(promptResult.stdout, 'docs/superpowers/plans/old-plan.md'), 1);
-  assert.match(fullResult.stdout, /### docs\/superpowers\/plans\/old-plan\.md\n\n_mentioned in issue_/);
+  assert.match(fullResult.stdout, /### docs\/superpowers\/plans\/old-plan\.md\n\n_source: issue-mentioned; mentioned in issue_/);
   assert.doesNotMatch(fullResult.stdout, /### docs\/superpowers\/plans\/old-plan\.md\n\n_[^\n]*auto-discovered_/);
   assert.match(fullResult.stdout, /SUPERPOWERS_EXPLICIT_SENTINEL/);
   assert.match(fullResult.stdout, /### docs\/architecture\.md/);
@@ -1023,7 +1111,7 @@ test('spec plan reports missing explicit issue-mentioned file paths without fail
   assert.equal(fullResult.code, 0, fullResult.stderr);
   assert.match(promptResult.stdout, /## 5\. Missing Files/);
   assert.match(promptResult.stdout, /apps\/dashboard\/src\/providers\/missingProvider\.ts/);
-  assert.match(fullResult.stdout, /## 7\. Missing Files/);
+  assert.match(fullResult.stdout, /## 9\. Missing Files/);
   assert.match(fullResult.stdout, /apps\/dashboard\/src\/providers\/missingProvider\.ts/);
 });
 
@@ -1066,7 +1154,7 @@ test('spec plan ignores URLs, traversal paths, and absolute paths', async (t) =>
   const result = await runSpec(['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run'], { env: fixture.env });
 
   assert.equal(result.code, 0, result.stderr);
-  const refsSection = sectionBetween(result.stdout, '## 3. Always-Read Files', '## 8. Suggested Verification Checklist');
+  const refsSection = sectionBetween(result.stdout, '## 3. Always-Read Files', '## 10. Suggested Verification Checklist');
   assert.doesNotMatch(refsSection, /https:\/\/github\.com\/nurockplayer\/tachigo\/issues\/467/);
   assert.doesNotMatch(refsSection, /\.\.\/secrets\.env/);
   assert.doesNotMatch(refsSection, /\/absolute\/path\.ts/);


### PR DESCRIPTION
Closes #84

## Summary
- Split issue-mentioned docs/source files into dedicated prompt and full task package sections.
- Label issue-mentioned references as `issue-mentioned` and auto-discovered references as `auto-discovered`.
- Keep repo `always_read` and built-in preset source labels intact.
- Update regression coverage and reference/task-package docs for the new output semantics.

## Tests / validation
- `pnpm build` — pass
- `pnpm test` — pass (44/44)
- `git diff --check` — pass

## Implementation Evidence
- Issue evidence comment: https://github.com/Erick52106/spec-injector/issues/84#issuecomment-4364437236
- Commit: 736bcc2be93359545ebbf11d5766b083d632aaca

## Scope guard / non-goals confirmation
- Did not handle #78, #81, or #100.
- No config schema change.
- No new CLI command or flag.
- No classifier behavior change.
- No custom domains runtime.
- No LLM / API / local model integration.
- No CI workflow change.
- No target repo code change.