### PR TITLE
fix(classifier): tune database evidence for generic transaction wording

### DIFF
--- a/src/classifier/domain.ts
+++ b/src/classifier/domain.ts
@@ -26,7 +26,7 @@ const DOMAIN_KEYWORDS: Record<string, string[]> = {
   backend: ['server', 'service', 'handler', 'controller', 'middleware', 'worker', 'daemon', 'queue', 'job', 'cron', 'scheduler', 'grpc', 'rpc'],
   api: ['api', 'endpoint', 'rest', 'graphql', 'http', 'route', 'swagger', 'openapi', 'webhook', 'request', 'response'],
   auth: ['auth', 'login', 'logout', 'token', 'jwt', 'oauth', 'session', 'password', 'credential', 'permission', 'role', 'access', 'signup', 'register'],
-  database: ['database', 'db', 'sql', 'query', 'migration', 'schema', 'table', 'model', 'orm', 'postgres', 'mysql', 'mongo', 'redis', 'index', 'transaction'],
+  database: ['database', 'db', 'sql', 'query', 'queries', 'migration', 'schema', 'table', 'column', 'model', 'data model', 'orm', 'repository layer', 'persistence', 'persisted', 'record storage', 'postgres', 'postgresql', 'mysql', 'sqlite', 'mongo', 'redis', 'index', 'prisma', 'drizzle', 'gorm'],
   infra: ['infra', 'deploy', 'docker', 'kubernetes', 'k8s', 'terraform', 'helm', 'nginx', 'network', 'devops', 'provision', 'cloud', 'vm', 'container'],
   'cloud-storage': ['s3', 'gcs', 'storage', 'bucket', 'upload', 'download', 'blob', 'cdn', 'file upload', 'asset', 'object storage'],
   blockchain: ['blockchain', 'on-chain', 'transaction hash', 'tx hash', 'block height', 'contract address', 'token transfer', 'gas', 'nonce', 'ethereum', 'evm', 'solana', 'polygon', 'web3', 'nft', 'defi', 'ledger', 'consensus', 'miner'],
@@ -45,6 +45,9 @@ const GENERIC_WALLET_REASON = 'generic product transaction wording';
 const GENERIC_API_CONTRACT_SIGNALS = ['contract'];
 const GENERIC_API_CONTRACT_CONTEXT = ['api', 'endpoint', 'route', 'request', 'response', 'backend', 'frontend', 'dashboard', 'settings'];
 const GENERIC_API_CONTRACT_REASON = 'generic API contract wording';
+const GENERIC_DATABASE_TRANSACTION_SIGNALS = ['transactions', 'transaction'];
+const GENERIC_DATABASE_TRANSACTION_CONTEXT = ['api', 'backend', 'billing', 'contract', 'dashboard', 'details', 'endpoint', 'frontend', 'history', 'list', 'page', 'product', 'record', 'records', 'request', 'response', 'route', 'settings', 'support', 'user'];
+const GENERIC_DATABASE_TRANSACTION_REASON = 'generic transaction wording';
 
 export function classifyDomains(issue: Issue): string[] {
   return classifyDomainsWithEvidence(issue).domains;
@@ -120,6 +123,11 @@ function buildRejectedDomainReasons(
     if (reason) rejected.push(reason);
   }
 
+  if (!detected.has('database') && hasGenericDatabaseTransactionContext(fields)) {
+    const reason = findRejectedSignal(fields, GENERIC_DATABASE_TRANSACTION_SIGNALS, GENERIC_DATABASE_TRANSACTION_REASON, 'database');
+    if (reason) rejected.push(reason);
+  }
+
   return rejected;
 }
 
@@ -148,4 +156,9 @@ function findRejectedSignal(
 function hasGenericApiContractContext(fields: Array<{ source: DomainEvidenceSource; value: string }>): boolean {
   const text = fields.map(({ value }) => value).join(' ');
   return GENERIC_API_CONTRACT_CONTEXT.some((term) => text.includes(term));
+}
+
+function hasGenericDatabaseTransactionContext(fields: Array<{ source: DomainEvidenceSource; value: string }>): boolean {
+  const text = fields.map(({ value }) => value).join(' ');
+  return GENERIC_DATABASE_TRANSACTION_CONTEXT.some((term) => text.includes(term));
 }

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -288,6 +288,108 @@ test('classifier reports wallet rejected reason for generic product transaction 
   }]);
 });
 
+test('classifier ignores generic transaction records wording for database domain', () => {
+  const issue = {
+    number: 137,
+    title: 'Dashboard transaction records endpoint contract',
+    body: [
+      'Review the billing transaction history list and product transaction page.',
+      'Update the backend route handler and API response contract for user transaction details.',
+      'Keep transaction settings copy aligned with dashboard support workflows.',
+    ].join('\n'),
+    labels: ['api', 'backend'],
+    url: 'https://github.com/Erick52106/spec-injector/issues/137',
+    state: 'open' as const,
+  };
+
+  const first = classifyDomainsWithEvidence(issue);
+  const second = classifyDomainsWithEvidence(issue);
+
+  assert.deepEqual(first, second);
+  assert.ok(first.domains.includes('api'), `Expected api in ${first.domains.join(', ')}`);
+  assert.ok(first.domains.includes('backend'), `Expected backend in ${first.domains.join(', ')}`);
+  assert.ok(!first.domains.includes('database'), `Expected database to be absent from ${first.domains.join(', ')}`);
+  assert.ok(!first.evidence.some((e) => e.domain === 'database'), `Expected no database evidence, got ${JSON.stringify(first.evidence)}`);
+  assert.ok(first.rejected.some((r) =>
+    r.domain === 'database' &&
+    r.signal === 'transaction' &&
+    r.source === 'title' &&
+    r.reason === 'generic transaction wording'
+  ));
+  assert.ok(!first.rejected.some((r) => !['wallet', 'smart-contract', 'database'].includes(r.domain)));
+});
+
+test('classifier keeps database domain for legitimate transaction table evidence', () => {
+  const result = classifyDomainsWithEvidence({
+    number: 137,
+    title: 'Add transaction table migration and SQL schema',
+    body: [
+      'Create a migration for transactions with table columns and indexes.',
+      'Update the repository layer and persistence data model for persisted records.',
+      'Cover PostgreSQL query behavior through the ORM path.',
+    ].join('\n'),
+    labels: ['backend'],
+    url: 'https://github.com/Erick52106/spec-injector/issues/137',
+    state: 'open',
+  });
+
+  assert.ok(result.domains.includes('database'), `Expected database in ${result.domains.join(', ')}`);
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'database' && e.term === 'migration' && e.source === 'title'
+  ));
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'database' && e.term === 'table' && e.source === 'title'
+  ));
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'database' && e.term === 'schema' && e.source === 'title'
+  ));
+  assert.ok(!result.rejected.some((r) => r.domain === 'database'), `Expected no database rejected reason, got ${JSON.stringify(result.rejected)}`);
+});
+
+test('classifier keeps generic transaction API backend wording out of database', () => {
+  const issue = {
+    number: 137,
+    title: 'Transaction endpoint API contract',
+    body: [
+      'Align backend route handler behavior for product transaction details.',
+      'Document request and response examples for the dashboard transaction API.',
+      'Do not change billing dashboard UI layout in this backend-only pass.',
+    ].join('\n'),
+    labels: ['api', 'backend'],
+    url: 'https://github.com/Erick52106/spec-injector/issues/137',
+    state: 'open' as const,
+  };
+
+  const first = classifyDomainsWithEvidence(issue);
+  const second = classifyDomainsWithEvidence(issue);
+
+  assert.deepEqual(first, second);
+  assert.ok(first.domains.includes('api'), `Expected api in ${first.domains.join(', ')}`);
+  assert.ok(first.domains.includes('backend'), `Expected backend in ${first.domains.join(', ')}`);
+  assert.ok(!first.domains.includes('database'), `Expected database to be absent from ${first.domains.join(', ')}`);
+  assert.ok(!first.evidence.some((e) => e.domain === 'database'), `Expected no database evidence, got ${JSON.stringify(first.evidence)}`);
+  assert.deepEqual(first.rejected, [
+    {
+      domain: 'wallet',
+      signal: 'transaction',
+      source: 'title',
+      reason: 'generic product transaction wording',
+    },
+    {
+      domain: 'smart-contract',
+      signal: 'contract',
+      source: 'title',
+      reason: 'generic API contract wording',
+    },
+    {
+      domain: 'database',
+      signal: 'transaction',
+      source: 'title',
+      reason: 'generic transaction wording',
+    },
+  ]);
+});
+
 test('classifier reports deterministic rejected reason for generic API contract wording only', () => {
   const issue = {
     number: 114,


### PR DESCRIPTION
Closes #137

## Summary

- 調整 database domain evidence，移除裸 `transaction` 作為 database keyword，避免 generic product / dashboard / billing transaction wording 單獨觸發 `database`。
- 補強明確 database evidence，例如 `queries`、`column`、`repository layer`、`persistence`、`data model`、`PostgreSQL`、`SQLite`、`Prisma`、`Drizzle`、`GORM` 等 deterministic keyword。
- 新增 generic transaction database rejected reason，讓 verbose diagnostics 可穩定說明 suppressed signal，但不改 default task package / prompt output。

## Tests / validation

- `pnpm build`
- `pnpm test`
- `node --test tests/cli.integration.test.ts`
- `git diff --check`

## Implementation Evidence

- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/137#issuecomment-4365404777
- Commit: `b58cff5020e46cf5a33213685d4155889aa06f8f`

## Scope guard / non-goals

- 沒有 classifier architecture rewrite。
- 沒有 config schema change。
- 沒有 references discovery behavior change。
- 沒有 guardrails behavior change。
- 沒有 template renderer behavior change。
- 沒有 task package output change。
- 沒有 prompt output change。
- 沒有 CI change。
- 沒有新增 dependency。
- 沒有 target repo / tachigo change。
- 沒有處理 #73 / #74 / #75 / #135。
