### PR TITLE
docs(workflow): require merge-time review closeout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,18 @@ Metadata-only 任務可以不用 dedicated worktree，但不得假設 main repo 
 
 PR 必須 ready for review，不要 draft，除非 issue 特別要求。AI agent 不自行 merge PR，也不刪 branch，除非 cleanup audit 已明確要求且 human 確認。
 
+## Merge-time review closeout
+
+Merge 前必須檢查 GitHub review conversations、CodeRabbit findings、Codex auto review findings 與 human review status。
+
+- 每個 actionable finding 必須分類為 adopted、not adopted、noise / not applicable 或 needs human review。
+- 不得在沒有 written reason 的情況下 resolve conversation。
+- 若任何 finding 是 blocking 或 needs human review，不得 merge，必須停下回報。
+- CodeRabbit / Codex auto review 是 auxiliary signals，不是 merge approval。
+- Merge 必須有 explicit human authorization。
+- Merge 後視情況將 linked issues 標成 `status:implemented` 並 close as completed。
+- Per-PR closeout 不刪 branch / worktree；cleanup 之後集中 audit。
+
 ## Evidence and PR body
 
 PR body 必須包含：

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,10 @@
 - 實作型任務預設交給 Codex 或依 human 指示執行。
 - Claude Code 若被要求直接實作，仍必須遵守 `AGENTS.md` 的 worktree-first workflow、scope discipline、evidence workflow、labels workflow、validation rules 與 stop-and-report rules。
 
+## Merge-time review closeout reminder
+
+Claude Code 做 read-only PR review、architecture review 或 planning review 時，必須依 `AGENTS.md`、`docs/workflow.md` 與 `docs/validation.md` 檢查 merge-time review closeout 是否完整。特別是 CodeRabbit / Codex auto review findings 是否已分類與處理、是否存在 unresolved actionable review conversation、stale evidence 或 needs-human-review finding。Claude Code 的 review verdict 不等於 merge authorization；若發現上述未處理事項，不應建議 merge。Conversation resolve、merge execution、issue closeout 仍必須依 canonical workflow 與 explicit human authorization 執行；除非任務明確授權且已有必要佐證，Claude Code 不自行 approve、merge、close issue 或 resolve conversations。
+
 ## Planning discipline
 
 - Claude Code 不應把 suggestion 當 approval。

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -86,8 +86,10 @@ Claude Code 優先負責 planning / review 類工作：
 7. Codex 在 source issue 留 implementation evidence comment。
 8. Codex 將 permanent issue evidence comment URL 回填 PR body，並反查 PR body。
 9. Claude Code 或 ChatGPT 可做 read-only review / risk synthesis / PR review。
-10. Human 做 merge decision。
-11. Merge 後進行 metadata closeout；branch / worktree cleanup 需經 audit 與 human confirmation。
+10. Implementation agent 回覆 / 佐證 review findings，並將採納、不採納、noise / not applicable 或 needs human review 的分類留下可追查紀錄。
+11. Human 做 merge decision；review agent findings、CodeRabbit 或 Codex auto review 不等於 approval。
+12. Merge executor 必須在 merge 前執行 `docs/workflow.md` 的 merge-time review closeout。
+13. Merge 後進行 metadata closeout；branch / worktree cleanup 需經 audit 與 human confirmation。
 
 `spec-injector` 只產出 handoff artifact。Branch、commit、PR、evidence comment、review、merge 與 cleanup 是 surrounding workflow，不是 CLI core 自動執行的 runtime behavior。
 
@@ -130,6 +132,8 @@ PR review agent 應優先檢查：
 - 是否沒有 agent orchestrator、daemon、自動分派、merge automation、CLI behavior change、CI change 或 dependency change，除非 source issue 明確授權。
 
 Review agent 不應直接修改 PR 或 push fix，除非 human 明確要求。Review suggestion 需要 implementation agent 或 human 明確接手，不會自動變成 approval。
+
+Review agent 可以提出 findings、風險與 blocking concerns，但不擁有 merge approval。Implementation agent 必須回覆或佐證 review findings；若 finding 需要 human decision，必須 stop-and-report。Human owns merge decision，負責 merge 的 executor 必須先完成 merge-time review closeout，不能把 review summary 或 bot approval 當作 merge authorization。
 
 ## Concurrency rules
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -300,6 +300,20 @@ A PR is ready for human review only when:
 
 Passing tests alone is not enough if evidence, PR body, scope guard, or CI reporting is missing.
 
+Before merge, review closeout must also confirm:
+
+- PR body includes evidence URL and commit hash.
+- Issue evidence comment exists.
+- CI / required checks pass.
+- CodeRabbit / Codex auto review findings were inspected.
+- GitHub review conversations and human review verdict were inspected.
+- Actionable findings were classified as adopted, not adopted, noise / not applicable, or needs human review.
+- Blocking / needs-human-review findings are not unresolved; if any remain, stop-and-report instead of merging.
+- Conversations are only resolved after written rationale.
+- Human merge authorization exists.
+- Linked issue closeout plan exists.
+- Branch / worktree cleanup is deferred.
+
 ## Stop-and-report Conditions
 
 Stop and report instead of continuing when:

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -143,6 +143,54 @@ PR 建立後要在 source issue 留 implementation evidence comment，再把 iss
 
 CI 通過後，若 PR checklist 有 CI item，應勾選。AI agent 不自行 merge PR。
 
+## Merge-time review closeout
+
+Merge-time review closeout 發生在 human 已決定可以 merge 之後、真正執行 merge 之前。這不是把 bot review 當 approval，而是確認所有 review 訊號都已被處理、記錄且可追查。
+
+Merge 前必須檢查：
+
+- GitHub review threads / review conversations。
+- CodeRabbit findings。
+- Codex auto review findings。
+- Human review verdict。
+- CI / required checks。
+- PR body 的 issue evidence URL。
+- Source issue implementation evidence comment。
+- Latest commit hash。
+
+每個 actionable finding 必須分類：
+
+- `adopted`：採納並完成修正；列出對應 implementation、commit hash 或 relevant commit，以及 validation。
+- `not adopted`：不採納；留下技術理由，說明為何目前不改。
+- `noise / not applicable`：summary、walkthrough、no actionable finding、誤報或與本 PR scope 無關；說明為何不適用。
+- `needs human review`：需要 human decision、scope decision 或風險判斷；stop-and-report，不 merge。
+
+Conversation resolve 規則：
+
+- Resolve conversation 前必須先留下 written rationale。
+- 採納的 finding 應回覆修正內容與 validation。
+- 不採納的 finding 應回覆技術理由。
+- Noise / not applicable finding 應說明為何不適用。
+- Summary / walkthrough / no actionable finding 可以在 closeout log 中記錄為 `noise / not applicable`，不必硬回覆每一則摘要。
+- 不得無說明 resolve review conversation。
+
+Merge authorization 規則：
+
+- CodeRabbit / Codex auto review 是 auxiliary signals，不是 approval。
+- AI agent 不得把 bot review、summary 或 green checks 當作 merge approval。
+- Merge 需要 explicit human authorization。
+- 若存在 valid blocking finding、unresolved actionable finding 或 `needs human review` finding，必須 stop-and-report，不得 merge。
+
+Merge 後 closeout：
+
+- Linked issue 加上 `status:implemented`。
+- 移除 active status labels，例如 `status:in-review`、`status:ready` 或 `status:blocked`，避免 status conflict。
+- 適用時 close as completed。
+- 保留 issue evidence comment、PR body evidence URL、commit hash 與 merge metadata，讓 closeout 可追查。
+- 不在 per-PR closeout 刪 branch / worktree；cleanup 之後集中 audit，並需 human confirmation。
+
+PR #153 / issue #127 是此流程的成功試跑範例：先分類並處理 CodeRabbit / Codex auto review / GitHub review findings，確認 CI、PR body、issue evidence 與 commit hash，再依 human authorization merge，merge 後完成 linked issue metadata closeout。此例是參考案例，不代表本流程只適用 #153。
+
 ## Validation matrix
 
 不同 change type 的 required validation、recommended validation、quality gates 與 stop-and-report conditions 見 `docs/validation.md`。


### PR DESCRIPTION
Closes #154

## Summary

- 在 `AGENTS.md` 新增 merge-time review closeout 的短硬規則，要求 merge 前檢查 GitHub review conversations、CodeRabbit findings、Codex auto review findings 與 human review status。
- 在 `docs/workflow.md` 補上完整 merge-time review closeout 流程，涵蓋 finding classification、conversation resolve、merge authorization、merge 後 linked issue closeout 與 branch / worktree cleanup defer。
- 在 `docs/validation.md` 補上 merge-readiness gates checklist，並在 `docs/agent-handoff.md` 補齊 review / implementation / human / merge executor 分工。
- 在 `CLAUDE.md` 新增短的 Claude-specific reminder，要求 Claude Code 在 read-only PR review、architecture review、planning review 時檢查 merge-time review closeout；`AGENTS.md` 仍是 canonical source。

## Docs / validation

- `git diff --check`：pass
- Markdown sanity check（包含 `CLAUDE.md`，code fence parity / heading sanity）：pass
- Local link check（包含 `CLAUDE.md`）：pass
- `pnpm install --frozen-lockfile`：pass；lockfile unchanged
- `pnpm test`：pass（74 tests, 0 fail）
- GitHub status readback：CI `build` success；CodeRabbit pending at readback，尚未進行 merge closeout。

## Implementation Evidence

- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/154#issuecomment-4365731041
- Commit hash: `da042ab91a2557b61969363d6e3ae912837280f6`

## Scope guard

- 只做 workflow docs。
- `CLAUDE.md` 只新增 thin adapter reminder，沒有成為第二份 canonical workflow spec。
- 沒有和 `AGENTS.md` / `docs/workflow.md` / `docs/validation.md` 產生 drift。
- 沒有 runtime code change。
- 沒有 tests change。
- 沒有 `package.json` / `pnpm-lock.yaml` change。
- 沒有 CI change。
- 沒有新增 dependency。
- 沒有 target repo / tachigo change。
- 沒有實作 review automation / bot。
- 沒有 merge。
- 沒有刪除 branch / worktree。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added merge-time review closeout procedures with standardized checklists
  * Introduced quality gates and validation requirements before merging
  * Established classification system for review findings (adopted, not adopted, noise, needs human review)
  * Clarified merge authorization requirements and explicit human approval process
  * Enhanced handoff flow documentation with detailed implementation and review responsibilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->