### PR TITLE
feat(config): support external config path for read-only dogfood

### DIFF
--- a/docs/dogfood.md
+++ b/docs/dogfood.md
@@ -26,10 +26,14 @@ Dogfood report 應觀察：
 2. 檢查 target repo branch 與 worktree。
 3. 如果 target repo dirty，停下回報。
 4. 不自動 stash / clean / reset。
-5. 執行 `spec plan <issue> --repo <target-repo> --dry-run --format prompt --verbose`。
-6. 保存或摘要 output。
-7. 分析 observations、false positives、false negatives、follow-up issues。
-8. 不直接修改 target repo code，除非另有 approved implementation plan。
+5. 若 clean target repo 沒有 `.spec-injector/config.json`，準備 target repo 外部的 config file path。
+6. 執行 `spec plan <issue> --repo <target-repo> --config <external-config.json> --dry-run --format prompt --verbose`。
+   - 若 target repo 已有可使用的 `.spec-injector/config.json`，可省略 `--config`，維持預設讀取行為。
+   - `--config` 只讀取指定檔案；不要把 `.spec-injector/` 複製或建立到 target repo。
+   - Read-only dogfood 應保留 `--dry-run`，避免產生 task package output。
+7. 保存或摘要 output。
+8. 分析 observations、false positives、false negatives、follow-up issues。
+9. 不直接修改 target repo code，除非另有 approved implementation plan。
 
 ## Dirty Worktree Rule
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,6 +15,7 @@ program
   .command('plan <issue>')
   .description('Read a GitHub issue via gh CLI and generate a task package')
   .option('--repo <path>', 'Path to target repo (default: CWD)')
+  .option('--config <path>', 'External config file path (may be outside target repo)')
   .option('--dry-run', 'Print output to stdout only; do not write a task package file')
   .option('--verbose', 'Show detailed pipeline steps while planning')
   .option('--format <format>', 'Output format: "full" task package or "prompt" compact AI planning prompt (default: full)')
@@ -27,9 +28,10 @@ Non-dry-run output:
 Notes:
   --dry-run        Preview output without writing files
   --format prompt  Emit a compact AI planning prompt instead of the full package
+  --config <path>  Read an external config file without copying it into the target repo
   --verbose        Print fetch / config / discovery pipeline steps
 `)
-  .action(async (issue: string, opts: { repo?: string; dryRun?: boolean; verbose?: boolean; format?: string }) => {
+  .action(async (issue: string, opts: { repo?: string; config?: string; dryRun?: boolean; verbose?: boolean; format?: string }) => {
     const { plan } = await import('./plan.js');
     await plan(issue, opts);
   });

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -23,7 +23,7 @@ import type { DomainClassificationResult } from '../classifier/domain.js';
 
 export async function plan(
   issueRef: string,
-  opts: { repo?: string; dryRun?: boolean; verbose?: boolean; format?: string }
+  opts: { repo?: string; config?: string; dryRun?: boolean; verbose?: boolean; format?: string }
 ): Promise<void> {
   const repoPath = path.resolve(opts.repo ?? process.cwd());
   const format = opts.format ?? 'full';
@@ -45,7 +45,7 @@ export async function plan(
 
   // 2. Load config
   if (opts.verbose) console.log('→ Loading config...');
-  const config = await loadConfig(repoPath);
+  const config = await loadConfig(repoPath, { configPath: opts.config });
 
   // 3. Match guardrails by detected domains
   const guardrails = config.specConfig.guardrails ?? [];

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -3,8 +3,16 @@ import fs from 'fs';
 import { safeReadFile } from '../utils/fs.js';
 import type { Config, SpecConfig, Guardrail } from './types.js';
 
-export async function loadConfig(repoPath: string): Promise<Config> {
+interface LoadConfigOptions {
+  configPath?: string;
+}
+
+export async function loadConfig(repoPath: string, opts: LoadConfigOptions = {}): Promise<Config> {
   const resolved = path.resolve(repoPath);
+  if (opts.configPath) {
+    return loadExternalConfig(resolved, opts.configPath);
+  }
+
   const specAgentDir = findSpecAgentDir(resolved);
 
   const configPath = path.join(specAgentDir, 'config.json');
@@ -21,6 +29,40 @@ export async function loadConfig(repoPath: string): Promise<Config> {
   }
 
   return { repoPath: resolved, specAgentDir, specConfig };
+}
+
+async function loadExternalConfig(repoPath: string, configPath: string): Promise<Config> {
+  const resolvedConfigPath = path.resolve(configPath);
+  let stat: fs.Stats;
+  try {
+    stat = await fs.promises.stat(resolvedConfigPath);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') {
+      throw new Error(`External config file not found: ${resolvedConfigPath}`);
+    }
+    throw new Error(`External config file is not readable: ${resolvedConfigPath}: ${(err as Error).message}`);
+  }
+
+  if (!stat.isFile()) {
+    throw new Error(`External config path is not a file: ${resolvedConfigPath}`);
+  }
+
+  let configText: string;
+  try {
+    configText = await fs.promises.readFile(resolvedConfigPath, 'utf8');
+  } catch (err) {
+    throw new Error(`External config file is not readable: ${resolvedConfigPath}: ${(err as Error).message}`);
+  }
+
+  let specConfig: SpecConfig;
+  try {
+    specConfig = parseAndValidateConfig(configText, resolvedConfigPath);
+  } catch (err) {
+    throw new Error(`Invalid config.json at ${resolvedConfigPath}: ${(err as Error).message}`);
+  }
+
+  return { repoPath, specAgentDir: path.dirname(resolvedConfigPath), specConfig };
 }
 
 function findSpecAgentDir(startPath: string): string {

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -200,6 +200,8 @@ test('spec plan/config/clean help describe AI-facing usage and safety constraint
   assert.match(planHelp.stdout, /do not write/i);
   assert.match(planHelp.stdout, /format prompt/i);
   assert.match(planHelp.stdout, /compact ai planning prompt/i);
+  assert.match(planHelp.stdout, /--config <path>/);
+  assert.match(planHelp.stdout, /external config file path/i);
   assert.match(planHelp.stdout, /verbose/i);
   assert.match(planHelp.stdout, /pipeline steps/i);
   assert.match(planHelp.stdout, /\.spec-injector\/out\/issue-<number>-task-package\.md/);
@@ -641,6 +643,74 @@ test('spec plan dry-run full output uses mocked gh data and keeps task package o
   assert.deepEqual(await readGhLog(fixture.ghLogPath), [
     'issue view 57 --repo Erick52106/spec-injector --json number,title,body,labels,url,state',
   ]);
+});
+
+test('spec plan keeps default target repo config behavior without --config', async (t) => {
+  const fixture = await createSpecPlanFixture(t);
+
+  const result = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run'],
+    { env: fixture.env }
+  );
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /### docs\/always-read\.md/);
+  assert.match(result.stdout, /ALWAYS_READ_LONG_BODY_SENTINEL/);
+  assert.match(result.stdout, /Require auth reviewer before changing login or permission flows\./);
+  await assertFileMissing(fixture.taskPackagePath);
+});
+
+test('spec plan reads external config outside target repo without modifying target repo', async (t) => {
+  const fixture = await createExternalConfigPlanFixture(t);
+  const beforeSnapshot = await readDirectorySnapshot(fixture.repoDir);
+
+  const result = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--config', fixture.configPath, '--dry-run'],
+    { env: fixture.env }
+  );
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /### docs\/external-always\.md/);
+  assert.match(result.stdout, /EXTERNAL_ALWAYS_READ_SENTINEL/);
+  assert.match(result.stdout, /\*\*external-auth-review\*\*: External config guardrail for read-only dogfood\./);
+  assert.doesNotMatch(result.stderr, /No \.spec-injector\/ directory found/i);
+  await assertFileMissing(path.join(fixture.repoDir, '.spec-injector'));
+  assert.deepEqual(await readDirectorySnapshot(fixture.repoDir), beforeSnapshot);
+});
+
+test('spec plan reports missing external config path clearly without falling back to target config', async (t) => {
+  const fixture = await createExternalConfigPlanFixture(t);
+  const missingConfigPath = path.join(path.dirname(fixture.configPath), 'missing-config.json');
+
+  const result = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--config', missingConfigPath, '--dry-run'],
+    { env: fixture.env }
+  );
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stderr, /External config file not found/i);
+  assert.match(result.stderr, new RegExp(escapeRegExp(missingConfigPath)));
+  assert.doesNotMatch(result.stderr, /No \.spec-injector\/ directory found/i);
+  assertNoRawStackTrace(result);
+  await assertFileMissing(path.join(fixture.repoDir, '.spec-injector'));
+});
+
+test('spec plan reports invalid external config clearly without requiring target config', async (t) => {
+  const fixture = await createExternalConfigPlanFixture(t);
+  const invalidConfigPath = path.join(path.dirname(fixture.configPath), 'invalid-config.json');
+  await fs.writeFile(invalidConfigPath, '{ invalid json\n', 'utf8');
+
+  const result = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--config', invalidConfigPath, '--dry-run'],
+    { env: fixture.env }
+  );
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stderr, /Invalid config\.json/i);
+  assert.match(result.stderr, new RegExp(escapeRegExp(invalidConfigPath)));
+  assert.doesNotMatch(result.stderr, /No \.spec-injector\/ directory found/i);
+  assertNoRawStackTrace(result);
+  await assertFileMissing(path.join(fixture.repoDir, '.spec-injector'));
 });
 
 test('spec plan dry-run prompt output stays compact and omits long inline docs', async (t) => {
@@ -1389,6 +1459,62 @@ async function createSpecPlanFixture(t) {
   };
 }
 
+async function createExternalConfigPlanFixture(t) {
+  const repoDir = await createTempRepo(t, 'spec-injector-external-target-');
+  const configDir = await fs.mkdtemp(path.join(os.tmpdir(), 'spec-injector-external-config-'));
+  t.after(async () => {
+    await fs.rm(configDir, { recursive: true, force: true });
+  });
+
+  const configPath = path.join(configDir, 'config.json');
+  await fs.writeFile(configPath, `${JSON.stringify({
+    version: 2,
+    always_read: ['docs/external-always.md'],
+    discovery: {
+      docs: [],
+      source: ['src'],
+      max_docs: 2,
+      max_source_files: 2,
+    },
+    guardrails: [
+      {
+        id: 'external-auth-review',
+        when_detected: ['auth'],
+        risk: 'External config guardrail for read-only dogfood.',
+      },
+    ],
+  }, null, 2)}\n`, 'utf8');
+
+  await writeRepoFiles(repoDir, {
+    'docs/external-always.md': '# External Always\n\nEXTERNAL_ALWAYS_READ_SENTINEL\n',
+    'docs/auth-note.md': '# Auth Note\n\nExternal config dogfood auth documentation.\n',
+    'src/auth.ts': 'export const authSentinel = "EXTERNAL_CONFIG_SOURCE_SENTINEL";\n',
+    'README.md': '# External Config Target\n\nRead-only dogfood fixture.\n',
+  });
+
+  const issue = {
+    number: 113,
+    title: 'Support external auth config for read-only dogfood',
+    body: [
+      'Use external config while planning auth changes.',
+      '',
+      '- [ ] verify external config guardrails',
+    ].join('\n'),
+    labels: [{ name: 'auth' }],
+    url: 'https://github.com/Erick52106/spec-injector/issues/113',
+    state: 'OPEN',
+  };
+  const fakeGh = await createFakeGh(t, issue);
+  fakeGh.env.FAKE_GH_EXPECT_REF = '113';
+
+  return {
+    repoDir,
+    configPath,
+    env: fakeGh.env,
+    issueUrl: issue.url,
+  };
+}
+
 async function createExplicitPathPlanFixture(t, options) {
   const repoDir = await createTempRepo(t);
   const issueNumber = options.issueNumber ?? 80;
@@ -1582,6 +1708,26 @@ async function writeConfig(repoDir, config) {
 
 async function readFile(filePath) {
   return fs.readFile(filePath, 'utf8');
+}
+
+async function readDirectorySnapshot(dirPath) {
+  const snapshot = {};
+
+  async function walk(currentDir) {
+    const entries = await fs.readdir(currentDir, { withFileTypes: true });
+    for (const entry of entries) {
+      const absolutePath = path.join(currentDir, entry.name);
+      const relativePath = path.relative(dirPath, absolutePath);
+      if (entry.isDirectory()) {
+        await walk(absolutePath);
+        continue;
+      }
+      snapshot[relativePath] = await fs.readFile(absolutePath, 'utf8');
+    }
+  }
+
+  await walk(dirPath);
+  return snapshot;
 }
 
 async function readGhLog(filePath) {


### PR DESCRIPTION
Closes #113

## Summary
- Add `spec plan --config <path>` so config can be read from outside the target repo.
- Keep default `.spec-injector/config.json` behavior when `--config` is omitted.
- Document read-only dogfood usage and cover external config behavior in fixture-based integration tests.

## Tests / validation
- `pnpm build`
- `pnpm test`
- `git diff --check`

## Implementation Evidence
- Issue evidence comment: https://github.com/Erick52106/spec-injector/issues/113#issuecomment-4364618971
- Commit: `e02dbb6601a9371cddc12a3e212a462b2771cd5a`

## Scope guard / non-goals confirmation
- No tachigo or target repo code changes.
- No `.spec-injector/` creation or copying into a target repo.
- No config schema change.
- No CI workflow change.
- No new dependency.
- No task package output format change.
- No classifier behavior change.
- No LLM / API / local model integration.
- No companion / daemon runtime.