### PR TITLE
docs(workflow): add agent worktree rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,77 +1,103 @@
-# AGENTS.md — Codex 預設行為規範
+# AGENTS.md - AI agent repository rules
 
-> 適用於 spec-injector 倉庫的 Codex 工作流程。
-> 完整 AI 協作規範請參閱 `presets/core/ai-collaboration.md`。
+> 適用於所有進入 `spec-injector` repo 的 Codex、Claude Code 與其他 AI coding agent。
+> 詳細 issue / PR / worktree 流程請見 `docs/workflow.md`。
 
-## 預設語言
-- 預設以繁體中文回覆
-- 技術術語（函式名稱、指令、程式語言關鍵字）保留英文
-- 禁止使用簡體中文
+## Default language
 
-## 角色定義
-- Codex 預設角色：實作者（Implementer）、程式碼編輯器（Code Editor）、建置/測試執行者（Build/Test Runner）
-- Codex 只實作已核准的計畫，不自行重新設計，除非明確要求
-- 不重構無關程式碼
+- 預設以繁體中文回覆。
+- 技術術語、檔名、函式名稱、CLI flags 與程式語言關鍵字保留英文。
+- 禁止使用簡體中文。
 
-## Claude + Codex 分工
+## Project positioning
 
-| 工作項目 | 負責方 |
-|---|---|
-| 規劃 / 設計 / 審查 | Claude |
-| 程式碼編輯 / 實作 / 測試 | Codex |
-| git / GitHub 操作 | Claude |
-| 最終決策 | Human |
+- `spec-injector` 是 deterministic issue-to-context compiler。
+- 它不是 autonomous agent。
+- 它不是 daemon。
+- 它不是 hidden LLM wrapper。
+- 它不是 target repo auto-editing system。
+- CLI core 不應被 companion、daemon 或 custom runtime 污染。
 
-## Scope 控制
-- 只修改核准計畫中明確列出的檔案
-- 不自行擴展 scope
-- 不重構無關程式碼
-- 不確定時先確認，不自行假設
+## Mandatory startup rules
 
-## `/spec-plan <issue>` 委派實作規範
-Codex 若被委派 `/spec-plan <issue>` 後的實作任務，必須：
-- 先確認 Claude 產出的 task package / implementation plan
-- 只依 approved plan 實作
-- 不得自行擴大 scope
-- 不得跳過 guardrails
-- 不得修改 approved plan 以外的檔案
-- 若發現需要修改 plan 以外的檔案，必須停止並回報
+Code/docs implementation 不得直接在 main repo worktree 進行。
 
-## 實作工作流程
-1. 從 Claude 接收已核准的計畫
-2. 確認 scope（列出允許修改的檔案）
-3. 逐步實作
-4. 執行必要的驗證指令
-5. 輸出實作證據摘要（修改檔案、驗證方式、風險範圍、commit hash），供 Claude 在來源 issue 留下 comment
-6. 回報結果給 Claude 審查
+開始任何 code/docs 任務前：
 
-## 驗證指令
-實作完成後必須執行：
-```bash
-npm run build
-npm test
-```
-（或此倉庫對應的等效指令）
+1. 在 main repo 執行 `git checkout main`。
+2. 執行 `git pull`。
+3. 執行 `git status`。
+4. 若 worktree dirty，停下回報。
+5. 不自動 `stash`、`clean`、`reset` 或 checkout 覆蓋 local changes。
+6. 建立 dedicated git worktree 後才實作。
 
-## Commit 規範
-- 訊息須包含 `refs #<issue-number>`
-- 只 commit scope 內的檔案
-- 不包含無關變更
+Metadata-only 任務可以不用 dedicated worktree，但不得假設 main repo 可以被任意切換或清理。若 metadata-only 任務遇到 dirty repo，停下回報。
 
-## Push / PR 工作流程
-被要求發布變更時：
-1. 在 feature branch 上工作，絕不在 main 上
-2. 禁止直接 push 到 main
-3. Push feature branch 到 origin
-4. 通知 Claude 建立 PR
-5. 確認 Claude 已在來源 issue 填入實作證據 comment URL
-6. 不自行 merge PR
+## Scope discipline
 
-## 禁止行為
-- 直接 push 到 main
-- Force push（除非明確要求）
-- 修改 scope 外的檔案
-- 未經核准重新設計架構
-- 未經核准擴展 scope
-- 未建立 PR 就 push
-- Merge PR
+- 只處理指定 issue。
+- 遵守 user、issue、approved plan 或 task package 中列出的 allowed files / forbidden changes。
+- Suggestion 不是 approval。
+- `status:needs-design` 不等於可以直接實作。
+- Guardrails 是 constraints / reminders，不是擴 scope 的授權。
+- 需要擴 scope、修改 forbidden files 或處理相鄰 issue 時，停下回報。
+- 不重構無關程式碼。
+
+## Issue / PR workflow
+
+標準順序：
+
+1. 先有 source issue。
+2. 建立 branch / dedicated worktree。
+3. 實作 issue scope。
+4. 驗證。
+5. Commit，commit message 包含 `refs #<issue-number>`。
+6. Push feature branch。
+7. 建立 ready-for-review PR。
+8. 在 source issue 留 implementation evidence comment。
+9. 將 issue evidence comment URL 回填 PR body。
+10. 交由 human review / merge。
+
+PR 必須 ready for review，不要 draft，除非 issue 特別要求。AI agent 不自行 merge PR，也不刪 branch，除非 cleanup audit 已明確要求且 human 確認。
+
+## Evidence and PR body
+
+PR body 必須包含：
+
+- `Closes #<issue-number>`
+- Summary
+- Tests / validation
+- Implementation Evidence
+- issue evidence comment URL
+- commit hash
+- scope guard / non-goals confirmation
+
+Source issue 必須有 implementation evidence comment。PR body 回填後必須用 `gh pr view` 或等價方式反查，確認不是空的，且包含 evidence URL 與 commit hash。
+
+## Labels
+
+- Issue 應有合理的 area / type / status labels。
+- PR review 階段可用 `status:in-review`。
+- 完成後可用 `status:implemented`。
+- 不要隨意建立新 labels。
+- 不要讓 status labels 衝突，例如 `status:ready` 與 `status:implemented` 同時存在。
+- Labels 不取代 issue body，也不授權擴 scope。
+
+## Testing / validation
+
+- 依 issue 執行最小但足夠的 validation。
+- 常見 validation：`pnpm build`、`pnpm test`、`git diff --check`。
+- Tests / feature implementation 不應依賴真實 GitHub API 或 network。
+- 正常 GitHub workflow 操作，例如 `gh pr view`、`gh pr checks`、push branch、create PR，不屬於 feature tests 打真 API。
+- 沒有新鮮驗證輸出前，不宣稱完成或通過。
+
+## Safety
+
+- 不自動 `stash` / `clean` / `reset`。
+- 不自動修改 target repo code。
+- 不自動刪 branch。
+- 不在 dirty worktree 上開工。
+- 不直接 push 到 `main`。
+- 不 force push，除非明確要求。
+- 不 merge PR。
+- Dogfood 時 target repo dirty 要停下回報，不自動清理。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,53 +1,47 @@
-# CLAUDE.md — Claude Code 預設行為規範
+@AGENTS.md
 
-> 適用於 spec-injector 倉庫的 Claude Code 工作流程。
-> 完整 AI 協作規範請參閱 `presets/core/ai-collaboration.md`。
+# CLAUDE.md - Claude Code adapter
 
-## 預設語言
-- 預設以繁體中文回覆
-- 技術術語（函式名稱、指令、程式語言關鍵字）保留英文
-- 禁止使用簡體中文
+> Claude Code 會讀取本檔。共用 repo-level AI agent 規範由 `AGENTS.md` 匯入；本檔只保留 Claude Code-specific deltas，避免兩份規範 drift。
 
-## 角色定義
-- Claude 預設角色：架構師（Architect）、規劃者（Planner）、審查者（Reviewer）
-- Claude 不直接實作程式碼，除非明確指示
-- 有 Codex 可用時，將實作工作委派給 Codex
+## Claude Code role
 
-## Claude + Codex 分工
+- Claude Code 優先負責 planning、architecture review、PR review 與 risk analysis。
+- 除非 human 明確要求，Claude Code 不應直接實作高風險 code changes。
+- 實作型任務預設交給 Codex 或依 human 指示執行。
+- Claude Code 若被要求直接實作，仍必須遵守 `AGENTS.md` 的 worktree-first workflow、scope discipline、evidence workflow、labels workflow、validation rules 與 stop-and-report rules。
 
-| 工作項目 | 負責方 |
-|---|---|
-| 規劃 / 設計 / 審查 | Claude |
-| 程式碼編輯 / 實作 / 測試 | Codex |
-| git / GitHub 操作 | Claude |
-| 最終決策 | Human |
+## Planning discipline
 
-## Scope 控制
-詳細規則參閱 `presets/core/ai-collaboration.md`。要點：
-- 嚴格遵守 Issue scope，不修改無關檔案
-- 不確定時先詢問，不自行擴展範圍
+- Claude Code 不應把 suggestion 當 approval。
+- `status:needs-design` 不等於可以直接實作。
+- 若發現需要擴 scope、修改 forbidden files 或處理相鄰 issue，必須停下回報。
+- 若 repo instructions、issue、task package 或 human message 互相衝突，必須停下回報並請 human 決定。
 
-## `/spec-plan <issue>` 工作流
+## `/spec-plan <issue>` workflow
+
 當使用者在 Claude Code 中輸入：
 
 ```bash
 /spec-plan <issue>
 ```
 
-Claude 必須先使用 compact prompt mode 執行：
+Claude Code 必須先使用 compact prompt mode 執行：
 
 ```bash
 spec plan <issue> --repo . --dry-run --format prompt --verbose
 ```
 
-若 `spec` 指令不存在，Claude 必須回報此狀態，並建議使用者先執行：
-- `npm run build`
-- `npm link`
+若 `spec` 指令不存在，Claude Code 必須回報此狀態，並建議使用者先執行：
+
+- `pnpm build`
+- `pnpm link --global`
 - 或使用 repo-local executable
 
-Claude 不得因為 `spec` 指令不存在而自行修改、建立或刪除檔案。
+Claude Code 不得因為 `spec` 指令不存在而自行修改、建立或刪除檔案。
 
-讀取 prompt output 後，Claude 必須摘要：
+讀取 prompt output 後，Claude Code 必須摘要：
+
 - source issue
 - detected domains
 - matched guardrails
@@ -56,46 +50,11 @@ Claude 不得因為 `spec` 指令不存在而自行修改、建立或刪除檔�
 - implementation constraints
 - suggested verification checklist
 
-接著 Claude 必須產生 implementation plan，並列出：
+接著 Claude Code 必須產生 implementation plan，並列出：
+
 - 預計修改檔案
 - 不包含範圍
 - 風險
 - 驗證方式
 
-最後必須停下來等待人類批准。未經批准，Claude 不得：
-- 修改檔案
-- 建立檔案
-- 刪除檔案
-- commit
-- push
-- 開 PR
-- merge PR
-
-## 實作工作流程
-1. 閱讀需求與相關檔案
-2. 提出計畫並說明風險
-3. 等待人類確認
-4. 委派給 Codex 執行
-5. 審查 Codex 輸出
-6. 執行驗證指令確認結果
-
-## Commit 規範
-- 訊息須包含 `refs #<issue-number>`
-- 只 commit scope 內的檔案
-- 不包含無關變更
-
-## Push / PR 工作流程
-1. 使用 feature branch
-2. 禁止直接 push 到 main
-3. Push feature branch 到 origin
-4. 建立 PR，目標分支為 main
-5. 使用倉庫 PR 範本（`.github/pull_request_template.md`）
-6. merge 前，在來源 issue 留下實作證據 comment，並將 URL 填入 PR 的「實作證據」欄位
-7. 不自行 merge PR，由人類決定
-
-## 禁止行為
-- 直接 push 到 main
-- Force push（除非明確要求）
-- 修改 scope 外的檔案
-- 未經核准 merge PR
-- 未建立 PR 就 push
+最後必須停下來等待 human approval。未經 approval，Claude Code 不得修改檔案、commit、push、開 PR 或 merge PR。

--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Important fields:
 
 ## Documentation links
 
+- Agent instructions: [AGENTS.md](AGENTS.md)
 - Architecture: [docs/architecture.md](docs/architecture.md)
 - Core concepts: [docs/concepts.md](docs/concepts.md)
 - Classifier: [docs/classifier.md](docs/classifier.md)

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -2,16 +2,88 @@
 
 ## Purpose
 
-本文件說明 `spec-injector` 在 issue-to-PR 流程中的位置。`spec-injector` 負責產生 deterministic task package；AI implementer 與 human review process 負責實作、驗證與 merge decision。
+本文件說明 `spec-injector` 在 issue-to-PR 流程中的位置，以及 AI agent 應如何使用 isolated git worktree、issue / PR structure、labels、implementation evidence、PR body backfill、review / merge / cleanup rules。
 
-## Standard Flow
+`spec-injector` 負責產生 deterministic task package。AI implementer 與 human review process 負責實作、驗證與 merge decision。Root `AGENTS.md` 是 AI agent 進入 repo 的第一層規範入口；本文件提供詳細流程。
+
+## Worktree-first workflow
+
+Main repo 是 control plane，應保持 clean / synced。Code/docs implementation 不直接在 main repo worktree 做。
+
+每張 code/docs issue / PR 應建立 dedicated git worktree。每個 worktree 對應一條 branch。這讓不同 issue 可以獨立 checkout、test、commit 與 push，而不會互相污染 working tree 狀態。
+
+不同 issue 若檔案範圍不重疊，可以在不同 worktree 併發。共用同一 working tree 時不應併發 code 任務。
+
+Metadata-only 任務原則上不需要 worktree，但 metadata 任務不得依賴切換 dirty repo，也不得自動 stash / clean / reset main repo。
+
+## Standard startup sequence
+
+Code/docs implementation 的標準啟動流程：
+
+```bash
+git checkout main
+git pull
+git status
+```
+
+若 main repo worktree dirty，必須 stop-and-report，不自動 `stash`、`clean`、`reset` 或 checkout 覆蓋 local changes。
+
+Main repo clean 且 synced 後，建立 dedicated worktree：
+
+```bash
+ROOT=$(git rev-parse --show-toplevel)
+mkdir -p "$ROOT/../spec-injector-worktrees"
+git worktree add -b <branch-name> "$ROOT/../spec-injector-worktrees/<worktree-name>" main
+cd "$ROOT/../spec-injector-worktrees/<worktree-name>"
+git status
+```
+
+Worktree 狀態必須 clean 才能實作。之後的 edit / test / commit / push / PR 都在該 worktree 內完成。
+
+## Worktree naming
+
+建議命名：
+
+- worktree parent: `../spec-injector-worktrees`
+- worktree path: `issue-<number>-<slug>`
+- branch name: `<type>/<issue-number>-<slug>`
+
+Examples:
+
+- `docs/123-agent-worktree-workflow`
+- `codex/81-dirty-worktree-warning`
+- `fix/84-separate-issue-mentioned-auto-discovered-references`
+
+Slug 應短、可讀，並對應 source issue。不要為同一 issue 建立多個語意重複的 worktree。
+
+## Prompt requirements
+
+交給 Codex / Claude Code / 其他 AI agent 的 implementation prompt 應包含：
+
+- issue URL
+- branch name
+- worktree path or naming rule
+- scope
+- allowed files
+- forbidden changes
+- stop-and-report conditions
+- validation commands
+- PR requirements
+- issue evidence comment requirement
+- PR body backfill requirement
+- final report format
+- no branch cleanup during implementation
+
+Prompt 中的 suggestions 不等於 approval。若 prompt、issue、repo instructions 或 human message 互相衝突，停下回報並請 human 決定。
+
+## Issue workflow
+
+標準順序：
 
 ```text
 GitHub issue
-  -> spec plan / task package
-  -> AI implementation plan
-  -> human approval
-  -> AI implementation
+  -> branch / dedicated worktree
+  -> implementation
   -> validation
   -> PR
   -> source issue implementation evidence
@@ -19,41 +91,59 @@ GitHub issue
   -> review / merge decision
 ```
 
-## Step-by-step
+Issue body 應包含：
 
-1. 確認 source issue。
-2. 同步 target repo branch state。
-3. 執行 `spec plan <issue> --repo . --dry-run --format prompt --verbose`。
-4. AI 依 task package 草擬 implementation plan。
-5. Human approve plan。
-6. AI 建立 feature branch。
-7. AI 只修改 approved scope 內檔案。
-8. AI 執行必要 validation。
-9. AI commit，commit message 包含 `refs #<issue-number>`。
-10. AI push feature branch。
-11. AI 建立 ready-for-review PR。
-12. AI 在 source issue 留下 implementation evidence comment。
-13. AI 將 evidence comment URL 回填 PR body。
-14. AI 用 `gh pr view` 或等價方式重新讀取 PR body，確認內容完整。
-15. Human / reviewer 決定 review、merge 或要求修改。
+- Goal
+- Motivation
+- Scope
+- Non-goals
+- Validation
+- Completion criteria
 
-## PR Requirements
+Issue 應有合適 labels。Open implementation issue 進 PR review 後可用 `status:in-review`。Merge / complete 後可用 `status:implemented`。Ambiguous planning issue 應保留 `status:needs-design`，不要把 needs-design 當成 implementation approval。
 
-PR 應為 ready for review。除非 issue 特別要求，不要建立 draft PR。
+## PR workflow
 
-PR body 應包含：
+PR 必須 ready for review，不要 draft，除非 issue 特別要求。
+
+PR body 必須包含：
 
 - `Closes #<issue-number>`
 - Summary
-- Docs / validation
-- Implementation Evidence section
+- Tests / validation
+- Implementation Evidence
 - issue evidence comment URL
 - commit hash
 - scope guard / non-goals confirmation
 
-若 PR template 有 checklist，且相關項目已驗證通過，應勾選，不要留下已完成項目的空 checkbox。
+PR 建立後要在 source issue 留 implementation evidence comment，再把 issue evidence comment URL 回填 PR body。
 
-## Implementation Evidence
+回填後必須用 `gh pr view` 或等價方式反查 PR body，確認：
+
+- PR body 非空
+- 包含 `Closes #<issue-number>`
+- 包含 issue evidence comment URL
+- 包含 commit hash
+- 包含 validation 結果
+- 包含 scope guard / non-goals confirmation
+
+CI 通過後，若 PR checklist 有 CI item，應勾選。AI agent 不自行 merge PR。
+
+## Labels workflow
+
+Issue 應至少有合理 area / type / status labels，依 repo taxonomy。Label taxonomy 見 `docs/conventions.md`。
+
+Rules:
+
+- 不要隨意建立新 labels。
+- 若缺 label taxonomy，先開 label taxonomy issue。
+- PR review 階段可使用 `status:in-review`。
+- Completed issue 可使用 `status:implemented`。
+- Closed as `NOT_PLANNED` 不應硬加 `status:implemented`。
+- 避免 status labels 衝突，例如 `status:ready` 與 `status:implemented` 同時存在。
+- Labels 不取代 issue body，也不授權擴 scope。
+
+## Evidence workflow
 
 Implementation evidence comment 應寫回 source issue，讓 issue 讀者不用只靠 PR diff 才能知道實作結果。
 
@@ -61,49 +151,92 @@ Evidence comment 應包含：
 
 - Summary
 - Files changed
-- Docs / validation
+- Tests / validation
 - Commit hash
 - PR URL
 - Scope boundaries
-- explicit non-goals confirmations
+- Non-goals confirmation
 
-## PR Body Backfill
+若 evidence comment URL 需要回填 PR body，先建立 PR，再貼 issue comment，取得永久 comment URL 後更新 PR body，最後反查 PR body。
 
-取得 issue evidence comment 的永久連結後，應回填 PR body 的 Implementation Evidence section。
+## Concurrency rules
 
-回填後必須重新讀取 PR body，確認：
+可併發：
 
-- PR body 不是空的
-- 包含 `Closes #<issue-number>`
-- 包含 Implementation Evidence
-- 包含 issue evidence comment URL
-- 包含 commit hash
-- 包含 docs / validation
+- 不同 worktree。
+- 檔案範圍不重疊。
+- Metadata-only 任務與 code 任務，但 metadata 任務不應依賴切換 dirty repo。
+- Docs planning 與 code implementation，若不碰同檔案。
 
-## Scope Guard
+不可併發：
+
+- 同一 worktree 中多個 code 任務。
+- 兩張 PR 都會碰同一批 files，例如 `tests/cli.integration.test.ts`、`src/cli/plan.ts`、`templates`。
+- 後一張依賴前一張 merge 的任務。
+- Dogfood 依賴安全護欄尚未 merge 時。
+
+若不確定是否會碰同一批 files，先停下回報並等 human 決定。
+
+## Cleanup workflow
+
+不要每張 PR merge 後立刻刪 branch。
+
+每個較大工作階段結束後做 branch / worktree cleanup audit：
+
+1. 列出 local branches、remote branches 與 worktrees。
+2. 確認哪些 branch 已 merged。
+3. 確認哪些 worktree clean 且不再需要。
+4. 向 human 回報 cleanup candidates。
+5. 取得 human confirmation 後才刪。
+
+`git worktree remove` 與 `git branch -D` 應只針對已 merge 且確認 safe 的 branch。Remote branch deletion 也應先 audit。不要自動刪不明狀態 branch。
+
+## Safety rules
+
+- 不自動 `stash` / `clean` / `reset`。
+- 不自動修改 target repo code，除非 issue 明確要求。
+- 不把 suggestion 當 approval。
+- 不在 dirty worktree 上開工。
+- 不把 GitHub workflow 操作誤認為測試打真 GitHub API。
+- Tests / implementation 不應依賴真實 GitHub API 或 network。
+- Package install / normal `gh` workflow 操作是 workflow I/O，不是 feature tests 打真 API。
+- 不直接 push 到 `main`。
+- 不 force push，除非明確要求。
+- 不 merge PR。
+
+## Scope guard
 
 Workflow 中每一步都應維持 issue scope：
 
-- 不處理相鄰 issue
-- 不修改 runtime code，除非 issue 明確要求
-- 不修改 classifier behavior，除非 issue 明確要求
-- 不修改 task package output，除非 issue 明確要求
-- 不修改 config schema，除非 issue 明確要求
-- 不新增 CLI command，除非 issue 明確要求
-- 不新增 LLM / API / local model integration
-- 不自行 merge PR
+- 不處理相鄰 issue。
+- 不修改 runtime code，除非 issue 明確要求。
+- 不修改 classifier behavior，除非 issue 明確要求。
+- 不修改 task package output，除非 issue 明確要求。
+- 不修改 config schema，除非 issue 明確要求。
+- 不新增 CLI command，除非 issue 明確要求。
+- 不新增 CLI flag，除非 issue 明確要求。
+- 不新增 dependency，除非 issue 明確要求。
+- 不新增 LLM / API / local model integration。
+- 不自行 merge PR。
 
-## Relationship To `spec-injector`
+若發現需要修改 forbidden files 或擴 scope，停下回報。
 
-`spec-injector` 只負責 deterministic context compiler 的部分。Branch、commit、PR、evidence comment、PR body backfill 與 merge decision 是 surrounding workflow，不是 CLI core 自動執行的 runtime behavior。
+## Relationship to `spec-injector`
+
+`spec-injector` 只負責 deterministic context compiler 的部分。Branch、commit、PR、evidence comment、PR body backfill、review、merge 與 cleanup 是 surrounding workflow，不是 CLI core 自動執行的 runtime behavior。
+
+CLI core 不應被 daemon、companion runtime、custom runtime 或 hidden LLM wrapper 污染。Future-facing runtime ideas 應先以 design issue 討論，不應順手塞進 implementation PR。
 
 ## Non-goals
 
 本 workflow doc 不實作：
 
 - new CLI command
+- new CLI flag
 - GitHub bot
 - PR automation daemon
+- companion runtime
 - hidden model integration
 - target repo auto-editing
+- status JSON runtime
 - CI workflow


### PR DESCRIPTION
Closes #103

## Summary
- Update root AGENTS.md as the first repo-level AI agent instruction entry point.
- Expand docs/workflow.md with isolated git worktree, issue / PR / evidence, labels, concurrency, cleanup, and safety rules.
- Add a small README documentation link to AGENTS.md.
- Review follow-up: update CLAUDE.md to import AGENTS.md and keep only Claude Code-specific deltas.

## Docs / validation
- `git diff --check -- AGENTS.md README.md docs/workflow.md` passed for the initial docs change.
- Markdown structure sanity check passed for `AGENTS.md`, `README.md`, and `docs/workflow.md` for the initial docs change.
- `pnpm test` passed for the initial docs change after `pnpm install --frozen-lockfile` populated the worktree dependencies.
- `git diff --check -- CLAUDE.md AGENTS.md docs/workflow.md` passed for the review follow-up.
- Markdown structure sanity check passed for `CLAUDE.md` for the review follow-up.
- `pnpm install --frozen-lockfile` kept the lockfile unchanged for the review follow-up.
- `pnpm test` passed for the review follow-up.

## Implementation Evidence
- Initial issue evidence comment: https://github.com/Erick52106/spec-injector/issues/103#issuecomment-4364504870
- Review follow-up comment: https://github.com/Erick52106/spec-injector/issues/103#issuecomment-4364520388
- Initial commit: a3f1ff7af0b5f8d4c2d0eb64c63793e92da57849
- Review follow-up commit: 7dafad94f7d49c574d801707831e5230b1fff9df

## Scope guard / non-goals confirmation
- Docs / agent-instructions only.
- No runtime code changes.
- No test changes.
- No package.json or pnpm-lock.yaml changes.
- No CI changes.
- No CLI behavior, classifier behavior, task package output, config schema, dependency, daemon, or companion runtime implementation changes.