### PR TITLE
docs(workflow): require necessity assessment for auto-review findings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,11 @@ PR 必須 ready for review，不要 draft，除非 issue 特別要求。AI agent
 
 Merge 前必須檢查 GitHub review conversations、CodeRabbit findings、Codex auto review findings 與 human review status。
 
-- 每個 actionable finding 必須分類為 adopted、not adopted、noise / not applicable 或 needs human review。
+- Automated review findings are signals, not commands.
+- 修任何 CodeRabbit / Codex auto review / automated review finding 前，必須先評估修正必要性並分類為 adopted、not adopted、optional polish、noise / not applicable 或 needs human review。
+- 只有在本 PR scope 內的 adopted findings 才能修；不要為了滿足 bot comment 產生 commit noise。
+- Not adopted、optional polish、noise / not applicable findings 仍必須留下 written rationale。
+- 若 finding 需要擴 scope 或不確定的 human judgment，必須 stop-and-report。
 - 不得在沒有 written reason 的情況下 resolve conversation。
 - 若任何 finding 是 blocking 或 needs human review，不得 merge，必須停下回報。
 - CodeRabbit / Codex auto review 是 auxiliary signals，不是 merge approval。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@
 
 ## Merge-time review closeout reminder
 
-Claude Code 做 read-only PR review、architecture review 或 planning review 時，必須依 `AGENTS.md`、`docs/workflow.md` 與 `docs/validation.md` 檢查 merge-time review closeout 是否完整。特別是 CodeRabbit / Codex auto review findings 是否已分類與處理、是否存在 unresolved actionable review conversation、stale evidence 或 needs-human-review finding。Claude Code 的 review verdict 不等於 merge authorization；若發現上述未處理事項，不應建議 merge。Conversation resolve、merge execution、issue closeout 仍必須依 canonical workflow 與 explicit human authorization 執行；除非任務明確授權且已有必要佐證，Claude Code 不自行 approve、merge、close issue 或 resolve conversations。
+Claude Code 做 read-only PR review、architecture review 或 planning review 時，必須依 `AGENTS.md`、`docs/workflow.md` 與 `docs/validation.md` 檢查 merge-time review closeout 是否完整，並確認 automated review findings 已先做 necessity assessment。Claude Code 的 review verdict 不等於 merge authorization；若發現 automated review finding 被一股腦照修、conversation 無 written rationale 就被 resolve，或 needs-human-review finding 未處理，應標記風險並不建議 merge。Conversation resolve、merge execution、issue closeout 與完整 classification flow 仍以 canonical workflow 與 explicit human authorization 為準；除非任務明確授權且已有必要佐證，Claude Code 不自行 approve、merge、close issue 或 resolve conversations。
 
 ## Planning discipline
 

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -86,10 +86,11 @@ Claude Code 優先負責 planning / review 類工作：
 7. Codex 在 source issue 留 implementation evidence comment。
 8. Codex 將 permanent issue evidence comment URL 回填 PR body，並反查 PR body。
 9. Claude Code 或 ChatGPT 可做 read-only review / risk synthesis / PR review。
-10. Implementation agent 回覆 / 佐證 review findings，並將採納、不採納、noise / not applicable 或 needs human review 的分類留下可追查紀錄。
-11. Human 做 merge decision；review agent findings、CodeRabbit 或 Codex auto review 不等於 approval。
-12. Merge executor 必須在 merge 前執行 `docs/workflow.md` 的 merge-time review closeout。
-13. Merge 後進行 metadata closeout；branch / worktree cleanup 需經 audit 與 human confirmation。
+10. Review agent 提出的 finding 不等於命令；Implementation agent 應先評估 finding necessity，再決定是否修正。
+11. Implementation agent 回覆 / 佐證 review findings，並將 adopted、not adopted、optional polish、noise / not applicable 或 needs human review 的分類留下可追查紀錄。
+12. Human 做 merge decision；review agent findings、CodeRabbit 或 Codex auto review 不等於 approval。
+13. Merge executor 必須在 merge 前執行 `docs/workflow.md` 的 merge-time review closeout，確認 automated review findings 已分類並有佐證。
+14. Merge 後進行 metadata closeout；branch / worktree cleanup 需經 audit 與 human confirmation。
 
 `spec-injector` 只產出 handoff artifact。Branch、commit、PR、evidence comment、review、merge 與 cleanup 是 surrounding workflow，不是 CLI core 自動執行的 runtime behavior。
 
@@ -131,9 +132,9 @@ PR review agent 應優先檢查：
 - 是否沒有 hidden LLM / external AI API / local model integration。
 - 是否沒有 agent orchestrator、daemon、自動分派、merge automation、CLI behavior change、CI change 或 dependency change，除非 source issue 明確授權。
 
-Review agent 不應直接修改 PR 或 push fix，除非 human 明確要求。Review suggestion 需要 implementation agent 或 human 明確接手，不會自動變成 approval。
+Review agent 不應直接修改 PR 或 push fix，除非 human 明確要求。Review suggestion / finding 不等於命令，需要 implementation agent 或 human 明確接手，不會自動變成 approval。
 
-Review agent 可以提出 findings、風險與 blocking concerns，但不擁有 merge approval。Implementation agent 必須回覆或佐證 review findings；若 finding 需要 human decision，必須 stop-and-report。Human owns merge decision，負責 merge 的 executor 必須先完成 merge-time review closeout，不能把 review summary 或 bot approval 當作 merge authorization。
+Review agent 可以提出 findings、風險與 blocking concerns，但不擁有 merge approval。Implementation agent 必須先評估 finding necessity，再回覆、佐證或修正 review findings；若 finding 需要 human decision，必須 stop-and-report。Human owns merge decision，負責 merge 的 executor 必須先確認 findings 已分類並有佐證，完成 merge-time review closeout，不能把 review summary 或 bot approval 當作 merge authorization。
 
 ## Concurrency rules
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -306,8 +306,15 @@ Before merge, review closeout must also confirm:
 - Issue evidence comment exists.
 - CI / required checks pass.
 - CodeRabbit / Codex auto review findings were inspected.
+- Automated review findings have been inspected.
+- Each actionable finding is classified according to `docs/workflow.md` as adopted, not adopted, optional polish, noise / not applicable, or needs human review.
+- Adopted findings have implementation / validation evidence.
+- Not adopted / optional polish / noise findings have written rationale.
+- Needs-human-review findings are not unresolved.
+- No conversation is resolved without written rationale.
+- No commit noise was introduced solely to satisfy a bot comment.
+- If the finding requires scope expansion, merge is blocked until human decision.
 - GitHub review conversations and human review verdict were inspected.
-- Actionable findings were classified as adopted, not adopted, noise / not applicable, or needs human review.
 - Blocking / needs-human-review findings are not unresolved; if any remain, stop-and-report instead of merging.
 - Conversations are only resolved after written rationale.
 - Human merge authorization exists.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -143,6 +143,49 @@ PR 建立後要在 source issue 留 implementation evidence comment，再把 iss
 
 CI 通過後，若 PR checklist 有 CI item，應勾選。AI agent 不自行 merge PR。
 
+## Automated review finding assessment
+
+Automated review finding assessment 適用於 CodeRabbit、Codex auto review、other automated review tools 與 GitHub review bot comments。
+
+原則：
+
+- Auto review 是訊號，不是命令。
+- 不可一股腦照修 automated review findings。
+- 只有分類為 `adopted` 且在本 PR scope 內的 finding 才修。
+- 不採納也要留下佐證，讓 reviewer 能追查採納與不採納的理由。
+- Summary、walkthrough、no actionable finding 可列為 `noise / not applicable`。
+- Finding 需要 human 判斷、scope decision 或風險不確定時，必須 stop-and-report。
+- CodeRabbit / Codex auto review 是 auxiliary signals，不是 approval；human merge decision 仍是唯一 merge 授權來源。
+
+分類定義：
+
+- `adopted`：finding 確實是 bug、risk 或 repo convention violation，且在本 PR scope 內。修正後必須留下 implementation evidence、validation evidence、commit hash 或 relevant commit。
+- `not adopted`：finding 不適用、會造成反效果，或與 repo design principle / workflow rule 衝突。必須留言說明技術理由，不得用沉默取代決策。
+- `optional polish`：finding 合理但非 blocking，不應阻擋 merge，可留待 follow-up 或 future cleanup。必須說明為何本 PR 不處理。
+- `noise / not applicable`：finding 是誤判、summary-only、walkthrough-only、已過期、已不成立，或不屬於本 PR scope。必須說明不適用理由。
+- `needs human review`：finding 不確定、需要 human decision、需要 scope expansion 或需要風險判斷。必須 stop-and-report，不 merge。
+
+Conversation resolve 規則：
+
+- 只有在留下 written rationale 後才可 resolve conversation。
+- `adopted` finding 應回覆修正內容與 validation。
+- `not adopted` finding 應回覆技術理由。
+- `optional polish` finding 應回覆為何不在本 PR 處理，以及是否需要 follow-up。
+- `noise / not applicable` finding 應回覆或記錄為何不適用。
+- 不要無說明 resolve conversation。
+- 如果 finding 沒有獨立 thread，或只是 summary / walkthrough / no actionable finding，可在 closeout log 記錄為 `noise / not applicable`，不必硬 resolve。
+
+Example:
+
+- PR #156 的 CodeRabbit finding 指出 `docs/source-trust.md` 可能缺 EOF trailing newline。
+- Codex 先 readback 檢查最後 byte 為 `0x0a`。
+- Finding 已不成立。
+- Classification: `noise / not applicable`。
+- Codex 留下 comment 佐證。
+- 不修改檔案，不產生 commit noise。
+
+本節不是 auto-fix 流程，也不暗示 bot findings 必須全部修正。
+
 ## Merge-time review closeout
 
 Merge-time review closeout 發生在 human 已決定可以 merge 之後、真正執行 merge 之前。這不是把 bot review 當 approval，而是確認所有 review 訊號都已被處理、記錄且可追查。
@@ -162,6 +205,7 @@ Merge 前必須檢查：
 
 - `adopted`：採納並完成修正；列出對應 implementation、commit hash 或 relevant commit，以及 validation。
 - `not adopted`：不採納；留下技術理由，說明為何目前不改。
+- `optional polish`：合理但非 blocking；說明為何本 PR 不處理，以及是否需要 follow-up。
 - `noise / not applicable`：summary、walkthrough、no actionable finding、誤報或與本 PR scope 無關；說明為何不適用。
 - `needs human review`：需要 human decision、scope decision 或風險判斷；stop-and-report，不 merge。
 
@@ -170,6 +214,7 @@ Conversation resolve 規則：
 - Resolve conversation 前必須先留下 written rationale。
 - 採納的 finding 應回覆修正內容與 validation。
 - 不採納的 finding 應回覆技術理由。
+- Optional polish finding 應回覆為何不在本 PR 處理，以及是否需要 follow-up。
 - Noise / not applicable finding 應說明為何不適用。
 - Summary / walkthrough / no actionable finding 可以在 closeout log 中記錄為 `noise / not applicable`，不必硬回覆每一則摘要。
 - 不得無說明 resolve review conversation。


### PR DESCRIPTION
Closes #157

## Summary

- 在 `AGENTS.md` 補上短而硬的 canonical rule：automated review findings are signals, not commands，修正前必須先做 necessity assessment。
- 在 `docs/workflow.md` 新增完整 Automated review finding assessment 流程，涵蓋 CodeRabbit / Codex auto review / GitHub review bot comments、分類定義、conversation resolve 規則與 PR #156 EOF newline finding 範例。
- 在 `docs/validation.md` 補上 merge-readiness / review finding assessment gate，要求 adopted / not adopted / optional polish / noise / needs human review 都可追查。
- 在 `CLAUDE.md` 保持 thin adapter，只提醒 Claude Code 檢查 necessity assessment，不複製 canonical workflow。
- 在 `docs/agent-handoff.md` 補充 review agent finding 不是命令、implementation agent 先評估必要性、merge executor 確認分類與佐證、human owns merge decision。

## Docs / validation

- `git diff --check`：pass
- Markdown sanity check for changed docs including `CLAUDE.md`：pass
- Local link check：skipped（no new markdown links added）
- `pnpm test`：pass（89 tests, 0 fail）
- `package.json` / `pnpm-lock.yaml`：unchanged

## Implementation Evidence

- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/157#issuecomment-4365944292
- Commit hash: `c4e19b0e20f837ef17ca37a28b4db82b93924de5`

## Scope guard

- 確認這是 workflow docs update。
- 確認沒有 runtime code change。
- 確認沒有 tests change。
- 確認沒有 `package.json` / `pnpm-lock.yaml` change。
- 確認沒有 CI change。
- 確認沒有新增 dependency。
- 確認沒有 review automation / bot implementation。
- 確認沒有 target repo / tachigo change。
- 確認沒有 merge。
- 確認沒有刪除 branch / worktree。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified procedures for evaluating automated code review findings before merge, introducing a formal classification system (adopted, not adopted, optional polish, noise, needs human review).
  * Enhanced workflow documentation with explicit audit requirements, risk criteria, and mandatory evidence/rationale documentation for code review closeout processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->