### PR TITLE
feat(references): add path alias hints for issue-mentioned missing files

### DIFF
--- a/docs/references.md
+++ b/docs/references.md
@@ -60,6 +60,14 @@ Issue-mentioned references 是 issue body 中明確提到的 repo-relative file 
 
 Issue-mentioned references 會在 prompt output 與 full task package 中獨立呈現，並標示 source `issue-mentioned` 與 reason `mentioned in issue`。若檔案不存在或讀取失敗，會進入 Missing Files，並保留 `issue-mentioned` source metadata。
 
+若 issue-mentioned path 不存在，spec-injector 會用 deterministic repo path matching 產生保守的 path alias hint。這些 hints 只出現在 Missing Files / diagnostics，並會標示 `not a confirmed issue reference`；hinted path 不會被提升成 issue-mentioned reference，也不會混進 normal references list。
+
+目前 path alias hint 只使用可解釋的 basename match：
+
+- 若只有一個 same-basename candidate，顯示 `possible moved path`。
+- 若有多個 same-basename candidates，顯示 ambiguous count 與有限候選清單。
+- 若沒有 deterministic candidate，維持原本 `not found` 行為。
+
 這類 references 通常是 strongest issue-local signal，但仍應遵守 scope guard：被提到不代表一定要修改。
 
 ## Auto-discovered References

--- a/docs/task-package.md
+++ b/docs/task-package.md
@@ -70,6 +70,8 @@ Task package 適合用於：
 
 Missing Files 會區分 `not found` 與 `read failed` / `unreadable` 類型的 read issue。不存在的 path 才應標示為 `not found`；已被發現但無法讀取的 reference 應保留 source metadata，避免把 read failure 誤當成 missing file。
 
+Issue-mentioned `not found` paths 可能附帶 deterministic path alias hint，例如 same-basename 的 possible moved path 或 ambiguous candidates。這是提示使用者確認 stale / renamed path 的輔助訊號，不是 confirmed reference；原始 missing path 仍會留在 Missing Files。
+
 ## What It Is Not
 
 Task package 不是：

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -107,7 +107,7 @@ export async function plan(
   const builtInPresetCount = foundAlwaysDocs.filter((d) => d.kind === 'built-in-preset').length;
   console.log(`✓ Docs — repo always_read: ${repoAlwaysReadCount}, built-in presets: ${builtInPresetCount}, discovered: ${filteredDiscoveredDocs.filter((d) => d.found).length}, explicit: ${explicitDocs.length + filteredDiscoveryDocs.filter(d => d.found).length}, missing/read issues: ${missingDocs.length}, sources: ${combinedSourceReferences.length}`);
   if (missingDocs.length > 0) {
-    for (const d of missingDocs) console.warn(`  ⚠  ${renderReadDiagnosticLabel(d)}: ${d.filePath}${renderReadErrorCodeSuffix(d)}`);
+    for (const d of missingDocs) console.warn(`  ⚠  ${renderReadDiagnosticLabel(d)}: ${d.filePath}${renderReadDiagnosticHintSuffix(d)}${renderReadErrorCodeSuffix(d)}`);
   }
 
   // 8. Build vars and render
@@ -285,6 +285,11 @@ function renderReadErrorCodeSuffix(doc: DocSection): string {
   return ` (${doc.readErrorCode})`;
 }
 
+function renderReadDiagnosticHintSuffix(doc: DocSection): string {
+  const hint = renderPathAliasHint(doc, { useMarkdown: false });
+  return hint ? `; ${hint}` : '';
+}
+
 function mergeReasonSignals(primary: DocSection[], secondary: DocSection[]): DocSection[] {
   const secondaryByPath = new Map(secondary.map((doc) => [doc.filePath, doc]));
   return primary.map((doc) => {
@@ -362,7 +367,28 @@ function renderDocMetadata(
     metadata.push(opts.includeSourcePrefix ? `source: ${sourceLabel}` : sourceLabel);
   }
   metadata.push(...(doc.reasons ?? []));
+  const aliasHint = renderPathAliasHint(doc, { useMarkdown: true });
+  if (aliasHint) metadata.push(aliasHint);
   return metadata;
+}
+
+function renderPathAliasHint(
+  doc: DocSection,
+  opts: { useMarkdown: boolean }
+): string | null {
+  const hint = doc.pathAliasHints?.[0];
+  if (!hint) return null;
+
+  const candidates = opts.useMarkdown
+    ? hint.candidatePaths.map((candidatePath) => `\`${candidatePath}\``).join(', ')
+    : hint.candidatePaths.join(', ');
+
+  switch (hint.kind) {
+    case 'possible-moved-path':
+      return `path alias hint: possible moved path ${candidates} (${hint.reason}; not a confirmed issue reference)`;
+    case 'ambiguous-same-basename-candidates':
+      return `path alias hint: ambiguous same basename candidates (${hint.candidateCount}): ${candidates} (not a confirmed issue reference)`;
+  }
 }
 
 function referenceSourceLabel(doc: DocSection): string | null {

--- a/src/docs/finder.ts
+++ b/src/docs/finder.ts
@@ -116,6 +116,7 @@ export async function extractExplicitIssueFileReferences(
   const docs: DocSection[] = [];
   const sources: DocSection[] = [];
   const missing: DocSection[] = [];
+  let repoPathAliasCandidates: string[] | null = null;
 
   for (const filePath of candidates) {
     validateDocPath(filePath, repoPath);
@@ -133,6 +134,12 @@ export async function extractExplicitIssueFileReferences(
         readStatus: readResult.status,
         readErrorCode: readResult.code,
         reasons: [ISSUE_MENTIONED_REASON],
+        pathAliasHints: readResult.status === 'missing'
+          ? findPathAliasHints(
+              filePath,
+              repoPathAliasCandidates ??= collectPathAliasCandidatePaths(repoPath)
+            )
+          : undefined,
       });
       continue;
     }
@@ -291,6 +298,7 @@ function scorePath(keywords: string[], filePath: string): number {
 
 const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.py', '.go', '.rs', '.java', '.sol', '.rb']);
 const SKIP_DIRS = new Set(['node_modules', '.git', 'dist', 'build', '.cache', 'vendor', 'coverage']);
+const ALIAS_HINT_SKIP_DIRS = new Set([...SKIP_DIRS, '.spec-injector']);
 
 export async function discoverSourceFiles(
   issue: Issue,
@@ -370,6 +378,69 @@ function walkSource(dir: string, repoPath: string, results: string[]): void {
       results.push(path.relative(repoPath, full));
     }
   }
+}
+
+function collectPathAliasCandidatePaths(repoPath: string): string[] {
+  const results: string[] = [];
+  walkPathAliasCandidates(repoPath, repoPath, results);
+  results.sort(comparePath);
+  return results;
+}
+
+function walkPathAliasCandidates(dir: string, repoPath: string, results: string[]): void {
+  const entries = fs.readdirSync(dir, { withFileTypes: true }).sort((a, b) => comparePath(a.name, b.name));
+  for (const entry of entries) {
+    if (ALIAS_HINT_SKIP_DIRS.has(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkPathAliasCandidates(full, repoPath, results);
+      continue;
+    }
+    if (!entry.isFile()) continue;
+
+    const relativePath = normalizeRepoPath(path.relative(repoPath, full));
+    if (isAliasHintCandidatePath(relativePath)) results.push(relativePath);
+  }
+}
+
+function isAliasHintCandidatePath(filePath: string): boolean {
+  const basename = path.posix.basename(filePath);
+  return EXPLICIT_FILE_EXTENSIONS.has(path.posix.extname(filePath)) || EXPLICIT_ROOT_FILES.has(basename);
+}
+
+function findPathAliasHints(filePath: string, candidatePaths: string[]): DocSection['pathAliasHints'] {
+  const normalizedFilePath = normalizeRepoPath(filePath);
+  const basename = path.posix.basename(normalizedFilePath).toLowerCase();
+  const sameBasenameCandidates = candidatePaths.filter((candidatePath) =>
+    candidatePath !== normalizedFilePath &&
+    path.posix.basename(candidatePath).toLowerCase() === basename
+  );
+
+  if (sameBasenameCandidates.length === 0) return undefined;
+
+  if (sameBasenameCandidates.length === 1) {
+    return [{
+      kind: 'possible-moved-path',
+      reason: 'same basename',
+      candidatePaths: sameBasenameCandidates,
+      candidateCount: 1,
+    }];
+  }
+
+  return [{
+    kind: 'ambiguous-same-basename-candidates',
+    reason: 'same basename',
+    candidatePaths: sameBasenameCandidates.slice(0, 3),
+    candidateCount: sameBasenameCandidates.length,
+  }];
+}
+
+function normalizeRepoPath(filePath: string): string {
+  return filePath.split(path.sep).join('/');
+}
+
+function comparePath(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
 }
 
 function scoreSrc(keywords: string[], filePath: string, content: string): number {

--- a/src/docs/types.ts
+++ b/src/docs/types.ts
@@ -16,4 +16,12 @@ export interface DocSection {
   readStatus?: 'missing' | 'unreadable' | 'read-error';
   readErrorCode?: string;
   reasons?: string[];
+  pathAliasHints?: PathAliasHint[];
+}
+
+export interface PathAliasHint {
+  kind: 'possible-moved-path' | 'ambiguous-same-basename-candidates';
+  reason: 'same basename';
+  candidatePaths: string[];
+  candidateCount: number;
 }

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -1624,6 +1624,75 @@ test('spec plan reports missing explicit issue-mentioned file paths without fail
   assert.match(fullResult.stdout, /apps\/dashboard\/src\/providers\/missingProvider\.ts/);
 });
 
+test('spec plan adds deterministic path alias hints for missing issue-mentioned paths', async (t) => {
+  const fixture = await createExplicitPathPlanFixture(t, {
+    issueNumber: 135,
+    title: 'Add missing issue-mentioned path alias hints',
+    bodyLines: [
+      'Missing references to inspect:',
+      '- `old/path/foo.ts`',
+      '- `old/path/bar.ts`',
+      '- `old/path/missing.ts`',
+      '- `src/readable.ts`',
+    ],
+    config: {
+      discovery: {
+        docs: [],
+        source: [],
+        max_docs: 5,
+        max_source_files: 5,
+      },
+    },
+    repoFiles: {
+      'new/path/foo.ts': 'export const movedFoo = "MOVED_FOO_SENTINEL";\n',
+      'feature/one/bar.ts': 'export const firstBar = "FIRST_BAR_SENTINEL";\n',
+      'feature/two/bar.ts': 'export const secondBar = "SECOND_BAR_SENTINEL";\n',
+      'src/readable.ts': 'export const readable = "READABLE_ISSUE_SENTINEL";\n',
+    },
+  });
+
+  const promptFirst = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'],
+    { env: fixture.env }
+  );
+  const promptSecond = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'],
+    { env: fixture.env }
+  );
+  const fullResult = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run'],
+    { env: fixture.env }
+  );
+
+  assert.equal(promptFirst.code, 0, promptFirst.stderr);
+  assert.equal(promptSecond.code, 0, promptSecond.stderr);
+  assert.equal(fullResult.code, 0, fullResult.stderr);
+  assert.equal(normalizePlanOutput(promptSecond.stdout), normalizePlanOutput(promptFirst.stdout));
+
+  const promptIssueSources = sectionBetween(promptFirst.stdout, '### Issue-Mentioned Source Files', '### Auto-Discovered Docs');
+  const promptMissing = sectionBetween(promptFirst.stdout, '## 5. Missing Files', '## 6. Instructions');
+  const fullIssueSources = sectionBetween(fullResult.stdout, '## 5. Issue-Mentioned Source Files', '## 6. Auto-Discovered Documentation');
+  const fullMissing = sectionBetween(fullResult.stdout, '## 9. Missing Files', '## 10. Suggested Verification Checklist');
+
+  assert.match(promptIssueSources, /`src\/readable\.ts` — issue-mentioned; mentioned in issue/);
+  assert.doesNotMatch(promptIssueSources, /path alias hint/);
+  assert.doesNotMatch(promptIssueSources, /new\/path\/foo\.ts|feature\/one\/bar\.ts|feature\/two\/bar\.ts/);
+  assert.match(fullIssueSources, /### src\/readable\.ts\n\n_source: issue-mentioned; mentioned in issue_/);
+  assert.doesNotMatch(fullIssueSources, /### new\/path\/foo\.ts|### feature\/one\/bar\.ts|### feature\/two\/bar\.ts/);
+
+  assert.match(promptMissing, /`old\/path\/foo\.ts` — not found \(issue-mentioned; mentioned in issue; path alias hint: possible moved path `new\/path\/foo\.ts` \(same basename; not a confirmed issue reference\)\)/);
+  assert.match(fullMissing, /`old\/path\/foo\.ts` — not found \(issue-mentioned; mentioned in issue; path alias hint: possible moved path `new\/path\/foo\.ts` \(same basename; not a confirmed issue reference\)\)/);
+  assert.match(promptFirst.stderr, /Not found: old\/path\/foo\.ts; path alias hint: possible moved path new\/path\/foo\.ts \(same basename; not a confirmed issue reference\)/);
+
+  assert.match(promptMissing, /`old\/path\/bar\.ts` — not found \(issue-mentioned; mentioned in issue; path alias hint: ambiguous same basename candidates \(2\): `feature\/one\/bar\.ts`, `feature\/two\/bar\.ts` \(not a confirmed issue reference\)\)/);
+  assert.match(promptFirst.stderr, /Not found: old\/path\/bar\.ts; path alias hint: ambiguous same basename candidates \(2\): feature\/one\/bar\.ts, feature\/two\/bar\.ts \(not a confirmed issue reference\)/);
+
+  assert.match(promptMissing, /`old\/path\/missing\.ts` — not found \(issue-mentioned; mentioned in issue\)/);
+  assert.doesNotMatch(promptMissing, /old\/path\/missing\.ts[^\n]*path alias hint/);
+  assert.doesNotMatch(promptMissing, /MOVED_FOO_SENTINEL|FIRST_BAR_SENTINEL|SECOND_BAR_SENTINEL/);
+  assert.doesNotMatch(fullMissing, /MOVED_FOO_SENTINEL|FIRST_BAR_SENTINEL|SECOND_BAR_SENTINEL/);
+});
+
 test('spec plan distinguishes missing files from existing paths that cannot be read', async (t) => {
   const fixture = await createExplicitPathPlanFixture(t, {
     issueNumber: 74,
@@ -1757,6 +1826,7 @@ test('spec plan keeps failed auto-discovered references out of prompt reference 
 
   assert.match(promptMissing, /`docs\/payment-failed\.md` — read failed \(EIO; auto-discovered\)/);
   assert.match(promptMissing, /`src\/payment-failed\.ts` — read failed \(EIO; auto-discovered\)/);
+  assert.doesNotMatch(promptMissing, /path alias hint/);
   assert.match(promptResult.stderr, /Read failed: docs\/payment-failed\.md \(EIO\)/);
   assert.match(promptResult.stderr, /Read failed: src\/payment-failed\.ts \(EIO\)/);
 });


### PR DESCRIPTION
Closes #135

## Summary
- 對 issue body 明確提到但 target repo 中不存在的 source/doc paths，新增 deterministic path alias hints。
- Missing Files 仍保留原始 missing path，hinted path 只作為 possible moved path / ambiguous candidate 提示。
- 補充 docs/references.md 與 docs/task-package.md 說明 hint 不是 confirmed issue reference。

## Tests / validation
- `pnpm build`：pass
- `pnpm test`：pass，69 tests
- `node --test tests/cli.integration.test.ts`：pass，69 tests
- `git diff --check`：pass

## Implementation Evidence
- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/135#issuecomment-4365379610
- Commit: `6587b922fde7ac970bde196a29d45c02a4b1c1e6`

## Scope guard / non-goals confirmation
- 沒有 config schema change。
- 沒有 classifier behavior change。
- 沒有 references discovery architecture rewrite。
- 沒有 CI change。
- 沒有新增 dependency。
- 沒有 target repo / tachigo change。
- 沒有處理 #74 / #75 / #73 / #137。