### PR TITLE
docs(workflow): document roadmap milestones and layer labels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,9 +74,14 @@ PR body 必須包含：
 
 Source issue 必須有 implementation evidence comment。PR body 回填後必須用 `gh pr view` 或等價方式反查，確認不是空的，且包含 evidence URL 與 commit hash。
 
-## Labels
+## Labels / roadmap metadata
 
 - Issue 應有合理的 area / type / status labels。
+- Future issues 在 high-confidence classification 可行時，應有 roadmap milestone。
+- Future issues 在 high-confidence classification 可行時，應有一個 primary layer label。
+- PR 原則上沿用 linked issue 的 roadmap milestone 與 primary layer label。
+- 若 milestone / layer 無法高信心判斷，停下回報或列入 needs human review。
+- 未經明確 approval，不建立新的 roadmap / layer labels 或 milestones。
 - PR review 階段可用 `status:in-review`。
 - 完成後可用 `status:implemented`。
 - 不要隨意建立新 labels。

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -11,6 +11,8 @@
 - Required validation 是 merge readiness 的最低門檻；若無法執行，必須在 PR body、issue evidence 與 final report 說明原因。
 - Recommended validation 應在成本低或變更風險較高時執行；若 reviewer 要求，應視為該 PR 的 required validation。
 - 若 PR 跨多個 change type，必須執行所有相關類型的 required validation；若 requirements 衝突、重疊或不確定，採較嚴格的 validation set，並在 PR body 說明實際採用的 validation 與原因。若無法執行任一 required validation，必須 stop-and-report 或清楚寫明 skipped reason。
+- 若 PR 跨多個 roadmap layers 或多個 source issues，必須在 PR body 說明採用的主要 roadmap milestone / primary layer label 與原因。
+- PR review 前應確認 linked issue 與 PR 的 roadmap milestone / primary layer label 是否存在且合理；無法高信心分類時，必須 stop-and-report 或列為 needs human review。
 - Feature tests 與 implementation 不應依賴真實 GitHub API 或 network。若測試需要 GitHub output，應使用 fixture、fake `gh`、mocked process 或等價 isolation。
 - Package installation 與 normal `gh` workflow 是允許的 workflow I/O，例如 `pnpm install --frozen-lockfile`、`gh pr view`、`gh pr checks`、`gh issue comment`、push branch、create PR。這些不是 feature test dependency。
 - `gh pr view`、`gh pr checks`、`gh issue comment`、push branch、create PR 是 issue / PR workflow 操作，不代表 runtime 或 tests 可以打真 GitHub API。
@@ -168,6 +170,7 @@ Required review checks:
 Examples:
 
 - Issue labels.
+- Roadmap milestones / layer labels.
 - Issue closing or reopening.
 - Planning issue creation.
 - Evidence comments.
@@ -175,6 +178,7 @@ Examples:
 Required:
 
 - Confirm no repo file changes.
+- For metadata-only roadmap updates, confirm no repo file changes and list every milestone / layer label mutation.
 - Verify GitHub issue, label, and PR state with `gh issue view`, `gh pr view`, or equivalent commands.
 - Final report lists exact GitHub mutations.
 
@@ -184,6 +188,8 @@ Required review checks:
 - No unintended PR changes.
 - No non-target issue close.
 - Status labels do not conflict, for example `status:ready` and `status:implemented` on the same open implementation issue.
+- Roadmap milestone and primary layer label are present and reasonable when high-confidence classification is possible.
+- Missing milestone / layer label is explicitly reported as follow-up when the current PR scope does not include metadata changes.
 
 ### 10. Dogfood / target repo evaluation
 
@@ -242,6 +248,7 @@ PR body must include:
 - Scope guard / non-goals confirmation.
 - CI checks status or an explicit note that CI was not available / not applicable.
 - Explicit skipped reason for any required validation that could not run.
+- Primary roadmap milestone / layer label rationale when the PR crosses multiple change types, layers, or source issues.
 
 After backfill, use `gh pr view` or equivalent to confirm the PR body is non-empty and contains the evidence URL and commit hash.
 
@@ -271,6 +278,8 @@ A PR is ready for human review only when:
 - Source issue has implementation evidence comment.
 - PR body is backfilled with issue evidence URL.
 - PR body includes commit hash.
+- Linked issue and PR have a roadmap milestone and one primary layer label when high-confidence classification is possible.
+- If milestone / layer label is missing and the current PR does not scope metadata updates, PR body, final report, or review notes mark a follow-up.
 - `gh pr view` confirms PR body is non-empty and contains evidence URL and commit hash.
 - CI checks are reported.
 - Scope guard confirms non-goals.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -100,11 +100,13 @@ Issue body 應包含：
 - Validation
 - Completion criteria
 
-Issue 應有合適 labels。Open implementation issue 進 PR review 後可用 `status:in-review`。Merge / complete 後可用 `status:implemented`。Ambiguous planning issue 應保留 `status:needs-design`，不要把 needs-design 當成 implementation approval。
+Issue 應有合適 labels、roadmap milestone 與 primary layer label。Open implementation issue 進 PR review 後可用 `status:in-review`。Merge / complete 後可用 `status:implemented`。Ambiguous planning issue 應保留 `status:needs-design`，不要把 needs-design 當成 implementation approval。
 
 ## PR workflow
 
 PR 必須 ready for review，不要 draft，除非 issue 特別要求。
+
+PR 原則上沿用 linked issue 的 roadmap milestone 與 primary layer label。若 PR 對應多個 issues，選擇主要 milestone / layer，並在 PR body 說明判斷。若 PR 沒有 linked issue，但 scope 可高信心分類，依實際變更套用 milestone / layer；無法高信心判斷時列入 human review，不要硬套。
 
 PR body 必須包含：
 
@@ -148,6 +150,43 @@ Rules:
 - Closed as `NOT_PLANNED` 不應硬加 `status:implemented`。
 - 避免 status labels 衝突，例如 `status:ready` 與 `status:implemented` 同時存在。
 - Labels 不取代 issue body，也不授權擴 scope。
+
+## Roadmap milestones and layer labels
+
+Roadmap milestone 表示主要 roadmap phase。Primary layer label 表示主要系統層。每個 issue / PR 原則上只使用一個 roadmap milestone 與一個 primary layer label；跨層工作應選主要責任層，並在 PR body 說明判斷。
+
+Fixed roadmap milestones:
+
+- `Layer 1 — Core Compiler`
+- `Layer 2 — Workflow Guardrails`
+- `Layer 3 — Protocolization`
+- `Layer 4 — Companion UX`
+
+Fixed layer labels:
+
+- `layer1 : Core Compiler`
+- `layer2 : Workflow Guardrails`
+- `layer3 : Protocolization`
+- `layer4 : Companion UX`
+
+Layer definitions:
+
+- `Layer 1 — Core Compiler` / `layer1 : Core Compiler`: 核心 deterministic issue-to-context compiler。包含 issue parsing、domain classifier、references / discovery core behavior、guardrails、safeReadFile、template rendering、task package output、CLI plan output、output correctness、core tests supporting compiler correctness。
+- `Layer 2 — Workflow Guardrails` / `layer2 : Workflow Guardrails`: 讓 core compiler 能安全、高速、可併發使用的 workflow / validation / evidence / worktree guardrails。包含 AGENTS.md / CLAUDE.md、isolated worktree workflow、validation matrix / quality gates、dirty target repo warning、dogfood、PR evidence workflow、issue label audit、worktree preflight checks、PR / evidence consistency checker、workflow metadata cleanup、CI / automation if primary goal is workflow guardrail。
+- `Layer 3 — Protocolization` / `layer3 : Protocolization`: 把 taxonomy / workflow 規則升級為穩定 catalog / protocol / machine-checkable contract。包含 catalog / protocol design、domain catalog、reference source catalog、guardrail catalog、task package section catalog、schema / compatibility rules、machine-checkable contract design、stable type naming、public vs internal contract boundaries。
+- `Layer 4 — Companion UX` / `layer4 : Companion UX`: Companion mascot / status layer / workflow observability UX。包含 companion mascot design、workflow status event schema、daemon / status runtime exploration、local status watcher、Tauri / browser overlay / local widget exploration、low-resource companion runtime、visual / mascot status layer planning。
+
+Rules:
+
+- Issue 建立時，若 high-confidence classification 可行，應套用合理 roadmap milestone 與一個 primary layer label。
+- PR 原則上沿用 linked issue 的 roadmap milestone 與 primary layer label。
+- 若 PR 對應多個 issues，選擇主要 milestone / layer，並在 PR body 說明。
+- 若 PR 沒有 linked issue，依實際 scope 高信心套用；無法判斷則列入 human review。
+- 不要同時套多個 layer labels，除非 human 明確要求。
+- Layer label 不是 area label 的替代品；area / type / status labels 仍應維持。
+- Milestone 不是 status label 的替代品；workflow state 仍由 status labels 與 PR state 表示。
+- 不要建立或提倡 `L1.5`、`Layer 1.5`、`layer1.5`、`layer:1`、`layer:1-core`、`layer:core` 或其他語意模糊 layer labels。
+- Closed as `NOT_PLANNED` 的 issue 仍可有 milestone / layer label 方便查詢，但不應硬套 `status:implemented`。
 
 ## Evidence workflow
 


### PR DESCRIPTION
Closes #115

## Summary

- Add short AGENTS.md rules requiring future issues and PRs to use roadmap milestones and one primary layer label when classification is high-confidence.
- Document the fixed roadmap milestone names, fixed layer label names, layer definitions, and PR inheritance rules in docs/workflow.md.
- Add PR review and merge-readiness checks for milestone / layer label presence and rationale in docs/validation.md.

## Docs / validation

- `git diff --check -- AGENTS.md docs/workflow.md docs/validation.md` — pass
- Markdown sanity check for `AGENTS.md`, `docs/workflow.md`, and `docs/validation.md` — pass
- `pnpm install --frozen-lockfile` — pass; lockfile unchanged
- `pnpm test` — pass, 55 tests after merging latest `origin/main`
- `gh pr checks 116 --repo Erick52106/spec-injector --json name,state,workflow` — pass; `build` is `SUCCESS`

## Implementation Evidence

- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/115#issuecomment-4364618701
- Commit: `3033e3583f5aa9e06d3ce3da4b32d6956f3ced54`

## Conflict resolution

- Merged latest `origin/main` into `docs/115-roadmap-layer-rules` with no manual conflict markers remaining.
- `git diff --check origin/main..HEAD -- AGENTS.md docs/workflow.md docs/validation.md` — pass
- Markdown sanity check for `AGENTS.md`, `docs/workflow.md`, and `docs/validation.md` — pass

## Roadmap metadata

- Milestone: `Layer 2 — Workflow Guardrails`
- Primary layer label: `layer2 : Workflow Guardrails`
- Rationale: this PR updates workflow / validation / evidence guardrails and does not touch core compiler runtime behavior.

## Scope guard / non-goals confirmation

- Only docs / AGENTS workflow rules were changed.
- No runtime code changes.
- No tests changes.
- No package.json or lockfile changes.
- No CI changes.
- No new dependency.
- No new CLI command or flag.
- No config schema changes.
- No GitHub milestones or labels were created or modified.
