### PR TITLE
docs(workflow): clarify GitHub language and PR metadata requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,9 @@
 ## Default language
 
 - 預設以繁體中文回覆。
+- GitHub issue body、PR body、implementation evidence comment 與 final report 預設使用繁體中文。
 - 技術術語、檔名、函式名稱、CLI flags 與程式語言關鍵字保留英文。
+- CLI command、raw output 與錯誤輸出可保留英文。
 - 禁止使用簡體中文。
 
 ## Project positioning
@@ -79,9 +81,9 @@ Source issue 必須有 implementation evidence comment。PR body 回填後必須
 - Issue 應有合理的 area / type / status labels。
 - Future issues 在 high-confidence classification 可行時，應有 roadmap milestone。
 - Future issues 在 high-confidence classification 可行時，應有一個 primary layer label。
-- PR 原則上沿用 linked issue 的 roadmap milestone 與 primary layer label。
-- 若 milestone / layer 無法高信心判斷，停下回報或列入 needs human review。
-- 未經明確 approval，不建立新的 roadmap / layer labels 或 milestones。
+- PR 原則上沿用 linked issue 的 roadmap milestone、primary layer label 與合理 area / type labels。
+- 若 PR metadata 無法高信心判斷，停下回報或列入 needs human review。
+- 未經明確 approval，不建立新的 labels 或 milestones。
 - PR review 階段可用 `status:in-review`。
 - 完成後可用 `status:implemented`。
 - 不要隨意建立新 labels。

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -13,6 +13,8 @@
 - 若 PR 跨多個 change type，必須執行所有相關類型的 required validation；若 requirements 衝突、重疊或不確定，採較嚴格的 validation set，並在 PR body 說明實際採用的 validation 與原因。若無法執行任一 required validation，必須 stop-and-report 或清楚寫明 skipped reason。
 - 若 PR 跨多個 roadmap layers 或多個 source issues，必須在 PR body 說明採用的主要 roadmap milestone / primary layer label 與原因。
 - PR review 前應確認 linked issue 與 PR 的 roadmap milestone / primary layer label 是否存在且合理；無法高信心分類時，必須 stop-and-report 或列為 needs human review。
+- PR review 前應確認 PR 有合理 area / type labels，且 metadata 與 linked issue 一致；不一致時應 request changes 或標記 metadata follow-up。
+- PR body、issue evidence comment 與 final report 預設應以繁體中文為主。英文應限於 commands、file paths、raw output、raw errors、technical terms、external API names 或更精準的英文片段。
 - Feature tests 與 implementation 不應依賴真實 GitHub API 或 network。若測試需要 GitHub output，應使用 fixture、fake `gh`、mocked process 或等價 isolation。
 - Package installation 與 normal `gh` workflow 是允許的 workflow I/O，例如 `pnpm install --frozen-lockfile`、`gh pr view`、`gh pr checks`、`gh issue comment`、push branch、create PR。這些不是 feature test dependency。
 - `gh pr view`、`gh pr checks`、`gh issue comment`、push branch、create PR 是 issue / PR workflow 操作，不代表 runtime 或 tests 可以打真 GitHub API。
@@ -189,6 +191,8 @@ Required review checks:
 - No non-target issue close.
 - Status labels do not conflict, for example `status:ready` and `status:implemented` on the same open implementation issue.
 - Roadmap milestone and primary layer label are present and reasonable when high-confidence classification is possible.
+- PR 在 high-confidence classification 可行時，有合理 area / type labels。
+- PR metadata 與 linked issue 一致；若不一致，PR body 或 final report 應說明 scoped reason。
 - Missing milestone / layer label is explicitly reported as follow-up when the current PR scope does not include metadata changes.
 
 ### 10. Dogfood / target repo evaluation
@@ -250,6 +254,8 @@ PR body must include:
 - Explicit skipped reason for any required validation that could not run.
 - Primary roadmap milestone / layer label rationale when the PR crosses multiple change types, layers, or source issues.
 
+PR body 應以繁體中文為主。若 PR body 主要使用英文，reviewer 應確認該英文限於 commands、raw output、technical terms、file paths、external API names 或短而精準的英文片段，而不是整份 PR body 的預設語言。
+
 After backfill, use `gh pr view` or equivalent to confirm the PR body is non-empty and contains the evidence URL and commit hash.
 
 ## Issue Evidence Validation Reporting
@@ -264,6 +270,8 @@ The source issue implementation evidence comment must include:
 - Scope boundaries.
 - Confirmation of important non-goals, especially runtime code, tests, package files, CI, CLI behavior, and config schema when those are out of scope.
 
+Issue evidence 應以繁體中文為主；commands、file paths、raw output、raw errors、technical terms、commit hash 與 PR URL 可保留英文。
+
 Issue evidence should be posted after the PR exists, then its permanent comment URL should be backfilled into the PR body.
 
 ## Merge-readiness Quality Gates
@@ -272,13 +280,17 @@ A PR is ready for human review only when:
 
 - PR is ready for review, not draft, unless the issue explicitly says draft.
 - PR body includes `Closes #<issue-number>`.
+- PR body 以繁體中文為主，commands、raw output、technical terms、file paths、external API names 或短而精準的英文片段除外。
 - PR body includes Summary.
 - PR body includes Tests / validation with exact commands.
 - PR body includes Implementation Evidence.
 - Source issue has implementation evidence comment.
+- Source issue evidence comment 以繁體中文為主，技術內容可保留英文。
 - PR body is backfilled with issue evidence URL.
 - PR body includes commit hash.
 - Linked issue and PR have a roadmap milestone and one primary layer label when high-confidence classification is possible.
+- PR 在 high-confidence classification 可行時，有合理 area / type labels。
+- PR metadata 與 linked issue 一致；若不一致，PR body 或 final report 說明 scoped exception。
 - If milestone / layer label is missing and the current PR does not scope metadata updates, PR body, final report, or review notes mark a follow-up.
 - `gh pr view` confirms PR body is non-empty and contains evidence URL and commit hash.
 - CI checks are reported.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -76,6 +76,12 @@ Slug 應短、可讀，並對應 source issue。不要為同一 issue 建立多�
 
 Prompt 中的 suggestions 不等於 approval。若 prompt、issue、repo instructions 或 human message 互相衝突，停下回報並請 human 決定。
 
+## GitHub language rules
+
+GitHub issue body、PR body、implementation evidence comment、review note 與 final report 預設使用繁體中文。
+
+技術名詞、CLI commands、file paths、raw errors、raw command output、external API names、labels、milestones、commit hash 與必要的英文片段可保留英文。英文應用於精準表達技術內容，不應讓整份 issue / PR / evidence / report 預設變成英文。
+
 ## Issue workflow
 
 標準順序：
@@ -100,13 +106,17 @@ Issue body 應包含：
 - Validation
 - Completion criteria
 
+Issue body 預設使用繁體中文。技術名詞、commands、file paths 與 raw errors 可保留英文。
+
 Issue 應有合適 labels、roadmap milestone 與 primary layer label。Open implementation issue 進 PR review 後可用 `status:in-review`。Merge / complete 後可用 `status:implemented`。Ambiguous planning issue 應保留 `status:needs-design`，不要把 needs-design 當成 implementation approval。
 
 ## PR workflow
 
 PR 必須 ready for review，不要 draft，除非 issue 特別要求。
 
-PR 原則上沿用 linked issue 的 roadmap milestone 與 primary layer label。若 PR 對應多個 issues，選擇主要 milestone / layer，並在 PR body 說明判斷。若 PR 沒有 linked issue，但 scope 可高信心分類，依實際變更套用 milestone / layer；無法高信心判斷時列入 human review，不要硬套。
+PR body 預設使用繁體中文。技術名詞、commands、file paths、raw errors、external API names 與必要的英文片段可保留英文。
+
+PR 原則上沿用 linked issue 的 roadmap milestone、primary layer label 與合理 area / type labels。若 linked issue 缺少 metadata，PR 作者應在 final report 標記 follow-up；若目前 scope 明確允許 metadata 修正，才可補上。若 PR 對應多個 issues，選擇主要 milestone / layer，並在 PR body 說明判斷。若 PR 沒有 linked issue，但 scope 可高信心分類，依實際變更套用 metadata；無法高信心判斷時列入 needs human review，不要硬套。
 
 PR body 必須包含：
 
@@ -145,6 +155,7 @@ Rules:
 
 - 不要隨意建立新 labels。
 - 若缺 label taxonomy，先開 label taxonomy issue。
+- PR 應有合理 area / type labels；若 linked issue 有可沿用的 area / type labels，原則上沿用。
 - PR review 階段可使用 `status:in-review`。
 - Completed issue 可使用 `status:implemented`。
 - Closed as `NOT_PLANNED` 不應硬加 `status:implemented`。
@@ -180,6 +191,7 @@ Rules:
 
 - Issue 建立時，若 high-confidence classification 可行，應套用合理 roadmap milestone 與一個 primary layer label。
 - PR 原則上沿用 linked issue 的 roadmap milestone 與 primary layer label。
+- 若 linked issue 缺 milestone、primary layer label 或合理 area / type labels，PR 作者應在 final report 標記 follow-up；若 scope 明確允許 metadata 修正，才可補上。
 - 若 PR 對應多個 issues，選擇主要 milestone / layer，並在 PR body 說明。
 - 若 PR 沒有 linked issue，依實際 scope 高信心套用；無法判斷則列入 human review。
 - 不要同時套多個 layer labels，除非 human 明確要求。
@@ -191,6 +203,8 @@ Rules:
 ## Evidence workflow
 
 Implementation evidence comment 應寫回 source issue，讓 issue 讀者不用只靠 PR diff 才能知道實作結果。
+
+Implementation evidence comment 預設使用繁體中文。技術名詞、commands、file paths、raw errors、raw command output、commit hash 與 PR URL 可保留英文。
 
 Evidence comment 應包含：
 


### PR DESCRIPTION
Closes #125

## Summary

- 在 AGENTS.md 補上 GitHub issue body、PR body、implementation evidence comment 與 final report 的繁體中文預設規則。
- 在 docs/workflow.md 補上 GitHub language rules、PR metadata inheritance、linked issue metadata 缺口處理與 evidence language rule。
- 在 docs/validation.md 將 PR metadata 與 GitHub language checks 納入 review / quality gates。

## Docs / validation

- git diff --check -- AGENTS.md docs/workflow.md docs/validation.md - pass
- node markdown sanity check for code fence parity and heading levels - pass
- pnpm install --frozen-lockfile - pass; pnpm-lock.yaml unchanged
- pnpm test - pass; 59 tests, 59 pass, 0 fail
- gh pr checks 126 - pass; 1/1 checks passed

## Implementation Evidence

- Issue evidence comment: https://github.com/Erick52106/spec-injector/issues/125#issuecomment-4364798337
- Commit: 4394ab922c2dc2befd87994bd85cd6cd466e16c5

## Scope guard / non-goals confirmation

- 只修改 AGENTS.md、docs/workflow.md、docs/validation.md。
- 沒有 runtime code changes。
- 沒有 tests changes。
- 沒有 package.json / pnpm-lock.yaml changes。
- 沒有 CI changes。
- 沒有新增 dependency。
- 沒有新增 CLI command or flag。
- 沒有 config schema changes。
- 沒有 classifier behavior changes。
- 沒有 task package output changes。
- 沒有修改 target repo。