### PR TITLE
fix(references): distinguish unreadable files from missing files

### DIFF
--- a/docs/references.md
+++ b/docs/references.md
@@ -45,7 +45,7 @@ Repo `always_read` references 由 target repo 的 `.spec-injector/config.json` �
 
 `spec config suggest always-read --repo .` 可以 deterministic 掃描候選文件，但只會建議，不會自動修改 config。
 
-Missing `always_read` files 會在 task package 的 Missing Files 中呈現。這是 config health signal，不一定是 fatal plan error。
+Missing `always_read` files 會在 task package 的 Missing Files 中呈現。這是 config health signal，不一定是 fatal plan error。若 path 存在但讀取失敗，Missing Files 會標示為 `read failed` 或 `unreadable`，而不是 `not found`。
 
 在 `spec plan` output 中，repo `always_read` references 會標示為 `repo always_read`，與 built-in preset references 分開。
 
@@ -58,7 +58,7 @@ Issue-mentioned references 是 issue body 中明確提到的 repo-relative file 
 - inline code path：``docs/architecture.md``
 - bullet path：`- src/cli/plan.ts`
 
-Issue-mentioned references 會在 prompt output 與 full task package 中獨立呈現，並標示 source `issue-mentioned` 與 reason `mentioned in issue`。若檔案不存在，會進入 Missing Files。
+Issue-mentioned references 會在 prompt output 與 full task package 中獨立呈現，並標示 source `issue-mentioned` 與 reason `mentioned in issue`。若檔案不存在或讀取失敗，會進入 Missing Files，並保留 `issue-mentioned` source metadata。
 
 這類 references 通常是 strongest issue-local signal，但仍應遵守 scope guard：被提到不代表一定要修改。
 

--- a/docs/task-package.md
+++ b/docs/task-package.md
@@ -68,6 +68,8 @@ Task package 適合用於：
 - listing relevant references before coding
 - preserving repo-defined workflow constraints
 
+Missing Files 會區分 `not found` 與 `read failed` / `unreadable` 類型的 read issue。不存在的 path 才應標示為 `not found`；已被發現但無法讀取的 reference 應保留 source metadata，避免把 read failure 誤當成 missing file。
+
 ## What It Is Not
 
 Task package 不是：

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -233,7 +233,7 @@ function buildTemplateVars(
     prompt_always_files: renderPathList(alwaysDocs.filter((d) => d.found)),
     prompt_issue_docs: renderPathList(issueDocs),
     prompt_issue_sources: renderPathList(issueSources),
-    prompt_discovered_docs: renderPathList(discoveredDocs),
+    prompt_discovered_docs: renderPathList(discoveredDocs.filter((d) => d.found)),
     prompt_rule_docs: renderPathList(discoveryDocs.filter((d) => d.found)),
     prompt_discovered_sources: renderPathList(discoveredSources.filter((d) => d.found)),
     prompt_implementation_constraints: renderImplementationConstraints(matchedGuardrails),

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -91,18 +91,23 @@ export async function plan(
   const filteredDiscoveredDocs = discoveredDocs.filter((d) => !explicitDocPaths.has(d.filePath));
   const filteredDiscoveredSources = discoveredSources.filter((d) => !explicitSourcePaths.has(d.filePath));
   const missingDocs = mergeMissingSections(
-    [...filteredAlwaysDocs, ...filteredDiscoveryDocs].filter((d) => !d.found),
+    [
+      ...filteredAlwaysDocs,
+      ...filteredDiscoveryDocs,
+      ...filteredDiscoveredDocs,
+      ...filteredDiscoveredSources,
+    ].filter((d) => !d.found),
     explicitReferences.missing
   );
-  const combinedSourceReferences = [...explicitSources, ...filteredDiscoveredSources];
+  const combinedSourceReferences = [...explicitSources, ...filteredDiscoveredSources.filter((d) => d.found)];
 
   // 7. Summarise
   const foundAlwaysDocs = filteredAlwaysDocs.filter((d) => d.found);
   const repoAlwaysReadCount = foundAlwaysDocs.filter((d) => d.kind === 'always').length;
   const builtInPresetCount = foundAlwaysDocs.filter((d) => d.kind === 'built-in-preset').length;
-  console.log(`✓ Docs — repo always_read: ${repoAlwaysReadCount}, built-in presets: ${builtInPresetCount}, discovered: ${filteredDiscoveredDocs.length}, explicit: ${explicitDocs.length + filteredDiscoveryDocs.filter(d => d.found).length}, missing: ${missingDocs.length}, sources: ${combinedSourceReferences.length}`);
+  console.log(`✓ Docs — repo always_read: ${repoAlwaysReadCount}, built-in presets: ${builtInPresetCount}, discovered: ${filteredDiscoveredDocs.filter((d) => d.found).length}, explicit: ${explicitDocs.length + filteredDiscoveryDocs.filter(d => d.found).length}, missing/read issues: ${missingDocs.length}, sources: ${combinedSourceReferences.length}`);
   if (missingDocs.length > 0) {
-    for (const d of missingDocs) console.warn(`  ⚠  Not found: ${d.filePath}`);
+    for (const d of missingDocs) console.warn(`  ⚠  ${renderReadDiagnosticLabel(d)}: ${d.filePath}${renderReadErrorCodeSuffix(d)}`);
   }
 
   // 8. Build vars and render
@@ -206,7 +211,7 @@ function buildTemplateVars(
     .join('\n') || '(none found)';
 
   const missingList = missingDocs.length > 0
-    ? missingDocs.map((d) => `- \`${d.filePath}\` — not found${renderMetadataSuffix(d, true)}`).join('\n')
+    ? missingDocs.map((d) => `- \`${d.filePath}\` — ${renderReadIssueLabel(d)}${renderReadIssueMetadataSuffix(d)}`).join('\n')
     : '(none)';
 
   return {
@@ -230,18 +235,54 @@ function buildTemplateVars(
     prompt_issue_sources: renderPathList(issueSources),
     prompt_discovered_docs: renderPathList(discoveredDocs),
     prompt_rule_docs: renderPathList(discoveryDocs.filter((d) => d.found)),
-    prompt_discovered_sources: renderPathList(discoveredSources),
+    prompt_discovered_sources: renderPathList(discoveredSources.filter((d) => d.found)),
     prompt_implementation_constraints: renderImplementationConstraints(matchedGuardrails),
     always_docs: renderDocList(alwaysDocs.filter((d) => d.found)),
     issue_docs: renderDocList(issueDocs),
     issue_sources: renderDocList(issueSources),
-    discovered_docs: renderDocList(discoveredDocs),
+    discovered_docs: renderDocList(discoveredDocs.filter((d) => d.found)),
     rule_docs: renderDocList(discoveryDocs.filter((d) => d.found)),
     missing_docs: missingList,
-    discovered_sources: renderDocList(discoveredSources),
+    discovered_sources: renderDocList(discoveredSources.filter((d) => d.found)),
     repo_path: repoPath,
     generated_at: new Date().toISOString(),
   };
+}
+
+function renderReadIssueLabel(doc: DocSection): string {
+  switch (doc.readStatus ?? 'missing') {
+    case 'unreadable':
+      return 'unreadable';
+    case 'read-error':
+      return 'read failed';
+    case 'missing':
+      return 'not found';
+  }
+}
+
+function renderReadDiagnosticLabel(doc: DocSection): string {
+  switch (doc.readStatus ?? 'missing') {
+    case 'unreadable':
+      return 'Unreadable';
+    case 'read-error':
+      return 'Read failed';
+    case 'missing':
+      return 'Not found';
+  }
+}
+
+function renderReadIssueMetadataSuffix(doc: DocSection): string {
+  const metadata = [
+    ...(doc.readStatus && doc.readStatus !== 'missing' && doc.readErrorCode ? [doc.readErrorCode] : []),
+    ...renderDocMetadata(doc),
+  ];
+  if (metadata.length === 0) return '';
+  return ` (${metadata.join('; ')})`;
+}
+
+function renderReadErrorCodeSuffix(doc: DocSection): string {
+  if (!doc.readStatus || doc.readStatus === 'missing' || !doc.readErrorCode) return '';
+  return ` (${doc.readErrorCode})`;
 }
 
 function mergeReasonSignals(primary: DocSection[], secondary: DocSection[]): DocSection[] {
@@ -264,7 +305,10 @@ function mergeMissingSections(primary: DocSection[], secondary: DocSection[]): D
   for (const doc of [...primary, ...secondary]) {
     const existing = merged.get(doc.filePath);
     if (!existing) {
-      merged.set(doc.filePath, doc);
+      const reasons = new Set<string>(doc.reasons ?? []);
+      const mappedCurrent = reasonForKind(doc.kind);
+      if (mappedCurrent) reasons.add(mappedCurrent);
+      merged.set(doc.filePath, { ...doc, reasons: [...reasons] });
       continue;
     }
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -16,14 +16,17 @@ export async function loadConfig(repoPath: string, opts: LoadConfigOptions = {})
   const specAgentDir = findSpecAgentDir(resolved);
 
   const configPath = path.join(specAgentDir, 'config.json');
-  const configText = await safeReadFile(configPath);
-  if (configText === null) {
+  const configReadResult = await safeReadFile(configPath);
+  if (configReadResult.status === 'missing') {
     return { repoPath: resolved, specAgentDir, specConfig: { version: 2, guardrails: [] } };
+  }
+  if (configReadResult.status !== 'ok') {
+    throw new Error(`Config file is not readable: ${configPath} (${configReadResult.code ?? configReadResult.status})`);
   }
 
   let specConfig: SpecConfig;
   try {
-    specConfig = parseAndValidateConfig(configText, configPath);
+    specConfig = parseAndValidateConfig(configReadResult.content, configPath);
   } catch (err) {
     throw new Error(`Invalid config.json: ${(err as Error).message}`);
   }

--- a/src/docs/finder.ts
+++ b/src/docs/finder.ts
@@ -5,6 +5,17 @@ import { safeReadFile } from '../utils/fs.js';
 import { isPlanDiscoveryExcluded } from './exclusions.js';
 import type { DocSection, DocSourceKind } from './types.js';
 import type { Issue } from '../github/types.js';
+import type { SafeReadFileResult } from '../utils/fs.js';
+
+type SafeReadFileFailure = Extract<SafeReadFileResult, { content: null }>;
+type ScoredReference = {
+  filePath: string;
+  score: number;
+  content: string;
+  found: boolean;
+  readStatus?: DocSection['readStatus'];
+  readErrorCode?: string;
+};
 
 const EXPLICIT_FILE_EXTENSIONS = new Set([
   '.ts', '.tsx', '.js', '.jsx', '.go', '.md', '.json', '.yml', '.yaml', '.sql', '.css', '.html', '.sh',
@@ -14,7 +25,7 @@ const DOC_EXTENSIONS = new Set(['.md']);
 const ISSUE_MENTIONED_REASON = 'mentioned in issue';
 
 // Load explicitly listed doc paths with a given kind label.
-// Missing files get kind 'missing' and found: false.
+// Failed reads keep their source kind and carry a deterministic read status.
 export async function loadExplicitDocs(
   docPaths: string[],
   repoPath: string,
@@ -25,11 +36,11 @@ export async function loadExplicitDocs(
     unique.map(async (docPath): Promise<DocSection> => {
       validateDocPath(docPath, repoPath);
       const absolute = path.resolve(repoPath, docPath);
-      const content = await safeReadFile(absolute);
-      if (content === null) {
-        return { filePath: docPath, content: '', found: false, kind: 'missing' };
+      const readResult = await safeReadFile(absolute);
+      if (readResult.status !== 'ok') {
+        return unreadableDocSection(docPath, kind, readResult);
       }
-      return { filePath: docPath, content, found: true, kind };
+      return { filePath: docPath, content: readResult.content, found: true, kind };
     })
   );
 }
@@ -37,13 +48,16 @@ export async function loadExplicitDocs(
 // Load the built-in core preset from the spec-injector package directory.
 export async function loadCorePreset(): Promise<DocSection> {
   const presetPath = fileURLToPath(new URL('../../presets/core/ai-collaboration.md', import.meta.url));
-  const content = await safeReadFile(presetPath);
-  if (content === null) {
+  const readResult = await safeReadFile(presetPath);
+  if (readResult.status === 'missing') {
     throw new Error('Core preset not found: presets/core/ai-collaboration.md');
+  }
+  if (readResult.status !== 'ok') {
+    throw new Error(`Core preset read failed: presets/core/ai-collaboration.md (${readResult.code ?? readResult.status})`);
   }
   return {
     filePath: 'presets/core/ai-collaboration.md',
-    content,
+    content: readResult.content,
     found: true,
     kind: 'built-in-preset',
   };
@@ -61,22 +75,35 @@ export async function discoverRelevantDocs(
   if (keywords.length === 0) return [];
 
   const candidates = await gatherCandidates(repoPath, excludePaths);
-  const scored: Array<{ filePath: string; score: number; content: string }> = [];
+  const scored: ScoredReference[] = [];
 
   for (const relPath of candidates) {
     const absolute = path.resolve(repoPath, relPath);
-    const content = await safeReadFile(absolute);
-    if (content === null) continue;
-    const score = scoreDoc(keywords, relPath, content);
-    if (score > 0) scored.push({ filePath: relPath, score, content });
+    const readResult = await safeReadFile(absolute);
+    if (readResult.status !== 'ok') {
+      const score = scorePath(keywords, relPath);
+      if (score > 0) scored.push({
+        filePath: relPath,
+        score,
+        content: '',
+        found: false,
+        readStatus: readResult.status,
+        readErrorCode: readResult.code,
+      });
+      continue;
+    }
+    const score = scoreDoc(keywords, relPath, readResult.content);
+    if (score > 0) scored.push({ filePath: relPath, score, content: readResult.content, found: true });
   }
 
   scored.sort((a, b) => b.score - a.score);
 
-  return scored.slice(0, maxDocs).map(({ filePath, content }) => ({
+  return scored.slice(0, maxDocs).map(({ filePath, content, found, readStatus, readErrorCode }) => ({
     filePath,
     content,
-    found: true,
+    found,
+    readStatus,
+    readErrorCode,
     kind: 'discovered' as DocSourceKind,
   }));
 }
@@ -93,15 +120,18 @@ export async function extractExplicitIssueFileReferences(
   for (const filePath of candidates) {
     validateDocPath(filePath, repoPath);
     const absolute = path.resolve(repoPath, filePath);
-    const content = await safeReadFile(absolute);
     const isDoc = isDocReferencePath(filePath);
+    const kind = isDoc ? 'issue-doc' : 'issue-source';
+    const readResult = await safeReadFile(absolute);
 
-    if (content === null) {
+    if (readResult.status !== 'ok') {
       missing.push({
         filePath,
         content: '',
         found: false,
-        kind: 'missing',
+        kind,
+        readStatus: readResult.status,
+        readErrorCode: readResult.code,
         reasons: [ISSUE_MENTIONED_REASON],
       });
       continue;
@@ -109,9 +139,9 @@ export async function extractExplicitIssueFileReferences(
 
     const section: DocSection = {
       filePath,
-      content,
+      content: readResult.content,
       found: true,
-      kind: isDoc ? 'issue-doc' : 'issue-source',
+      kind,
       reasons: [ISSUE_MENTIONED_REASON],
     };
 
@@ -238,14 +268,21 @@ function tokenize(text: string): string[] {
 }
 
 function scoreDoc(keywords: string[], filePath: string, content: string): number {
+  let score = scorePath(keywords, filePath);
+  const sample = content.slice(0, 2000).toLowerCase();
+  for (const kw of keywords) {
+    if (sample.includes(kw)) score += 1;
+  }
+  return score;
+}
+
+function scorePath(keywords: string[], filePath: string): number {
   const pathLower = filePath.toLowerCase();
   const baseLower = path.basename(filePath).toLowerCase();
-  const sample = content.slice(0, 2000).toLowerCase();
   let score = 0;
   for (const kw of keywords) {
     if (pathLower.includes(kw)) score += 2;
     if (baseLower.includes(kw)) score += 2;
-    if (sample.includes(kw)) score += 1;
   }
   return score;
 }
@@ -274,23 +311,53 @@ export async function discoverSourceFiles(
     }
   }
 
-  const scored: Array<{ filePath: string; score: number; content: string }> = [];
+  const scored: ScoredReference[] = [];
   for (const relPath of candidates) {
     const absolute = path.resolve(repoPath, relPath);
-    const raw = await safeReadFile(absolute);
-    if (raw === null) continue;
-    const score = scoreSrc(keywords, relPath, raw);
-    if (score > 0) scored.push({ filePath: relPath, score, content: raw.slice(0, 500) });
+    const readResult = await safeReadFile(absolute);
+    if (readResult.status !== 'ok') {
+      const score = scorePath(keywords, relPath);
+      if (score > 0) {
+        scored.push({
+          filePath: relPath,
+          score,
+          content: '',
+          readStatus: readResult.status,
+          readErrorCode: readResult.code,
+          found: false,
+        });
+      }
+      continue;
+    }
+    const score = scoreSrc(keywords, relPath, readResult.content);
+    if (score > 0) scored.push({ filePath: relPath, score, content: readResult.content.slice(0, 500), found: true });
   }
 
   scored.sort((a, b) => b.score - a.score);
 
-  return scored.slice(0, maxFiles).map(({ filePath, content }) => ({
-    filePath,
-    content,
-    found: true,
+  return scored.slice(0, maxFiles).map((entry) => ({
+    filePath: entry.filePath,
+    content: entry.content,
+    found: entry.found,
+    readStatus: entry.readStatus,
+    readErrorCode: entry.readErrorCode,
     kind: 'source' as DocSourceKind,
   }));
+}
+
+function unreadableDocSection(
+  filePath: string,
+  kind: DocSourceKind,
+  readResult: SafeReadFileFailure
+): DocSection {
+  return {
+    filePath,
+    content: '',
+    found: false,
+    kind,
+    readStatus: readResult.status,
+    readErrorCode: readResult.code,
+  };
 }
 
 function walkSource(dir: string, repoPath: string, results: string[]): void {

--- a/src/docs/types.ts
+++ b/src/docs/types.ts
@@ -13,5 +13,7 @@ export interface DocSection {
   content: string;          // file content (empty string when missing)
   found: boolean;
   kind: DocSourceKind;
+  readStatus?: 'missing' | 'unreadable' | 'read-error';
+  readErrorCode?: string;
   reasons?: string[];
 }

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,11 +1,24 @@
 import fs from 'fs';
 import path from 'path';
 
-export async function safeReadFile(filePath: string): Promise<string | null> {
+export type SafeReadFileStatus = 'ok' | 'missing' | 'unreadable' | 'read-error';
+
+export type SafeReadFileResult =
+  | { status: 'ok'; content: string }
+  | { status: Exclude<SafeReadFileStatus, 'ok'>; content: null; code?: string };
+
+export async function safeReadFile(filePath: string): Promise<SafeReadFileResult> {
   try {
-    return await fs.promises.readFile(filePath, 'utf8');
-  } catch {
-    return null;
+    return { status: 'ok', content: await fs.promises.readFile(filePath, 'utf8') };
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') {
+      return { status: 'missing', content: null, code };
+    }
+    if (code === 'EACCES' || code === 'EPERM') {
+      return { status: 'unreadable', content: null, code };
+    }
+    return { status: 'read-error', content: null, code: code ?? 'UNKNOWN' };
   }
 }
 

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -35,6 +35,41 @@ import {
 
 const UNREPLACED_TEMPLATE_PLACEHOLDER_PATTERN = /\{\{\s*[A-Za-z_][A-Za-z0-9_]*\s*\}\}|__[A-Z][A-Z0-9_]*__/;
 
+async function createReadFailureEnv(
+  t: { after(fn: () => void | Promise<void>): void },
+  baseEnv: NodeJS.ProcessEnv,
+  failures: Array<[string, string]>
+): Promise<NodeJS.ProcessEnv> {
+  const preloadDir = await fs.mkdtemp(path.join(path.dirname(createMissingPath()), 'spec-injector-read-failure-'));
+  t.after(async () => {
+    await fs.rm(preloadDir, { recursive: true, force: true });
+  });
+
+  const preloadPath = path.join(preloadDir, 'read-failure-preload.mjs');
+  await fs.writeFile(preloadPath, [
+    "import fs from 'node:fs';",
+    `const failures = ${JSON.stringify(failures)};`,
+    'const originalReadFile = fs.promises.readFile.bind(fs.promises);',
+    'fs.promises.readFile = async function readFileWithFixtureFailures(filePath, ...args) {',
+    "  const normalized = String(filePath).replaceAll('\\\\', '/');",
+    '  const match = failures.find(([suffix]) => normalized.endsWith(suffix));',
+    '  if (match) {',
+    "    const error = new Error('fixture read failure');",
+    '    error.code = match[1];',
+    '    throw error;',
+    '  }',
+    '  return originalReadFile(filePath, ...args);',
+    '};',
+    '',
+  ].join('\n'), 'utf8');
+
+  const existingNodeOptions = baseEnv.NODE_OPTIONS ?? process.env.NODE_OPTIONS ?? '';
+  return {
+    ...baseEnv,
+    NODE_OPTIONS: [existingNodeOptions, `--import=${preloadPath}`].filter(Boolean).join(' '),
+  };
+}
+
 test('classifier does not treat dashboard transactions endpoint wording as wallet evidence', () => {
   const domains = classifyDomains({
     number: 77,
@@ -1564,6 +1599,57 @@ test('spec plan distinguishes missing files from existing paths that cannot be r
   assert.match(fullResult.stdout, /ISSUE_READABLE_SOURCE_SENTINEL/);
   assert.match(fullResult.stdout, /### docs\/payment-runbook\.md\n\n_source: auto-discovered_/);
   assert.match(fullResult.stdout, /### src\/payment-worker\.ts\n\n_source: auto-discovered_/);
+});
+
+test('spec plan keeps failed auto-discovered references out of prompt reference lists', async (t) => {
+  const fixture = await createExplicitPathPlanFixture(t, {
+    issueNumber: 174,
+    title: 'Payment auto discovery read failure regression',
+    bodyLines: [
+      'Payment work should include readable auto-discovered references only.',
+      'The payment failed doc and source names score by path, but read failures must not be trusted references.',
+    ],
+    config: {
+      discovery: {
+        docs: [],
+        source: ['src'],
+        max_docs: 5,
+        max_source_files: 5,
+      },
+    },
+    repoFiles: {
+      'docs/payment-readable.md': '# Payment Readable\n\nREADABLE_AUTO_DOC_SENTINEL payment\n',
+      'docs/payment-failed.md': '# Payment Failed\n\nFAILED_AUTO_DOC_SENTINEL payment\n',
+      'src/payment-readable.ts': 'export const readablePayment = "READABLE_AUTO_SOURCE_SENTINEL payment";\n',
+      'src/payment-failed.ts': 'export const failedPayment = "FAILED_AUTO_SOURCE_SENTINEL payment";\n',
+    },
+  });
+  const env = await createReadFailureEnv(t, fixture.env, [
+    ['docs/payment-failed.md', 'EIO'],
+    ['src/payment-failed.ts', 'EIO'],
+  ]);
+
+  const promptResult = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'],
+    { env }
+  );
+
+  assert.equal(promptResult.code, 0, promptResult.stderr);
+  assertNoRawStackTrace(promptResult);
+
+  const promptAutoDocs = sectionBetween(promptResult.stdout, '### Auto-Discovered Docs', '### Rule-Matched Docs');
+  const promptAutoSources = sectionBetween(promptResult.stdout, '### Auto-Discovered Source Files', '## 5. Missing Files');
+  const promptMissing = sectionBetween(promptResult.stdout, '## 5. Missing Files', '## 6. Instructions');
+
+  assert.match(promptAutoDocs, /`docs\/payment-readable\.md` — auto-discovered/);
+  assert.doesNotMatch(promptAutoDocs, /docs\/payment-failed\.md/);
+  assert.match(promptAutoSources, /`src\/payment-readable\.ts` — auto-discovered/);
+  assert.doesNotMatch(promptAutoSources, /src\/payment-failed\.ts/);
+
+  assert.match(promptMissing, /`docs\/payment-failed\.md` — read failed \(EIO; auto-discovered\)/);
+  assert.match(promptMissing, /`src\/payment-failed\.ts` — read failed \(EIO; auto-discovered\)/);
+  assert.match(promptResult.stderr, /Read failed: docs\/payment-failed\.md \(EIO\)/);
+  assert.match(promptResult.stderr, /Read failed: src\/payment-failed\.ts \(EIO\)/);
 });
 
 test('spec plan ignores API and route paths when extracting file references', async (t) => {

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -1480,6 +1480,92 @@ test('spec plan reports missing explicit issue-mentioned file paths without fail
   assert.match(fullResult.stdout, /apps\/dashboard\/src\/providers\/missingProvider\.ts/);
 });
 
+test('spec plan distinguishes missing files from existing paths that cannot be read', async (t) => {
+  const fixture = await createExplicitPathPlanFixture(t, {
+    issueNumber: 74,
+    title: 'Distinguish unreadable and missing references',
+    bodyLines: [
+      'Payment references to inspect:',
+      '- `docs/missing-issue.md`',
+      '- `docs/unreadable-issue.md`',
+      '- `src/readable-reference.ts`',
+    ],
+    config: {
+      always_read: [
+        'docs/readable-always.md',
+        'docs/missing-always.md',
+        'docs/unreadable-always.md',
+      ],
+      discovery: {
+        docs: [],
+        source: ['src'],
+        max_docs: 5,
+        max_source_files: 5,
+      },
+    },
+    repoFiles: {
+      'docs/readable-always.md': '# Readable Always\n\nREADABLE_ALWAYS_SENTINEL payment\n',
+      'docs/unreadable-always.md/child.md': '# Directory child\n',
+      'docs/unreadable-issue.md/child.md': '# Directory child\n',
+      'docs/payment-runbook.md': '# Payment Runbook\n\nAUTO_DISCOVERED_PAYMENT_SENTINEL payment\n',
+      'src/readable-reference.ts': 'export const readableReference = "ISSUE_READABLE_SOURCE_SENTINEL payment";\n',
+      'src/payment-worker.ts': 'export const paymentWorker = "AUTO_DISCOVERED_SOURCE_SENTINEL payment";\n',
+    },
+  });
+
+  const promptFirst = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'],
+    { env: fixture.env }
+  );
+  const promptSecond = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'],
+    { env: fixture.env }
+  );
+  const fullResult = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run'],
+    { env: fixture.env }
+  );
+
+  assert.equal(promptFirst.code, 0, promptFirst.stderr);
+  assert.equal(promptSecond.code, 0, promptSecond.stderr);
+  assert.equal(fullResult.code, 0, fullResult.stderr);
+  assert.equal(normalizePlanOutput(promptSecond.stdout), normalizePlanOutput(promptFirst.stdout));
+  assertNoRawStackTrace(promptFirst);
+  assertNoRawStackTrace(fullResult);
+
+  const promptMissing = sectionBetween(promptFirst.stdout, '## 5. Missing Files', '## 6. Instructions');
+  assert.match(promptMissing, /`docs\/missing-issue\.md` — not found \(issue-mentioned; mentioned in issue\)/);
+  assert.match(promptMissing, /`docs\/missing-always\.md` — not found \(repo always_read; always_read\)/);
+  assert.match(promptMissing, /`docs\/unreadable-issue\.md` — read failed \(EISDIR; issue-mentioned; mentioned in issue\)/);
+  assert.match(promptMissing, /`docs\/unreadable-always\.md` — read failed \(EISDIR; repo always_read; always_read\)/);
+  assert.doesNotMatch(promptMissing, /docs\/unreadable-issue\.md` — not found/);
+  assert.doesNotMatch(promptMissing, /docs\/unreadable-always\.md` — not found/);
+  assert.doesNotMatch(promptMissing, /docs\/missing-issue\.md` — read failed/);
+
+  const promptIssueSources = sectionBetween(promptFirst.stdout, '### Issue-Mentioned Source Files', '### Auto-Discovered Docs');
+  assert.match(promptIssueSources, /`src\/readable-reference\.ts` — issue-mentioned; mentioned in issue/);
+  assert.doesNotMatch(promptIssueSources, /read failed|not found/);
+
+  const promptAutoDocs = sectionBetween(promptFirst.stdout, '### Auto-Discovered Docs', '### Rule-Matched Docs');
+  const promptAutoSources = sectionBetween(promptFirst.stdout, '### Auto-Discovered Source Files', '## 5. Missing Files');
+  assert.match(promptAutoDocs, /`docs\/payment-runbook\.md` — auto-discovered/);
+  assert.match(promptAutoSources, /`src\/payment-worker\.ts` — auto-discovered/);
+  assert.doesNotMatch(promptAutoDocs, /issue-mentioned|mentioned in issue/);
+  assert.doesNotMatch(promptAutoSources, /issue-mentioned|mentioned in issue/);
+
+  assert.match(promptFirst.stderr, /Not found: docs\/missing-issue\.md/);
+  assert.match(promptFirst.stderr, /Not found: docs\/missing-always\.md/);
+  assert.match(promptFirst.stderr, /Read failed: docs\/unreadable-issue\.md \(EISDIR\)/);
+  assert.match(promptFirst.stderr, /Read failed: docs\/unreadable-always\.md \(EISDIR\)/);
+  assert.doesNotMatch(promptFirst.stderr, /Not found: docs\/unreadable-issue\.md/);
+  assert.doesNotMatch(promptFirst.stderr, /Not found: docs\/unreadable-always\.md/);
+
+  assert.match(fullResult.stdout, /### src\/readable-reference\.ts\n\n_source: issue-mentioned; mentioned in issue_/);
+  assert.match(fullResult.stdout, /ISSUE_READABLE_SOURCE_SENTINEL/);
+  assert.match(fullResult.stdout, /### docs\/payment-runbook\.md\n\n_source: auto-discovered_/);
+  assert.match(fullResult.stdout, /### src\/payment-worker\.ts\n\n_source: auto-discovered_/);
+});
+
 test('spec plan ignores API and route paths when extracting file references', async (t) => {
   const fixture = await createExplicitPathPlanFixture(t, {
     issueNumber: 83,


### PR DESCRIPTION
Closes #74

## Summary
- 將 reference/file read 結果拆成 deterministic 狀態：not found、unreadable、read failed。
- 讓 issue-mentioned、repo always_read、auto-discovered references 在 read failure 時保留 source metadata，不再把存在但不可讀的 path 誤報成 missing。
- 小幅同步 references / task package 文件，說明 Missing Files 會呈現 read issue 狀態。
- Review follow-up：failed auto-discovered docs / sources 不再出現在 prompt mode 的 Auto-Discovered reference lists，只保留在 Missing Files / diagnostics。

## Tests / validation
- `pnpm build`：pass
- `pnpm test`：pass，63 tests
- `node --test tests/cli.integration.test.ts`：pass，63 tests
- `git diff --check`：pass

## Implementation Evidence
- Original issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/74#issuecomment-4364986919
- Review follow-up comment URL: https://github.com/Erick52106/spec-injector/issues/74#issuecomment-4365006879
- Original commit: ce35d004f01b9107651cd9f2003551c7bac38099
- Latest commit: 07b2a54be4661dbf1df5145d0428a88f1dae9ebd

## Scope guard / non-goals confirmation
- 沒有 config schema change。
- 沒有 classifier behavior change。
- 沒有 references discovery architecture rewrite。
- 沒有 CI change。
- 沒有新增 dependency。
- 沒有 target repo / tachigo change。
- 沒有處理 #75 / #73 / #135 / #137 / #78。
- 沒有 merge；等待 human review / merge decision。