### PR TITLE
docs(workflow): clarify GitHub language and PR metadata rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,14 @@
 - 技術術語、檔名、函式名稱、CLI flags 與程式語言關鍵字保留英文。
 - 禁止使用簡體中文。
 
+## GitHub language and metadata
+
+- GitHub issue body、PR body、implementation evidence comment 與 final report 預設使用繁體中文。
+- 技術名詞、檔名、CLI command、錯誤輸出與外部 API 名稱可保留英文。
+- PR 應繼承 linked issue 的 roadmap milestone、primary layer label，以及合理 area / type labels。
+- 若 PR metadata 無法高信心判斷，停下回報或列入 needs human review。
+- 未經明確 approval，不建立新的 labels 或 milestones。
+
 ## Project positioning
 
 - `spec-injector` 是 deterministic issue-to-context compiler。
@@ -79,7 +87,7 @@ Source issue 必須有 implementation evidence comment。PR body 回填後必須
 - Issue 應有合理的 area / type / status labels。
 - Future issues 在 high-confidence classification 可行時，應有 roadmap milestone。
 - Future issues 在 high-confidence classification 可行時，應有一個 primary layer label。
-- PR 原則上沿用 linked issue 的 roadmap milestone 與 primary layer label。
+- PR 原則上沿用 linked issue 的 roadmap milestone、primary layer label 與合理 area / type labels。
 - 若 milestone / layer 無法高信心判斷，停下回報或列入 needs human review。
 - 未經明確 approval，不建立新的 roadmap / layer labels 或 milestones。
 - PR review 階段可用 `status:in-review`。

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -13,6 +13,8 @@
 - 若 PR 跨多個 change type，必須執行所有相關類型的 required validation；若 requirements 衝突、重疊或不確定，採較嚴格的 validation set，並在 PR body 說明實際採用的 validation 與原因。若無法執行任一 required validation，必須 stop-and-report 或清楚寫明 skipped reason。
 - 若 PR 跨多個 roadmap layers 或多個 source issues，必須在 PR body 說明採用的主要 roadmap milestone / primary layer label 與原因。
 - PR review 前應確認 linked issue 與 PR 的 roadmap milestone / primary layer label 是否存在且合理；無法高信心分類時，必須 stop-and-report 或列為 needs human review。
+- PR review 前應確認 PR metadata 與 linked issue 一致，包含 milestone、primary layer label、合理 area / type labels。
+- PR body、issue evidence comment 與 final report 預設使用繁體中文；commands、raw output、file paths、technical terms 與精準英文片段可保留英文。
 - Feature tests 與 implementation 不應依賴真實 GitHub API 或 network。若測試需要 GitHub output，應使用 fixture、fake `gh`、mocked process 或等價 isolation。
 - Package installation 與 normal `gh` workflow 是允許的 workflow I/O，例如 `pnpm install --frozen-lockfile`、`gh pr view`、`gh pr checks`、`gh issue comment`、push branch、create PR。這些不是 feature test dependency。
 - `gh pr view`、`gh pr checks`、`gh issue comment`、push branch、create PR 是 issue / PR workflow 操作，不代表 runtime 或 tests 可以打真 GitHub API。
@@ -190,6 +192,8 @@ Required review checks:
 - Status labels do not conflict, for example `status:ready` and `status:implemented` on the same open implementation issue.
 - Roadmap milestone and primary layer label are present and reasonable when high-confidence classification is possible.
 - Missing milestone / layer label is explicitly reported as follow-up when the current PR scope does not include metadata changes.
+- PR metadata inherits linked issue milestone, primary layer label, and reasonable area / type labels when applicable.
+- GitHub body / evidence language changes stay scoped to requested language requirement updates.
 
 ### 10. Dogfood / target repo evaluation
 
@@ -249,6 +253,7 @@ PR body must include:
 - CI checks status or an explicit note that CI was not available / not applicable.
 - Explicit skipped reason for any required validation that could not run.
 - Primary roadmap milestone / layer label rationale when the PR crosses multiple change types, layers, or source issues.
+- 以繁體中文為主要語言；technical terms、commands、file paths、raw output、commit hashes 與精準英文片段可保留英文。
 
 After backfill, use `gh pr view` or equivalent to confirm the PR body is non-empty and contains the evidence URL and commit hash.
 
@@ -266,6 +271,8 @@ The source issue implementation evidence comment must include:
 
 Issue evidence should be posted after the PR exists, then its permanent comment URL should be backfilled into the PR body.
 
+Issue evidence 應以繁體中文為主要語言；commands、file paths、validation output、commit hashes 與 technical terms 可保留英文。
+
 ## Merge-readiness Quality Gates
 
 A PR is ready for human review only when:
@@ -275,10 +282,13 @@ A PR is ready for human review only when:
 - PR body includes Summary.
 - PR body includes Tests / validation with exact commands.
 - PR body includes Implementation Evidence.
+- PR body 以繁體中文為主要語言。若出現英文，確認其屬於 technical terms、commands、file paths、raw output 或精準英文片段，而不是整份 PR body 默認英文。
+- Source issue implementation evidence comment 在同樣例外下以繁體中文為主要語言。
 - Source issue has implementation evidence comment.
 - PR body is backfilled with issue evidence URL.
 - PR body includes commit hash.
-- Linked issue and PR have a roadmap milestone and one primary layer label when high-confidence classification is possible.
+- PR has a roadmap milestone, one primary layer label, and reasonable area / type labels when high-confidence classification is possible.
+- PR metadata is consistent with the linked issue. If linked issue metadata is missing, the PR body, final report, or review notes mark a follow-up unless current scope authorizes fixing it.
 - If milestone / layer label is missing and the current PR does not scope metadata updates, PR body, final report, or review notes mark a follow-up.
 - `gh pr view` confirms PR body is non-empty and contains evidence URL and commit hash.
 - CI checks are reported.
@@ -303,5 +313,7 @@ Stop and report instead of continuing when:
 - Target repo is dirty during dogfood.
 - Worktree path or branch does not match the source issue plan.
 - GitHub permission is insufficient to create the required issue, PR, labels, evidence comment, or PR body backfill.
+- PR metadata cannot be classified with high confidence and current scope does not authorize guessing.
+- GitHub language requirement cannot be satisfied without rewriting unrelated issue / PR content.
 
 Stop-and-report should include current branch, worktree path, failed command or blocker, and the smallest clear decision needed from the human.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -102,11 +102,26 @@ Issue body 應包含：
 
 Issue 應有合適 labels、roadmap milestone 與 primary layer label。Open implementation issue 進 PR review 後可用 `status:in-review`。Merge / complete 後可用 `status:implemented`。Ambiguous planning issue 應保留 `status:needs-design`，不要把 needs-design 當成 implementation approval。
 
+## GitHub language requirements
+
+GitHub issue body、PR body、implementation evidence comment、review / final report 預設使用繁體中文。技術詞、CLI commands、file paths、raw errors、commit hashes、外部 API 名稱與更精準的英文片段可保留英文。
+
+Rules:
+
+- Issue body 預設繁體中文。
+- PR body 預設繁體中文。
+- Implementation evidence comment 預設繁體中文。
+- Review / final report 預設繁體中文。
+- 不使用簡體中文。
+- 若引用 command output、error text、schema field、CLI flag、檔名或外部 API 名稱，保留原文。
+
 ## PR workflow
 
 PR 必須 ready for review，不要 draft，除非 issue 特別要求。
 
-PR 原則上沿用 linked issue 的 roadmap milestone 與 primary layer label。若 PR 對應多個 issues，選擇主要 milestone / layer，並在 PR body 說明判斷。若 PR 沒有 linked issue，但 scope 可高信心分類，依實際變更套用 milestone / layer；無法高信心判斷時列入 human review，不要硬套。
+PR 原則上沿用 linked issue 的 roadmap milestone、primary layer label 與合理 area / type labels。若 linked issue 缺 metadata，PR 作者應在 final report 標記 follow-up；若目前 scope 允許 metadata cleanup，才補上 linked issue metadata。
+
+若 PR 對應多個 issues，選擇主要 milestone / layer，並在 PR body 說明判斷。若 PR 沒有 linked issue，但 scope 可高信心分類，依實際變更套用 milestone / layer 與合理 area / type labels；無法高信心判斷時列入 human review，不要硬套。
 
 PR body 必須包含：
 
@@ -123,11 +138,14 @@ PR 建立後要在 source issue 留 implementation evidence comment，再把 iss
 回填後必須用 `gh pr view` 或等價方式反查 PR body，確認：
 
 - PR body 非空
+- 以繁體中文為主，允許 technical terms / commands / paths / raw output 保留英文
 - 包含 `Closes #<issue-number>`
 - 包含 issue evidence comment URL
 - 包含 commit hash
 - 包含 validation 結果
 - 包含 scope guard / non-goals confirmation
+- PR metadata 包含 milestone、一個 primary layer label、合理 area / type labels
+- PR metadata 與 linked issue 一致，或 PR body / final report 說明高信心例外理由
 
 CI 通過後，若 PR checklist 有 CI item，應勾選。AI agent 不自行 merge PR。
 
@@ -145,6 +163,7 @@ Rules:
 
 - 不要隨意建立新 labels。
 - 若缺 label taxonomy，先開 label taxonomy issue。
+- PR 應繼承 linked issue 的合理 area / type labels；若 linked issue 缺 labels，應在 final report 標記 follow-up。
 - PR review 階段可使用 `status:in-review`。
 - Completed issue 可使用 `status:implemented`。
 - Closed as `NOT_PLANNED` 不應硬加 `status:implemented`。
@@ -179,7 +198,7 @@ Layer definitions:
 Rules:
 
 - Issue 建立時，若 high-confidence classification 可行，應套用合理 roadmap milestone 與一個 primary layer label。
-- PR 原則上沿用 linked issue 的 roadmap milestone 與 primary layer label。
+- PR 原則上沿用 linked issue 的 roadmap milestone、primary layer label 與合理 area / type labels。
 - 若 PR 對應多個 issues，選擇主要 milestone / layer，並在 PR body 說明。
 - 若 PR 沒有 linked issue，依實際 scope 高信心套用；無法判斷則列入 human review。
 - 不要同時套多個 layer labels，除非 human 明確要求。
@@ -201,6 +220,8 @@ Evidence comment 應包含：
 - PR URL
 - Scope boundaries
 - Non-goals confirmation
+
+Evidence comment 預設使用繁體中文；技術名詞、commands、file paths、raw errors 與 commit hash 可保留英文。
 
 若 evidence comment URL 需要回填 PR body，先建立 PR，再貼 issue comment，取得永久 comment URL 後更新 PR body，最後反查 PR body。
 


### PR DESCRIPTION
Closes #123

## Summary

- 在 AGENTS.md 加入短規則，明確要求 GitHub issue body、PR body、implementation evidence comment 與 final report 預設使用繁體中文。
- 在 docs/workflow.md 補上 GitHub language requirements，以及 PR metadata 繼承 linked issue milestone、primary layer label、合理 area / type labels 的流程。
- 在 docs/validation.md 將 PR metadata 與 GitHub language checks 納入 review / quality gates。

## Docs / validation

- `git diff --check -- AGENTS.md docs/workflow.md docs/validation.md` - pass
- `node -e ...` markdown sanity check for `AGENTS.md`, `docs/workflow.md`, and `docs/validation.md` - pass
- `pnpm install --frozen-lockfile` - pass; lockfile unchanged
- `pnpm test` - pass; 55 tests, 55 pass, 0 fail
- `gh pr checks 124 --repo Erick52106/spec-injector --json name,state,workflow` - pass; `build` is `SUCCESS`

## Implementation Evidence

- Issue evidence comment: https://github.com/Erick52106/spec-injector/issues/123#issuecomment-4364788971
- Commit: `8203c3b87aeee5364c3a8c6cca2f1acc15caf1d4`

## Scope guard / non-goals confirmation

- 只更新 AGENTS.md / docs/workflow.md / docs/validation.md 的 workflow 規範。
- 沒有 runtime code changes。
- 沒有 tests changes。
- 沒有 `package.json` / `pnpm-lock.yaml` changes。
- 沒有 CI changes。
- 沒有新增 dependency。
- 沒有新增 CLI command or flag。
- 沒有 config schema changes。
- 沒有 classifier behavior changes。
- 沒有 task package output changes。
- 沒有建立 labels / milestones。
