### PR TITLE
fix(classifier): reduce blockchain false positives for generic API contract wording

### DIFF
--- a/docs/classifier.md
+++ b/docs/classifier.md
@@ -38,6 +38,8 @@ Generic product wording 需要小心處理。某些字在不同 domain 中都可
 例如：
 
 - `transaction` 可以是 database transaction，也可以是 product wording。
+- `contract` 可以是 API / endpoint / request-response contract，不等於 smart contract。
+- `block` / `hash` 單字容易出現在 generic engineering wording，應偏好 `block height`、`transaction hash`、`tx hash` 等更明確 evidence。
 - `address` 可以是 wallet address，也可以是 shipping address、email address 或 UI copy。
 - `send` / `receive` 可以是 wallet 動作，也可以是 messaging 或 notification。
 
@@ -57,12 +59,16 @@ Generic product wording 需要小心處理。某些字在不同 domain 中都可
 - `mnemonic`
 - `on-chain`
 - `transaction hash` / `tx hash`
+- `contract address`
+- `block height`
 - `token transfer`
 - `ethereum`
+- `evm`
 - `solana`
+- `polygon`
 - `web3`
 
-Generic `transaction` 不應單獨代表 wallet。Legitimate wallet / blockchain evidence 應比 generic product wording 更強。
+Generic `transaction` 不應單獨代表 wallet。Generic API / endpoint `contract` 不應單獨代表 `smart-contract` 或 `blockchain`。Legitimate wallet / blockchain evidence 應比 generic product wording 更強。
 
 ## Classifier Output Is Advisory
 

--- a/src/classifier/domain.ts
+++ b/src/classifier/domain.ts
@@ -29,8 +29,8 @@ const DOMAIN_KEYWORDS: Record<string, string[]> = {
   database: ['database', 'db', 'sql', 'query', 'migration', 'schema', 'table', 'model', 'orm', 'postgres', 'mysql', 'mongo', 'redis', 'index', 'transaction'],
   infra: ['infra', 'deploy', 'docker', 'kubernetes', 'k8s', 'terraform', 'helm', 'nginx', 'network', 'devops', 'provision', 'cloud', 'vm', 'container'],
   'cloud-storage': ['s3', 'gcs', 'storage', 'bucket', 'upload', 'download', 'blob', 'cdn', 'file upload', 'asset', 'object storage'],
-  blockchain: ['blockchain', 'chain', 'block', 'hash', 'ledger', 'consensus', 'miner', 'ethereum', 'solana', 'web3', 'nft', 'defi'],
-  'smart-contract': ['smart contract', 'contract', 'solidity', 'abi', 'evm', 'vyper', 'bytecode', 'deploy contract'],
+  blockchain: ['blockchain', 'on-chain', 'transaction hash', 'tx hash', 'block height', 'contract address', 'token transfer', 'gas', 'nonce', 'ethereum', 'evm', 'solana', 'polygon', 'web3', 'nft', 'defi', 'ledger', 'consensus', 'miner'],
+  'smart-contract': ['smart contract', 'contract address', 'solidity', 'abi', 'evm', 'vyper', 'bytecode', 'deploy contract'],
   wallet: ['wallet', 'connect wallet', 'wallet address', 'private key', 'public key', 'address', 'signature', 'signing', 'transaction hash', 'tx hash', 'token transfer', 'on-chain', 'send', 'receive', 'balance', 'seed phrase', 'mnemonic'],
   i18n: ['i18n', 'l10n', 'locale', 'translation', 'lang', 'language', 'localize', 'multilang'],
   testing: ['test', 'spec', 'unit', 'integration', 'e2e', 'mock', 'stub', 'coverage', 'jest', 'vitest', 'playwright', 'cypress', 'assert', 'fixture'],
@@ -42,6 +42,9 @@ const DOMAIN_KEYWORDS: Record<string, string[]> = {
 const MAX_DOMAINS = 5;
 const GENERIC_WALLET_SIGNALS = ['transactions', 'transaction'];
 const GENERIC_WALLET_REASON = 'generic product transaction wording';
+const GENERIC_API_CONTRACT_SIGNALS = ['contract'];
+const GENERIC_API_CONTRACT_CONTEXT = ['api', 'endpoint', 'route', 'request', 'response', 'backend', 'frontend', 'dashboard', 'settings'];
+const GENERIC_API_CONTRACT_REASON = 'generic API contract wording';
 
 export function classifyDomains(issue: Issue): string[] {
   return classifyDomainsWithEvidence(issue).domains;
@@ -105,20 +108,44 @@ function buildRejectedDomainReasons(
   fields: Array<{ source: DomainEvidenceSource; value: string }>,
   detected: Set<string>
 ): RejectedDomainReason[] {
-  if (detected.has('wallet')) return [];
+  const rejected: RejectedDomainReason[] = [];
 
+  if (!detected.has('wallet')) {
+    const reason = findRejectedSignal(fields, GENERIC_WALLET_SIGNALS, GENERIC_WALLET_REASON, 'wallet');
+    if (reason) rejected.push(reason);
+  }
+
+  if (!detected.has('smart-contract') && hasGenericApiContractContext(fields)) {
+    const reason = findRejectedSignal(fields, GENERIC_API_CONTRACT_SIGNALS, GENERIC_API_CONTRACT_REASON, 'smart-contract');
+    if (reason) rejected.push(reason);
+  }
+
+  return rejected;
+}
+
+function findRejectedSignal(
+  fields: Array<{ source: DomainEvidenceSource; value: string }>,
+  signals: string[],
+  reason: string,
+  domain: string
+): RejectedDomainReason | undefined {
   for (const { source, value } of fields) {
-    for (const signal of GENERIC_WALLET_SIGNALS) {
+    for (const signal of signals) {
       if (value.includes(signal)) {
-        return [{
-          domain: 'wallet',
+        return {
+          domain,
           signal,
           source,
-          reason: GENERIC_WALLET_REASON,
-        }];
+          reason,
+        };
       }
     }
   }
 
-  return [];
+  return undefined;
+}
+
+function hasGenericApiContractContext(fields: Array<{ source: DomainEvidenceSource; value: string }>): boolean {
+  const text = fields.map(({ value }) => value).join(' ');
+  return GENERIC_API_CONTRACT_CONTEXT.some((term) => text.includes(term));
 }

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -26,7 +26,60 @@ test('classifier does not treat dashboard transactions endpoint wording as walle
   assert.ok(domains.includes('frontend'), `Expected frontend in ${domains.join(', ')}`);
   assert.ok(domains.includes('api'), `Expected api in ${domains.join(', ')}`);
   assert.ok(domains.includes('backend'), `Expected backend in ${domains.join(', ')}`);
+  assert.ok(!domains.includes('blockchain'), `Expected blockchain to be absent from ${domains.join(', ')}`);
+  assert.ok(!domains.includes('smart-contract'), `Expected smart-contract to be absent from ${domains.join(', ')}`);
   assert.ok(!domains.includes('wallet'), `Expected wallet to be absent from ${domains.join(', ')}`);
+});
+
+test('classifier suppresses generic dashboard endpoint contract wording from blockchain domains', () => {
+  const result = classifyDomainsWithEvidence({
+    number: 114,
+    title: 'Dashboard transactions/settings endpoint contract alignment blocking release',
+    body: [
+      'Align the transactions endpoint and settings endpoint API contract.',
+      'This is a backend route handler contract and request / response contract issue for dashboard records.',
+      'Keep the frontend dashboard page and database-backed product transaction records in sync.',
+    ].join('\n'),
+    labels: ['frontend', 'api', 'backend'],
+    url: 'https://github.com/Erick52106/spec-injector/issues/114',
+    state: 'open',
+  });
+
+  assert.ok(result.domains.includes('frontend'), `Expected frontend in ${result.domains.join(', ')}`);
+  assert.ok(result.domains.includes('api'), `Expected api in ${result.domains.join(', ')}`);
+  assert.ok(result.domains.includes('backend'), `Expected backend in ${result.domains.join(', ')}`);
+  assert.ok(result.domains.includes('database'), `Expected database in ${result.domains.join(', ')}`);
+  assert.ok(!result.domains.includes('blockchain'), `Expected blockchain to be absent from ${result.domains.join(', ')}`);
+  assert.ok(!result.domains.includes('smart-contract'), `Expected smart-contract to be absent from ${result.domains.join(', ')}`);
+  assert.ok(!result.domains.includes('wallet'), `Expected wallet to be absent from ${result.domains.join(', ')}`);
+  assert.ok(result.rejected.some((r) =>
+    r.domain === 'smart-contract' &&
+    r.signal === 'contract' &&
+    r.source === 'title' &&
+    r.reason === 'generic API contract wording'
+  ));
+  assert.ok(result.rejected.length <= 2, `Expected only targeted rejected reasons, got ${JSON.stringify(result.rejected)}`);
+});
+
+test('classifier does not overfit non-tachigo transaction history API contract wording to blockchain', () => {
+  const result = classifyDomainsWithEvidence({
+    number: 114,
+    title: 'Admin dashboard transaction history API contract',
+    body: [
+      'Review the request / response contract for billing transaction history.',
+      'The backend route handler should return product transaction records from database rows.',
+    ].join('\n'),
+    labels: ['api', 'backend'],
+    url: 'https://github.com/example/product/issues/114',
+    state: 'open',
+  });
+
+  assert.ok(result.domains.includes('api'), `Expected api in ${result.domains.join(', ')}`);
+  assert.ok(result.domains.includes('backend'), `Expected backend in ${result.domains.join(', ')}`);
+  assert.ok(result.domains.includes('database'), `Expected database in ${result.domains.join(', ')}`);
+  assert.ok(!result.domains.includes('blockchain'), `Expected blockchain to be absent from ${result.domains.join(', ')}`);
+  assert.ok(!result.domains.includes('smart-contract'), `Expected smart-contract to be absent from ${result.domains.join(', ')}`);
+  assert.ok(!result.domains.includes('wallet'), `Expected wallet to be absent from ${result.domains.join(', ')}`);
 });
 
 test('classifier keeps wallet detection for explicit wallet and on-chain transaction evidence', () => {
@@ -43,6 +96,32 @@ test('classifier keeps wallet detection for explicit wallet and on-chain transac
   });
 
   assert.ok(domains.includes('wallet'), `Expected wallet in ${domains.join(', ')}`);
+});
+
+test('classifier keeps blockchain detection for legitimate smart contract and on-chain evidence', () => {
+  const result = classifyDomainsWithEvidence({
+    number: 114,
+    title: 'Smart contract on-chain tx hash contract address indexing',
+    body: [
+      'Index Ethereum EVM contract address activity with transaction hash and tx hash lookup.',
+      'Persist block height, gas, and nonce metadata for token transfer reconciliation.',
+    ].join('\n'),
+    labels: ['backend'],
+    url: 'https://github.com/Erick52106/spec-injector/issues/114',
+    state: 'open',
+  });
+
+  assert.ok(result.domains.includes('blockchain'), `Expected blockchain in ${result.domains.join(', ')}`);
+  assert.ok(result.domains.includes('smart-contract'), `Expected smart-contract in ${result.domains.join(', ')}`);
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'blockchain' && e.term === 'on-chain' && e.source === 'title'
+  ));
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'blockchain' && e.term === 'contract address' && e.source === 'title'
+  ));
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'smart-contract' && e.term === 'smart contract' && e.source === 'title'
+  ));
 });
 
 test('classifier does not overfit product transaction records to wallet', () => {
@@ -145,6 +224,35 @@ test('classifier reports wallet rejected reason for generic product transaction 
     signal: 'transactions',
     source: 'title',
     reason: 'generic product transaction wording',
+  }]);
+});
+
+test('classifier reports deterministic rejected reason for generic API contract wording only', () => {
+  const issue = {
+    number: 114,
+    title: 'Settings endpoint contract alignment',
+    body: [
+      'Review the backend route handler contract.',
+      'Keep the API request / response contract stable for dashboard settings.',
+    ].join('\n'),
+    labels: ['api', 'backend'],
+    url: 'https://github.com/Erick52106/spec-injector/issues/114',
+    state: 'open' as const,
+  };
+
+  const first = classifyDomainsWithEvidence(issue);
+  const second = classifyDomainsWithEvidence(issue);
+
+  assert.deepEqual(first, second);
+  assert.ok(first.domains.includes('api'), `Expected api in ${first.domains.join(', ')}`);
+  assert.ok(first.domains.includes('backend'), `Expected backend in ${first.domains.join(', ')}`);
+  assert.ok(!first.domains.includes('blockchain'), `Expected blockchain to be absent from ${first.domains.join(', ')}`);
+  assert.ok(!first.domains.includes('smart-contract'), `Expected smart-contract to be absent from ${first.domains.join(', ')}`);
+  assert.deepEqual(first.rejected, [{
+    domain: 'smart-contract',
+    signal: 'contract',
+    source: 'title',
+    reason: 'generic API contract wording',
   }]);
 });
 


### PR DESCRIPTION
Closes #114

## Summary
- Reduced generic API and endpoint contract wording from causing blockchain-adjacent classifier false positives.
- Replaced broad blockchain signals such as chain, block, and hash with stronger blockchain evidence such as on-chain, transaction hash, tx hash, block height, contract address, gas, nonce, Ethereum, EVM, Solana, and Polygon.
- Kept legitimate smart contract and on-chain wording classified as blockchain and smart-contract.
- Documented generic contract wording boundaries in docs/classifier.md.

## Tests / validation
- pnpm build
- node --test --test-name-pattern classifier tests/cli.integration.test.ts
- pnpm test
- git diff --check

## Implementation Evidence
- Issue evidence comment: https://github.com/Erick52106/spec-injector/issues/114#issuecomment-4364685838
- Commit: adb16ece52d456d712446c58cc3d752688f5bd7e

## Scope guard / non-goals confirmation
- No classifier architecture rewrite.
- No config schema change.
- No CLI command or flag change.
- No task package output or prompt output change.
- No CI workflow change.
- No dependency change.
- No target repo or tachigo change.
- No LLM, API, or local model integration.
- Did not handle #78 dogfood, #113, #118, #119, or #120.