### PR TITLE
fix(template): detect unreplaced placeholders in rendered output

### DIFF
--- a/src/template/renderer.ts
+++ b/src/template/renderer.ts
@@ -1,9 +1,34 @@
 import type { TemplateVars } from './types.js';
 
+const UNREPLACED_PLACEHOLDER_PATTERNS = [
+  /\{\{\s*[A-Za-z_][A-Za-z0-9_]*\s*\}\}/g,
+  /__[A-Z][A-Z0-9_]*__/g,
+];
+
 export function renderTemplate(template: string, vars: TemplateVars): string {
   let result = template;
   for (const [key, value] of Object.entries(vars)) {
     result = result.replaceAll(`{{${key}}}`, value);
   }
+  assertNoUnreplacedPlaceholders(result);
   return result;
+}
+
+function assertNoUnreplacedPlaceholders(rendered: string): void {
+  const placeholders = new Set<string>();
+
+  for (const pattern of UNREPLACED_PLACEHOLDER_PATTERNS) {
+    for (const match of rendered.matchAll(pattern)) {
+      placeholders.add(normalizePlaceholder(match[0]));
+    }
+  }
+
+  if (placeholders.size === 0) return;
+
+  throw new Error(`Template rendering issue: unreplaced placeholder(s): ${[...placeholders].sort().join(', ')}`);
+}
+
+function normalizePlaceholder(value: string): string {
+  if (!value.startsWith('{{')) return value;
+  return value.replace(/\{\{\s*/, '{{').replace(/\s*\}\}/, '}}');
 }

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { classifyDomains, classifyDomainsWithEvidence } from '../dist/classifier/domain.js';
+import { renderTemplate } from '../dist/template/renderer.js';
 import { repoRoot, runSpec } from './helpers/cli.ts';
 import {
   createExplicitPathPlanFixture,
@@ -31,6 +32,8 @@ import {
   normalizePlanOutput,
   sectionBetween,
 } from './helpers/assertions.ts';
+
+const UNREPLACED_TEMPLATE_PLACEHOLDER_PATTERN = /\{\{\s*[A-Za-z_][A-Za-z0-9_]*\s*\}\}|__[A-Z][A-Z0-9_]*__/;
 
 test('classifier does not treat dashboard transactions endpoint wording as wallet evidence', () => {
   const domains = classifyDomains({
@@ -769,6 +772,7 @@ test('spec plan dry-run full output uses mocked gh data and keeps task package o
   assert.match(result.stdout, /- `docs\/missing-handbook\.md` — not found/);
   assert.doesNotMatch(result.stdout, /## 8\. Implementation Constraints/);
   assert.doesNotMatch(result.stdout, /Implementation Constraints:\s*\(none\)/);
+  assert.doesNotMatch(result.stdout, UNREPLACED_TEMPLATE_PLACEHOLDER_PATTERN);
   assert.doesNotMatch(result.stdout, /issue-57-task-package\.md/);
   await assertFileMissing(fixture.taskPackagePath);
   assert.deepEqual(await readGhLog(fixture.ghLogPath), [
@@ -881,7 +885,60 @@ test('spec plan dry-run prompt output stays compact and omits long inline docs',
   assert.doesNotMatch(result.stdout, /ALWAYS_READ_LONG_BODY_SENTINEL/);
   assert.doesNotMatch(result.stdout, /DISCOVERED_DOC_LONG_BODY_SENTINEL/);
   assert.doesNotMatch(result.stdout, /SOURCE_SNIPPET_BODY_SENTINEL/);
+  assert.doesNotMatch(result.stdout, UNREPLACED_TEMPLATE_PLACEHOLDER_PATTERN);
   await assertFileMissing(fixture.taskPackagePath);
+});
+
+test('template renderer rejects unreplaced placeholders in full and prompt templates deterministically', () => {
+  const fullTemplate = [
+    '# Broken Task Package',
+    '',
+    '{{issue_title}}',
+    '{{missing_section}}',
+    '__MISSING_TOKEN__',
+  ].join('\n');
+  const promptTemplate = [
+    '# Broken Implementation Plan Prompt',
+    '',
+    '{{issue_title}}',
+    '{{prompt_missing_section}}',
+  ].join('\n');
+  const vars = {
+    issue_title: 'Detect placeholder leakage',
+  };
+
+  assert.throws(
+    () => renderTemplate(fullTemplate, vars),
+    /Template rendering issue: unreplaced placeholder\(s\): __MISSING_TOKEN__, \{\{missing_section\}\}/
+  );
+  assert.throws(
+    () => renderTemplate(fullTemplate, vars),
+    /Template rendering issue: unreplaced placeholder\(s\): __MISSING_TOKEN__, \{\{missing_section\}\}/
+  );
+  assert.throws(
+    () => renderTemplate(promptTemplate, vars),
+    /Template rendering issue: unreplaced placeholder\(s\): \{\{prompt_missing_section\}\}/
+  );
+});
+
+test('template renderer allows common Markdown braces and non-placeholder code syntax', () => {
+  const rendered = renderTemplate([
+    '# {{issue_title}}',
+    '',
+    '{{issue_body}}',
+  ].join('\n'), {
+    issue_title: 'Normal syntax examples',
+    issue_body: [
+      'Use object literals like `{ enabled: true }` in examples.',
+      'Shell commands may include `echo ${HOME}`.',
+      'Paths such as `apps/dashboard/src/providers/__tests__/dataProvider.test.ts` are normal source paths.',
+    ].join('\n'),
+  });
+
+  assert.match(rendered, /Normal syntax examples/);
+  assert.match(rendered, /\{ enabled: true \}/);
+  assert.match(rendered, /\$\{HOME\}/);
+  assert.match(rendered, /__tests__/);
 });
 
 test('spec plan distinguishes built-in preset references from repo always_read references', async (t) => {


### PR DESCRIPTION
Closes #75

## Summary
- 在 template renderer 完成變數替換後，加入 deterministic unreplaced placeholder detection。
- 偵測 repo 目前使用的 `{{placeholder}}` pattern，以及明顯的 `__PLACEHOLDER__` uppercase token，避免 broken task package / prompt output 流出。
- 新增 integration coverage，確認 full / prompt 正常 output 不含殘留 placeholder，broken template 會被 renderer 擋下，常見 Markdown braces、shell `${HOME}` 與 `__tests__` path 不會誤判。

## Tests / validation
- `pnpm build`：pass
- `pnpm test`：pass，61 tests pass
- `node --test tests/cli.integration.test.ts`：pass，61 tests pass
- `git diff --check`：pass

## Implementation Evidence
- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/75#issuecomment-4364958601
- Commit: `eb2dbe08062c8e5423aff2d7d64574c769a14dec`

## Scope guard / non-goals confirmation
- 沒有 config schema change。
- 沒有 classifier behavior change。
- 沒有 references discovery behavior change。
- 沒有 task package intended content change；正常 rendered output 維持既有內容，只新增 broken placeholder failure guard。
- 沒有 CI change。
- 沒有新增 dependency。
- 沒有 target repo / tachigo change。
- 沒有處理 #74 / #73 / #135 / #137。