### PR TITLE
feat(plan): warn when target repo worktree is dirty

### DIFF
--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -14,6 +14,7 @@ import { DEFAULT_TEMPLATE } from '../template/default-template.js';
 import { PROMPT_TEMPLATE } from '../template/prompt-template.js';
 import { writePackage } from '../output/writer.js';
 import { classifyDomainsWithEvidence } from '../classifier/domain.js';
+import { getWorktreeState } from '../utils/git.js';
 import type { TemplateVars } from '../template/types.js';
 import type { Guardrail } from '../config/types.js';
 import type { Issue } from '../github/types.js';
@@ -31,6 +32,7 @@ export async function plan(
   }
 
   if (opts.verbose) console.log(`→ Target repo: ${repoPath}`);
+  warnIfTargetRepoWorktreeStateNeedsReview(repoPath);
 
   // 1. Fetch issue
   if (opts.verbose) console.log('→ Fetching issue...');
@@ -129,6 +131,18 @@ export async function plan(
   const outDir = path.join(config.specAgentDir, 'out');
   const outPath = await writePackage(rendered, outDir, issue.number);
   console.log(`✓ Task package written: ${path.relative(repoPath, outPath)}`);
+}
+
+function warnIfTargetRepoWorktreeStateNeedsReview(repoPath: string): void {
+  const state = getWorktreeState(repoPath);
+  if (state.kind === 'clean' || state.kind === 'not-git') return;
+
+  if (state.kind === 'dirty') {
+    console.warn('⚠ Target repo dirty: target repo has uncommitted or untracked changes; generated references may reflect the current worktree. Review repo state with a human before implementation. spec-injector will continue without modifying files.');
+    return;
+  }
+
+  console.warn('⚠ Unable to determine target repo worktree state; generated references may reflect the current worktree. Review repo state with a human before implementation. spec-injector will continue without modifying files.');
 }
 
 function renderDocList(docs: DocSection[]): string {

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1,0 +1,29 @@
+import { run } from './shell.js';
+
+export type WorktreeState =
+  | { kind: 'clean' }
+  | { kind: 'dirty' }
+  | { kind: 'not-git' }
+  | { kind: 'unknown'; message: string };
+
+export function getWorktreeState(repoPath: string): WorktreeState {
+  const result = run(
+    ['git', 'status', '--porcelain=v1', '--untracked-files=normal'],
+    { cwd: repoPath }
+  );
+
+  if (result.exitCode === 0) {
+    return result.stdout.trim() === '' ? { kind: 'clean' } : { kind: 'dirty' };
+  }
+
+  const message = `${result.stderr}\n${result.stdout}`.trim();
+  if (isNotGitRepository(message)) {
+    return { kind: 'not-git' };
+  }
+
+  return { kind: 'unknown', message };
+}
+
+function isNotGitRepository(message: string): boolean {
+  return /not a git repository/i.test(message);
+}

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
-import { spawn } from 'node:child_process';
+import { spawn, execFile } from 'node:child_process';
 import { classifyDomains, classifyDomainsWithEvidence } from '../dist/classifier/domain.js';
 
 const repoRoot = process.cwd();
@@ -873,6 +873,113 @@ test('spec plan non-dry-run writes task package file with mocked gh data', async
   assert.doesNotMatch(written, /Implementation Constraints:\s*\(none\)/);
 });
 
+test('spec plan does not warn when target git repo is clean', async (t) => {
+  const fixture = await createSpecPlanFixture(t);
+  await initCleanGitRepo(fixture.repoDir);
+
+  const result = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run'],
+    { env: fixture.env }
+  );
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.doesNotMatch(result.stderr, /target repo dirty/i);
+  assert.doesNotMatch(result.stderr, /uncommitted or untracked changes/i);
+});
+
+test('spec plan warns without failing when target git repo has modified tracked files', async (t) => {
+  const fixture = await createSpecPlanFixture(t);
+  await initCleanGitRepo(fixture.repoDir);
+  await fs.appendFile(path.join(fixture.repoDir, 'README.md'), '\nDirty tracked change.\n', 'utf8');
+
+  const result = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run'],
+    { env: fixture.env }
+  );
+
+  assert.equal(result.code, 0, result.stderr);
+  assertDirtyWarning(result.stderr);
+});
+
+test('spec plan warns without failing when target git repo has untracked files', async (t) => {
+  const fixture = await createSpecPlanFixture(t);
+  await initCleanGitRepo(fixture.repoDir);
+  await fs.writeFile(path.join(fixture.repoDir, 'untracked-notes.md'), 'Untracked fixture notes.\n', 'utf8');
+
+  const result = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run'],
+    { env: fixture.env }
+  );
+
+  assert.equal(result.code, 0, result.stderr);
+  assertDirtyWarning(result.stderr);
+});
+
+test('spec plan checks --repo target state instead of current repo state', async (t) => {
+  const fixture = await createSpecPlanFixture(t);
+  await initCleanGitRepo(fixture.repoDir);
+  await fs.appendFile(path.join(fixture.repoDir, 'README.md'), '\nTarget-only dirty change.\n', 'utf8');
+
+  const result = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run'],
+    { cwd: repoRoot, env: fixture.env }
+  );
+
+  assert.equal(result.code, 0, result.stderr);
+  assertDirtyWarning(result.stderr);
+});
+
+test('spec plan silently skips dirty warning when target is not a git repo', async (t) => {
+  const fixture = await createSpecPlanFixture(t);
+
+  const result = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run'],
+    { env: fixture.env }
+  );
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.doesNotMatch(result.stderr, /target repo dirty/i);
+  assert.doesNotMatch(result.stderr, /unable to determine target repo worktree state/i);
+});
+
+test('spec plan warns without failing when git worktree state check fails unexpectedly', async (t) => {
+  const fixture = await createSpecPlanFixture(t);
+  const env = await createFailingGitEnv(t, fixture.env);
+
+  const result = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run'],
+    { env }
+  );
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stderr, /unable to determine target repo worktree state/i);
+  assertNoCleanupCommands(result.stderr);
+});
+
+test('spec plan dirty warning stays on stderr and out of rendered full and prompt output', async (t) => {
+  const fixture = await createSpecPlanFixture(t);
+  await initCleanGitRepo(fixture.repoDir);
+  await fs.writeFile(path.join(fixture.repoDir, 'untracked-dirty.md'), 'dirty\n', 'utf8');
+
+  const fullResult = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run'],
+    { env: fixture.env }
+  );
+  const promptResult = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'],
+    { env: fixture.env }
+  );
+
+  assert.equal(fullResult.code, 0, fullResult.stderr);
+  assert.equal(promptResult.code, 0, promptResult.stderr);
+  assertDirtyWarning(fullResult.stderr);
+  assertDirtyWarning(promptResult.stderr);
+  assert.doesNotMatch(fullResult.stdout, /target repo dirty/i);
+  assert.doesNotMatch(promptResult.stdout, /target repo dirty/i);
+  assert.doesNotMatch(fullResult.stdout, /current worktree/i);
+  assert.doesNotMatch(promptResult.stdout, /current worktree/i);
+});
+
 test('spec plan keeps missing always_read files non-fatal and reports found vs missing references', async (t) => {
   const fixture = await createSpecPlanFixture(t);
 
@@ -1380,6 +1487,47 @@ process.stdout.write(fs.readFileSync(process.env.FAKE_GH_RESPONSE_FILE, 'utf8'))
   };
 }
 
+async function createFailingGitEnv(t, baseEnv) {
+  const binDir = await fs.mkdtemp(path.join(os.tmpdir(), 'spec-injector-git-'));
+  t.after(async () => {
+    await fs.rm(binDir, { recursive: true, force: true });
+  });
+
+  const gitPath = path.join(binDir, 'git');
+  await fs.writeFile(gitPath, [
+    '#!/bin/sh',
+    'echo "simulated git failure" >&2',
+    'exit 2',
+    '',
+  ].join('\n'), 'utf8');
+  await fs.chmod(gitPath, 0o755);
+
+  return {
+    ...baseEnv,
+    PATH: `${binDir}${path.delimiter}${baseEnv.PATH ?? process.env.PATH ?? ''}`,
+  };
+}
+
+async function initCleanGitRepo(repoDir) {
+  await runCommand('git', ['init'], repoDir);
+  await runCommand('git', ['config', 'user.email', 'spec-injector@example.test'], repoDir);
+  await runCommand('git', ['config', 'user.name', 'Spec Injector Test'], repoDir);
+  await runCommand('git', ['add', '.'], repoDir);
+  await runCommand('git', ['commit', '-m', 'Initial fixture commit'], repoDir);
+}
+
+function runCommand(command, args, cwd) {
+  return new Promise((resolve, reject) => {
+    execFile(command, args, { cwd }, (error, stdout, stderr) => {
+      if (error) {
+        reject(new Error(`${command} ${args.join(' ')} failed\nstdout:\n${stdout}\nstderr:\n${stderr}`));
+        return;
+      }
+      resolve({ stdout, stderr });
+    });
+  });
+}
+
 function runSpec(args, options = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, [cliPath, ...args], {
@@ -1454,6 +1602,20 @@ async function assertFileMissing(filePath) {
 function assertNoRawStackTrace(result) {
   const combined = `${result.stdout}\n${result.stderr}`;
   assert.doesNotMatch(combined, /\n\s*at .+\(.+:\d+:\d+\)|\n\s*at .+:\d+:\d+/);
+}
+
+function assertDirtyWarning(stderr) {
+  assert.match(stderr, /target repo dirty/i);
+  assert.match(stderr, /references may reflect the current worktree/i);
+  assert.match(stderr, /human/i);
+  assert.match(stderr, /continue without modifying files/i);
+  assertNoCleanupCommands(stderr);
+}
+
+function assertNoCleanupCommands(value) {
+  assert.doesNotMatch(value, /\bstash\b/i);
+  assert.doesNotMatch(value, /\bclean\b/i);
+  assert.doesNotMatch(value, /\breset\b/i);
 }
 
 function escapeRegExp(value) {


### PR DESCRIPTION
Closes #81

## Summary
- Added a target repo worktree state check to `spec plan` using `git status --porcelain=v1 --untracked-files=normal`.
- Emits a non-fatal stderr warning when the resolved target repo is dirty or when git state cannot be determined unexpectedly.
- Leaves plan generation, default task package Markdown, and prompt output unchanged.

## Tests / validation
- `pnpm build`
- `pnpm test`
- `git diff --check`

## Implementation Evidence
- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/81#issuecomment-4364464401
- Commit hash: `9da1a427abe1e696e915d195f2f6f1fbd05a21a1`

## Scope guard / non-goals confirmation
- Dirty worktree warning is non-fatal.
- Only the resolved target repo is checked.
- No automatic stash / clean / reset behavior was added.
- Default task package Markdown output was not changed.
- Prompt output was not changed.
- No CLI flag was added.
- No config schema change was made.
- No CI change was made.
- No LLM / API / local model integration was added.
- No target repo code is modified by this behavior.
