### PR TITLE
fix(cli): avoid direct process.exit in config command

### DIFF
--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -8,6 +8,10 @@ interface ConfigCommandOptions {
   repo?: string;
 }
 
+function failConfigCommand(message: string): never {
+  throw new Error(message);
+}
+
 export async function config(
   action: string,
   section: string | undefined,
@@ -27,9 +31,7 @@ export async function config(
   const configPath = path.join(repoPath, '.spec-injector', 'config.json');
 
   if (!fs.existsSync(configPath)) {
-    console.error(`✗ No .spec-injector/config.json found at ${configPath}`);
-    console.error(`  Run "spec init --repo ${repoPath}" first.`);
-    process.exit(1);
+    failConfigCommand(`No .spec-injector/config.json found at ${configPath}\n  Run "spec init --repo ${repoPath}" first.`);
   }
 
   if (normalizedAction === 'list') {
@@ -39,13 +41,11 @@ export async function config(
   }
 
   if (section !== 'always-read') {
-    console.error('✗ Unsupported config section. This command currently only supports always-read.');
-    process.exit(1);
+    failConfigCommand('Unsupported config section. This command currently only supports always-read.');
   }
 
   if (!filePath) {
-    console.error(`✗ Missing path. Usage: spec config ${normalizedAction} always-read <path> --repo <repo>`);
-    process.exit(1);
+    failConfigCommand(`Missing path. Usage: spec config ${normalizedAction} always-read <path> --repo <repo>`);
   }
 
   if (normalizedAction === 'add') {
@@ -60,8 +60,7 @@ function parseAction(action: string): ConfigAction {
   if (action === 'list' || action === 'add' || action === 'remove' || action === 'suggest') {
     return action;
   }
-  console.error('✗ Unsupported config action. Use list, add, remove, or suggest.');
-  process.exit(1);
+  failConfigCommand('Unsupported config action. Use list, add, remove, or suggest.');
 }
 
 async function suggestConfig(
@@ -70,13 +69,11 @@ async function suggestConfig(
   filePath: string | undefined
 ): Promise<void> {
   if (section !== 'always-read') {
-    console.error('✗ Unsupported suggest section. Usage: spec config suggest always-read --repo <repo>');
-    process.exit(1);
+    failConfigCommand('Unsupported suggest section. Usage: spec config suggest always-read --repo <repo>');
   }
 
   if (filePath !== undefined) {
-    console.error('✗ The suggest always-read command does not accept a path. Usage: spec config suggest always-read --repo <repo>');
-    process.exit(1);
+    failConfigCommand('The suggest always-read command does not accept a path. Usage: spec config suggest always-read --repo <repo>');
   }
 
   const { suggestAlwaysRead } = await import('./config-suggest.js');
@@ -85,13 +82,11 @@ async function suggestConfig(
 
 function validateListArgs(section: string | undefined, filePath: string | undefined): void {
   if (section !== undefined && section !== 'always-read') {
-    console.error('✗ Unsupported config section. This command currently only supports always-read.');
-    process.exit(1);
+    failConfigCommand('Unsupported config section. This command currently only supports always-read.');
   }
 
   if (filePath !== undefined) {
-    console.error('✗ The list action does not accept a path. Usage: spec config list [always-read] --repo <repo>');
-    process.exit(1);
+    failConfigCommand('The list action does not accept a path. Usage: spec config list [always-read] --repo <repo>');
   }
 }
 
@@ -104,8 +99,7 @@ function readConfig(configPath: string): Record<string, unknown> {
     }
     return raw as Record<string, unknown>;
   } catch (err) {
-    console.error(`✗ Invalid config.json: ${(err as Error).message}`);
-    process.exit(1);
+    failConfigCommand(`Invalid config.json: ${(err as Error).message}`);
   }
 }
 
@@ -113,8 +107,7 @@ function readAlwaysRead(raw: Record<string, unknown>): string[] {
   const value = raw['always_read'];
   if (value === undefined) return [];
   if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
-    console.error('✗ Invalid config.json: always_read must be an array of strings');
-    process.exit(1);
+    failConfigCommand('Invalid config.json: always_read must be an array of strings');
   }
   return value as string[];
 }

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { classifyDomains, classifyDomainsWithEvidence } from '../dist/classifier/domain.js';
+import { config as runConfigCommand } from '../dist/cli/config.js';
 import { renderTemplate } from '../dist/template/renderer.js';
 import { repoRoot, runSpec } from './helpers/cli.ts';
 import {
@@ -34,6 +35,32 @@ import {
 } from './helpers/assertions.ts';
 
 const UNREPLACED_TEMPLATE_PLACEHOLDER_PATTERN = /\{\{\s*[A-Za-z_][A-Za-z0-9_]*\s*\}\}|__[A-Z][A-Z0-9_]*__/;
+
+async function captureConsoleOutput(fn: () => Promise<void>): Promise<{ stdout: string; stderr: string }> {
+  const originalLog = console.log;
+  const originalError = console.error;
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+
+  console.log = (...args: unknown[]) => {
+    stdout.push(args.join(' '));
+  };
+  console.error = (...args: unknown[]) => {
+    stderr.push(args.join(' '));
+  };
+
+  try {
+    await fn();
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+  }
+
+  return {
+    stdout: stdout.length > 0 ? `${stdout.join('\n')}\n` : '',
+    stderr: stderr.length > 0 ? `${stderr.join('\n')}\n` : '',
+  };
+}
 
 async function createReadFailureEnv(
   t: { after(fn: () => void | Promise<void>): void },
@@ -757,6 +784,28 @@ test('spec config list/add/remove always-read manages config entries idempotentl
   const duplicateRemove = await runSpec(['config', 'remove', 'always-read', 'docs/security.md', '--repo', repoDir]);
   assert.equal(duplicateRemove.code, 0, duplicateRemove.stderr);
   assert.match(duplicateRemove.stdout, /does not include: docs\/security\.md/);
+});
+
+test('config command handler lists always-read entries without direct process exit', async (t) => {
+  const repoDir = await createTempRepo(t);
+  await runSpec(['init', '--repo', repoDir]);
+
+  const result = await captureConsoleOutput(async () => {
+    await runConfigCommand('list', undefined, undefined, { repo: repoDir });
+  });
+
+  assert.equal(result.stderr, '');
+  assert.match(result.stdout, /No always_read files configured\./);
+});
+
+test('config command handler throws catchable errors for invalid arguments', async (t) => {
+  const repoDir = await createTempRepo(t);
+  await runSpec(['init', '--repo', repoDir]);
+
+  await assert.rejects(
+    runConfigCommand('add', 'always-read', undefined, { repo: repoDir }),
+    /Missing path\. Usage: spec config add always-read <path> --repo <repo>/
+  );
 });
 
 test('spec config suggest always-read scans fixed and scoring candidates with stable grouped output', async (t) => {


### PR DESCRIPTION
Closes #70

## Summary
- 將 `src/cli/config.ts` 的 config command failure path 改為 throw catchable `Error`，不再由 handler 直接 `process.exit(1)`。
- 保留既有 top-level CLI `.catch()` 統一輸出 stderr 與 non-zero exit code。
- 新增 focused regression tests，覆蓋 handler success path 與 invalid argument failure path，且不需要 mock `process.exit`。

## Tests / validation
- `pnpm build`：pass
- `pnpm test`：pass，74 tests
- `node --test tests/cli.integration.test.ts`：pass，74 tests
- `git diff --check`：pass
- 手動 CLI 行為確認：`spec config list` exit code 0，`spec config add always-read` missing path exit code 1 且 stderr 保持清楚訊息。

## Implementation Evidence
- Issue evidence comment URL：https://github.com/Erick52106/spec-injector/issues/70#issuecomment-4365434982
- Commit hash：5228e5b8f528e1ab5ef8916568f8a3879628a695

## Scope guard / non-goals
- 沒有 config schema change。
- 沒有 CLI architecture rewrite，只沿用 top-level CLI error handler。
- 沒有新增 CLI command / flag。
- 沒有 classifier behavior change。
- 沒有 references discovery behavior change。
- 沒有 template renderer behavior change。
- 沒有 task package / prompt output change。
- 沒有 CI change。
- 沒有新增 dependency。
- 沒有 target repo / tachigo change。
- 沒有處理 #71 大範圍 focused unit tests。
