### PR TITLE
docs(context): define source trust and context budget strategy

### DIFF
--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -9,6 +9,7 @@
 核心提醒：相鄰工具可以啟發 artifact discipline、workflow clarity、review handoff 與產品呈現，但不應把 `spec-injector` 推向 another Spec Kit、Spec Kitty lite，或 generic agent workflow platform。
 
 產品護城河、non-moat risk register、do-not-build list 與 roadmap ordering 的 source of truth 見 [docs/product-moat.md](product-moat.md)。
+Source trust taxonomy、include modes 與 context budget vocabulary 見 [docs/source-trust.md](source-trust.md)。
 
 ## spec-injector positioning
 

--- a/docs/product-moat.md
+++ b/docs/product-moat.md
@@ -124,9 +124,13 @@ Why it matters: 很多 AI tooling 偏向從 clean spec 或 greenfield lifecycle 
 
 Why it matters: `repo always_read`、`built-in preset`、`issue-mentioned`、`auto-discovered` 的 trust level 不同。把它們清楚標出，能避免 inferred context 被誤讀成 human-approved scope。
 
+Canonical design vocabulary: [docs/source-trust.md](source-trust.md)。
+
 ### Context budget
 
 Why it matters: AI context 不只是 token 成本問題，也是 attention budget 問題。若 `spec-injector` 能清楚定義 full content、summary、reference-only 與 diagnostics 的 include policy，會比 generic prompt collector 更有價值。
+
+Canonical design vocabulary: [docs/source-trust.md](source-trust.md)。
 
 ### Repo-safe no target mutation
 

--- a/docs/references.md
+++ b/docs/references.md
@@ -6,6 +6,8 @@ References 是 task package 中提供給 AI implementer 的 repo context。它�
 
 Reference collection 是 deterministic context selection，不是 general-purpose RAG system。
 
+Source trust levels、include modes、diagnostics vocabulary 與 context budget policy 的 design vocabulary 見 [docs/source-trust.md](source-trust.md)。本文件描述目前 references behavior；`source-trust.md` 描述後續 #129 / #107 / #147 可共用的 trust-labeled context model。
+
 ## Reference Taxonomy
 
 目前與 intended taxonomy 可分成四類：

--- a/docs/source-trust.md
+++ b/docs/source-trust.md
@@ -1,0 +1,256 @@
+# Source Trust And Context Budget
+
+## Purpose
+
+本文件定義 `spec-injector` 如何描述 context source 的 trust label、include mode 與 context budget policy。
+
+它的用途是讓 task package / prompt 在未來演進時，能清楚區分：
+
+- 哪些 source 是 confirmed reference。
+- 哪些 source 只是 hint。
+- 哪些 source 可 full include。
+- 哪些 source 只能 reference-only。
+- 哪些 source 只能 diagnostics-only。
+- 哪些 evidence 可以支援 validation hints。
+- 哪些 output 不應給 AI 錯誤信任訊號。
+
+本文件是 #129 input adapters、#107 catalog / protocol、#147 internal workflow contract 的設計基礎。它不是 runtime implementation，不改現有 task package / prompt output，不是 hidden LLM、RAG、semantic search 或 vector DB design。
+
+## Source Categories
+
+| Source category | How it is produced | Trust implication | Common failure mode | Expected output treatment | Full include? | Caveat needed? |
+| --- | --- | --- | --- | --- | --- | --- |
+| repo `always_read` | target repo `.spec-injector/config.json` 明確列入 | repo author / maintainer 明確要求的 baseline context | path stale、檔案不存在、permission / encoding read issue、內容過大 | 高優先 reference；read issue 進 diagnostics | Yes, if budget allows | 若 missing / unreadable / read failed 必須清楚標示 |
+| built-in preset | `spec-injector` package 內建 preset，例如 core AI collaboration guidance | tool-defined baseline，不是 target repo config | 被誤讀成 repo `always_read`、內容與 target repo policy 衝突 | 與 repo `always_read` 分開標示 source | Yes, if budget allows | 需標示 built-in preset，不代表 target repo approval |
+| issue-mentioned | issue body 明確提到 repo-relative path | issue-local 強訊號；通常最接近 source issue intent | stale path、renamed path、typo、read issue | found 時高優先；missing / read issue 進 diagnostics，保留 source metadata | Yes, high priority | 被提到不等於修改授權；missing 不可靜默忽略 |
+| configured discovery docs | `.spec-injector/config.json` 的 discovery docs / rule-matched docs | config-driven context，不是 classifier 自動 approval | config 過廣、path stale、read issue | reference list 或 budgeted full include；read issue 進 diagnostics | Yes, if budget allows | 應說明 config/rule reason |
+| auto-discovered | deterministic docs/source scan 與 keyword scoring | inferred candidate，輔助理解，不是 human-approved scope | false positive、false negative、generic wording overmatch、too many candidates | reference-only by default 或低優先 budgeted full include | Maybe, after stronger sources | 必須標示 auto-discovered / inferred |
+| diagnostics / missing files | safe read / path resolution / discovery failure | source health signal，不是 reference content | hidden read error、raw stack trace、absolute path leakage | diagnostics-only；不可混入 normal confirmed references | No | 必須可見且語意明確 |
+| path alias hints | missing issue-mentioned path 的 deterministic basename candidate | weak hint；不是 confirmed source | candidate ambiguous、stale issue path、basename coincidence | hint-only in diagnostics near original missing path | No | 必須標示 not confirmed |
+| future raw request / markdown brief inputs | future #129 deterministic input adapter 解析 | external / untrusted until repo confirmation exists | AI-generated partial plan 被誤當 source of truth、paste 內容缺 repo evidence | input provenance + extracted candidates；需 attached trust labels | No by default | 必須清楚標示 external / unconfirmed |
+
+## Trust Levels
+
+以下 trust levels 是 design vocabulary，不代表目前 runtime 已經完整實作。
+
+### confirmed
+
+Source exists and was explicitly required or deterministically selected with a stable reason. `confirmed` 表示 path / content 可讀且 source metadata 可追蹤，但不等於 human approval to edit。
+
+### strong
+
+Repo `always_read`、built-in preset、found issue-mentioned source 屬於 strong signal。它們通常應優先被保留，並在 budget 壓力下優先於 auto-discovered candidates。
+
+### medium
+
+Auto-discovered 或 configured discovery source 若有 deterministic reason，可視為 medium。它有助於 AI understanding，但仍可能是 false positive，不應被寫成 issue author 明確指定。
+
+### weak / hint
+
+Path alias hint、ambiguous candidate、inferred relation 屬於 weak / hint。它只能提醒 human / AI 檢查可能的 renamed path 或相關 candidate，不能升格成 confirmed reference。
+
+### diagnostic
+
+Missing、unreadable、read failed、rejected classifier evidence、omitted due to budget 都是 diagnostic signal。它們應可見、可審查，但不提供 reference content。
+
+### untrusted / external
+
+Future raw request、markdown brief、AI-generated partial plan、external pasted text 在 repo confirmation 前應視為 untrusted / external。它可以提供 request intent，但不應直接驅動 confirmed references 或 validation hints。
+
+## Include Modes
+
+### full-include
+
+Reference content included in the full task package. AI 可以讀到內容，但仍需遵守 issue scope、repo instructions 與 human approval。
+
+Prompt compact output 應只包含 path / source label，而不是無限制塞入全文。Full include 不應用於 hint、diagnostic 或 untrusted external input。
+
+### reference-only
+
+Output lists path、source label、reason，content not included。適合 prompt compact output、large files、低優先 auto-discovered candidates，或 budget 壓力下仍需保留可見性的位置。
+
+### diagnostics-only
+
+Output surfaces warning / missing / unreadable / read failed / rejected / omitted reason。它可以進 full task package 與 prompt compact output 的 diagnostics section，但不應進 normal reference list。
+
+### hint-only
+
+Displayed as possible path / candidate near the diagnostic that caused it. Alias hints 必須保留 "not confirmed" 語意，不可被 normal reference rendering 或 future protocol 當成 found reference。
+
+### excluded
+
+Source intentionally omitted due to budget, safety, irrelevance, duplicate coverage, or exclusion rules。若 omitted source 來自 strong / explicit signal，應留下 visible reason；低價值 auto-discovered candidate 可被 deterministic limits 排除，但不能影響 diagnostics visibility。
+
+## Context Budget Policy
+
+Context budget 應先採 rule-based priority order，不設計 complex scoring algorithm。
+
+### Priority Order
+
+1. Issue body、human prompt、repo instructions。
+2. Issue-mentioned found references。
+3. Repo `always_read` and built-in preset baseline context。
+4. Configured discovery docs / rule-matched docs。
+5. Auto-discovered docs。
+6. Auto-discovered source candidates。
+7. Weak hints and diagnostics, displayed outside normal references。
+
+優先順序不等於修改權限。它只決定 context visibility 與 budget retention。
+
+### Full Include Limit
+
+Full include 應保守，優先給 explicit / strong sources。若 strong sources 已經填滿 budget，auto-discovered sources 應降級為 reference-only，而不是擠掉 issue-mentioned content。
+
+未來 implementation 可以用固定 item count、固定 byte / token estimate、或 config-driven limit，但必須 deterministic、可測試，且不可依賴 model confidence。
+
+### Reference-only Fallback
+
+當檔案太大、candidate 太多、或 priority 較低時，降級為 reference-only。Reference-only output 應保留 path、source category、reason、以及必要 caveat，避免 silent omission。
+
+### Diagnostics Always Visible
+
+Missing、unreadable、read failed、ambiguous alias candidates、important budget omissions 應保持 visible。Prompt compact mode 不應因為省 token 而隱藏 critical diagnostics。
+
+### Large Files
+
+Large files 不應被無限制 full include。設計上可採：
+
+- strong / explicit large file: reference-only plus "omitted or truncated due to budget" reason。
+- auto-discovered large file: reference-only by default。
+- diagnostics for read issues remain visible。
+
+不要用 hidden summarization 假裝 full include。若未來要做 summary，必須另有 deterministic / inspectable design issue。
+
+### Too Many Auto-discovered Docs
+
+Auto-discovered docs 應受 deterministic max limit。當 candidates 過多：
+
+- 先保留 path / reason 排序穩定。
+- 讓 lower-ranked candidates excluded 或 reference-only。
+- 不得擠掉 issue-mentioned / always_read。
+- 若 output 暗示 "complete relevant docs"，必須避免；應稱為 candidates。
+
+### Ambiguous Alias Candidates
+
+Ambiguous alias candidates 只能 hint-only。它們應出現在 original missing issue-mentioned path 附近，顯示有限候選清單與 candidate count。不得把任一 candidate 升級成 confirmed reference。
+
+### Avoiding Prompt Bloat
+
+Prompt compact output 應偏向 reference-only + diagnostics summary。Full content 應留在 full task package，且受 budget limit。Prompt 的目標是讓 AI 產生 plan，不是把 repo dump 進聊天上下文。
+
+### Avoiding Silent Omission
+
+Strong / explicit source 被降級或 omitted 時，應留下 visible reason。Low-priority auto-discovered candidate 因 max limit 未出現時，可以依 deterministic limit 處理，但若它曾進入 selected set 又被 budget trim，應記錄 reason。
+
+## Trust x Include Matrix
+
+| Source state | Design trust level | Preferred include mode | Current behavior note | Proposed interpretation |
+| --- | --- | --- | --- | --- |
+| repo `always_read` + found | strong / confirmed | full-include if budget allows; otherwise high-priority reference-only | Currently included with source label | Treat as baseline context, not edit approval |
+| repo `always_read` + missing / read issue | diagnostic | diagnostics-only | Currently appears in Missing Files with read status | Keep visible as config health signal |
+| built-in preset + found | strong / confirmed | full-include or reference-only depending budget | Currently included with `built-in preset` source label | Keep separate from repo `always_read` |
+| issue-mentioned + found | strong / confirmed | full-include or highest-priority reference-only | Currently separate issue-mentioned docs/source sections | Preserve before auto-discovered sources |
+| issue-mentioned + missing | diagnostic | diagnostics-only plus optional hint-only alias hint | Currently Missing Files keeps source metadata and alias hints | Never silently drop original missing path |
+| path alias hint | weak / hint | hint-only | Currently says not a confirmed issue reference | Never enter normal reference list |
+| configured discovery doc + found | medium / confirmed by config | full-include if budget allows; otherwise reference-only | Currently rule/config docs are distinct | Show config/rule reason |
+| auto-discovered doc/source + found | medium | reference-only or low-priority budgeted full-include | Currently auto-discovered sections are separate | Treat as candidate, not issue author signal |
+| auto-discovered + read failed | diagnostic | diagnostics-only | Currently can appear as missing/read issue if selected | Keep source reason, no raw stack trace |
+| rejected classifier evidence | diagnostic | diagnostics-only | Currently verbose diagnostics can show rejected signals | Use for explainability, not reference selection by itself |
+| future raw request / AI partial plan | untrusted / external | input provenance; no full include until repo-confirmed | Not implemented | Adapter must attach trust labels before compilation |
+
+## Failure And Diagnostic Vocabulary
+
+Diagnostics should be visible, short, and safe to show in task package / prompt.
+
+### not found
+
+The repo-relative path was requested or selected, but no file exists at that path. Use for true missing paths, not permission or read failures.
+
+### unreadable
+
+The path exists or was discovered, but the file cannot be read due to permission or access constraints. Show the stable error code when useful; do not show raw stack trace.
+
+### read failed
+
+The path exists or was selected, but reading failed for an IO / encoding / unexpected read reason. Preserve source metadata and avoid treating it as missing.
+
+### ambiguous alias candidates
+
+The original path is missing and deterministic matching found multiple same-basename candidates. Show limited candidates and total count; label them as not confirmed.
+
+### rejected classifier evidence
+
+A classifier signal was observed but suppressed because it was too generic or lower-confidence than stronger evidence. This is diagnostic context, not a source reference.
+
+### source omitted due to budget
+
+A selected source was not full-included because of budget, size, priority, safety, or duplicate coverage. Strong / explicit sources should leave a visible reason.
+
+### source included as hint, not confirmed
+
+The output contains a candidate path or relation for human review only. It must not be rendered as a normal reference or used as edit scope.
+
+Diagnostics should not expose raw stack traces or unnecessary local absolute paths. Repo-relative paths and stable error labels are preferred.
+
+## Relationship To Existing Behavior
+
+The current codebase already contains pieces that support this design:
+
+- #74 distinguished `not found`, `unreadable`, and `read failed`, which makes diagnostic trust possible.
+- #75 added unreplaced placeholder detection, reducing the risk that task package output silently carries invalid template state.
+- #73 and #137 tuned classifier false positives, showing why rejected / weak evidence must stay separate from strong source trust.
+- #82 separated built-in preset from repo `always_read`, preventing tool baseline context from being mistaken for repo config.
+- #84 separated issue-mentioned references from auto-discovered references, preserving stronger issue-local signals.
+- #113 external config support lets dogfood run read-only without mutating target repos, reinforcing source provenance and repo-safe diagnostics.
+- #135 path alias hints prove that missing issue-mentioned paths can produce deterministic hints without pretending the hinted path is confirmed.
+- #151 second brownfield dogfood should validate whether this trust / budget vocabulary is useful outside the first target repo sample.
+
+These are existing supports, not proof that the full trust / budget model is implemented.
+
+## Relationship To Future Issues
+
+- #129 input adapters must attach trust labels before raw request, markdown brief, PR note, dogfood report, or AI-generated partial plan enters context compilation.
+- #107 catalog / protocol should encode source category, trust level, include mode, diagnostic vocabulary, and compatibility rules.
+- #147 internal workflow contract may consume source trust metadata for repo workflow checks, but source trust remains product/compiler design, not a harness platform.
+- #151 second dogfood should measure whether trust labels, diagnostics, alias hints, and budget fallback help real brownfield planning.
+- #108 / #109 / #110 workflow guardrails may check evidence completeness or workflow consistency, but they should not define source trust semantics.
+
+## Do-not-build / Non-goals
+
+Do not build:
+
+- hidden LLM / RAG / semantic search
+- vector DB
+- source trust by model confidence
+- target repo auto-editing
+- alias hint as confirmed reference
+- future AI-generated partial plan as trusted source
+- runtime source trust implementation in this PR
+- context budget algorithm implementation in this PR
+- task package / prompt output changes in this PR
+- config schema changes
+- new CLI command / flag
+- JSON / machine-readable output runtime
+
+## Acceptance Criteria For Future Implementation
+
+These criteria are for future implementation issues, not this PR's runtime behavior.
+
+- Task package clearly labels confirmed, hint, diagnostic, and external sources.
+- Prompt compact mode does not hide critical diagnostics.
+- Issue-mentioned references outrank auto-discovered references.
+- Budget trimming is deterministic and test-covered.
+- Important omitted sources leave visible reasons.
+- Alias hints never enter normal references as confirmed files.
+- Large files degrade to reference-only or deterministic truncation with visible reason.
+- Tests cover trust label ordering, include mode selection, diagnostics visibility, and budget fallback.
+- Future structured output uses stable names that align with #107 catalog / protocol.
+- Future input adapters from #129 mark external / untrusted text before reference extraction.
+
+## Decision Summary
+
+- Canonical vocabulary: source category, trust level, include mode, diagnostics, budget fallback.
+- Canonical trust distinction: confirmed / strong / medium / weak hint / diagnostic / untrusted external.
+- Canonical include distinction: full-include / reference-only / diagnostics-only / hint-only / excluded.
+- Deferred: runtime implementation, context budget algorithm, structured output, input adapters, catalog protocol, workflow contract consumers.
+- Must not be built: hidden LLM, RAG, vector DB, source trust by model confidence, target repo auto-editing, or hint-to-reference promotion.

--- a/docs/task-package.md
+++ b/docs/task-package.md
@@ -6,6 +6,8 @@ Task package 是 AI 開工前使用的 structured context。它把 issue、class
 
 Task package 不是 autonomous execution plan，也不包含 hidden LLM reasoning。
 
+Task package 未來的 source trust / context budget vocabulary 見 [docs/source-trust.md](source-trust.md)。該文件定義 confirmed / hint / diagnostic source、full-include / reference-only / diagnostics-only 等設計語彙，但不代表目前 output 行為已改變。
+
 ## Current Outputs
 
 目前 `spec plan` 支援兩種主要輸出：


### PR DESCRIPTION
Closes #130

## Summary

- 新增 `docs/source-trust.md`，定義 source categories、trust levels、include modes、context budget policy、trust x include matrix、diagnostic vocabulary、future implementation acceptance criteria 與 non-goals。
- 在 `docs/positioning.md`、`docs/references.md`、`docs/task-package.md`、`docs/product-moat.md` 加入短連結，讓既有 positioning / references / task package docs 指向 canonical source trust vocabulary。
- 明確將 #129 input adapters、#107 catalog / protocol、#147 internal workflow contract、#151 second dogfood 與本設計的關係分開，避免把未來能力寫成已實作 runtime。

## Docs / validation

- `git diff --check` - pass
- `git diff --cached --check` - pass
- `node -e '...'` markdown sanity check for changed docs - pass
- `node -e '...'` local link check for changed docs - pass
- `pnpm install --frozen-lockfile` - pass；`pnpm-lock.yaml` 未變更
- `pnpm test` - pass；89 tests, 0 failures

## Implementation Evidence

- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/130#issuecomment-4365859563
- Commit hash: `a5fed203bf8055516284a18d758070da56d67b0a`

## Scope guard / non-goals confirmation

- 這是 source trust / context budget design PR。
- 沒有 runtime code change。
- 沒有 tests change。
- 沒有 package.json / lockfile change。
- 沒有 CI change。
- 沒有 task package / prompt output change。
- 沒有實作 source trust runtime。
- 沒有實作 context budget algorithm。
- 沒有實作 #129 / #107 / #147。
- 沒有 hidden LLM / RAG / semantic search / vector DB。
- 沒有 target repo / tachigo change。
