### PR TITLE
fix(references): dedupe basename missing diagnostics when full issue path is confirmed

### DIFF
--- a/docs/references.md
+++ b/docs/references.md
@@ -64,6 +64,8 @@ Issue-mentioned references 會在 prompt output 與 full task package 中獨立�
 
 若 issue-mentioned path 不存在，spec-injector 會用 deterministic repo path matching 產生保守的 path alias hint。這些 hints 只出現在 Missing Files / diagnostics，並會標示 `not a confirmed issue reference`；hinted path 不會被提升成 issue-mentioned reference，也不會混進 normal references list。
 
+若同一個 issue 已經明確提到且成功讀到某個 full repo-relative path，後續再次提到同 basename 的 bare filename 時，不會再產生獨立 Missing Files diagnostic；若同 basename 對應多個 confirmed full paths，仍保留 ambiguity / missing diagnostic，避免 unsafe assignment。
+
 目前 path alias hint 只使用可解釋的 basename match：
 
 - 若只有一個 same-basename candidate，顯示 `possible moved path`。

--- a/src/docs/finder.ts
+++ b/src/docs/finder.ts
@@ -116,6 +116,7 @@ export async function extractExplicitIssueFileReferences(
   const docs: DocSection[] = [];
   const sources: DocSection[] = [];
   const missing: DocSection[] = [];
+  const confirmedBasenameCounts = new Map<string, number>();
   let repoPathAliasCandidates: string[] | null = null;
 
   for (const filePath of candidates) {
@@ -126,6 +127,10 @@ export async function extractExplicitIssueFileReferences(
     const readResult = await safeReadFile(absolute);
 
     if (readResult.status !== 'ok') {
+      if (isCoveredBySingleConfirmedFullPathBasename(filePath, confirmedBasenameCounts)) {
+        continue;
+      }
+
       missing.push({
         filePath,
         content: '',
@@ -157,6 +162,8 @@ export async function extractExplicitIssueFileReferences(
     } else {
       sources.push(section);
     }
+
+    recordConfirmedFullPathBasename(filePath, confirmedBasenameCounts);
   }
 
   return { docs, sources, missing };
@@ -188,6 +195,28 @@ function collectExplicitPathCandidates(body: string): string[] {
   }
 
   return [...candidates];
+}
+
+function isCoveredBySingleConfirmedFullPathBasename(
+  filePath: string,
+  confirmedBasenameCounts: Map<string, number>
+): boolean {
+  if (isFullRepoRelativePath(filePath)) return false;
+  const basename = path.posix.basename(filePath).toLowerCase();
+  return confirmedBasenameCounts.get(basename) === 1;
+}
+
+function recordConfirmedFullPathBasename(
+  filePath: string,
+  confirmedBasenameCounts: Map<string, number>
+): void {
+  if (!isFullRepoRelativePath(filePath)) return;
+  const basename = path.posix.basename(filePath).toLowerCase();
+  confirmedBasenameCounts.set(basename, (confirmedBasenameCounts.get(basename) ?? 0) + 1);
+}
+
+function isFullRepoRelativePath(filePath: string): boolean {
+  return filePath.includes('/');
 }
 
 function normalizeBulletPathCandidate(line: string): string | null {

--- a/src/docs/finder.ts
+++ b/src/docs/finder.ts
@@ -113,10 +113,11 @@ export async function extractExplicitIssueFileReferences(
   repoPath: string
 ): Promise<{ docs: DocSection[]; sources: DocSection[]; missing: DocSection[] }> {
   const candidates = collectExplicitPathCandidates(issue.body);
+  const totalConfirmedBasenameCounts = await collectConfirmedFullPathBasenameCounts(candidates, repoPath);
   const docs: DocSection[] = [];
   const sources: DocSection[] = [];
   const missing: DocSection[] = [];
-  const confirmedBasenameCounts = new Map<string, number>();
+  const seenConfirmedBasenameCounts = new Map<string, number>();
   let repoPathAliasCandidates: string[] | null = null;
 
   for (const filePath of candidates) {
@@ -127,7 +128,19 @@ export async function extractExplicitIssueFileReferences(
     const readResult = await safeReadFile(absolute);
 
     if (readResult.status !== 'ok') {
-      if (isCoveredBySingleConfirmedFullPathBasename(filePath, confirmedBasenameCounts)) {
+      const pathAliasHints = readResult.status === 'missing'
+        ? findPathAliasHints(
+            filePath,
+            repoPathAliasCandidates ??= collectPathAliasCandidatePaths(repoPath)
+          )
+        : undefined;
+
+      if (isCoveredBySingleConfirmedFullPathBasename(
+        filePath,
+        seenConfirmedBasenameCounts,
+        totalConfirmedBasenameCounts,
+        pathAliasHints
+      )) {
         continue;
       }
 
@@ -139,12 +152,7 @@ export async function extractExplicitIssueFileReferences(
         readStatus: readResult.status,
         readErrorCode: readResult.code,
         reasons: [ISSUE_MENTIONED_REASON],
-        pathAliasHints: readResult.status === 'missing'
-          ? findPathAliasHints(
-              filePath,
-              repoPathAliasCandidates ??= collectPathAliasCandidatePaths(repoPath)
-            )
-          : undefined,
+        pathAliasHints,
       });
       continue;
     }
@@ -163,7 +171,7 @@ export async function extractExplicitIssueFileReferences(
       sources.push(section);
     }
 
-    recordConfirmedFullPathBasename(filePath, confirmedBasenameCounts);
+    recordConfirmedFullPathBasename(filePath, seenConfirmedBasenameCounts);
   }
 
   return { docs, sources, missing };
@@ -197,13 +205,40 @@ function collectExplicitPathCandidates(body: string): string[] {
   return [...candidates];
 }
 
+async function collectConfirmedFullPathBasenameCounts(
+  candidates: string[],
+  repoPath: string
+): Promise<Map<string, number>> {
+  const counts = new Map<string, number>();
+
+  for (const filePath of candidates) {
+    if (!isFullRepoRelativePath(filePath)) continue;
+
+    validateDocPath(filePath, repoPath);
+    const absolute = path.resolve(repoPath, filePath);
+    const readResult = await safeReadFile(absolute);
+    if (readResult.status !== 'ok') continue;
+
+    const basename = path.posix.basename(filePath).toLowerCase();
+    counts.set(basename, (counts.get(basename) ?? 0) + 1);
+  }
+
+  return counts;
+}
+
 function isCoveredBySingleConfirmedFullPathBasename(
   filePath: string,
-  confirmedBasenameCounts: Map<string, number>
+  seenConfirmedBasenameCounts: Map<string, number>,
+  totalConfirmedBasenameCounts: Map<string, number>,
+  pathAliasHints: DocSection['pathAliasHints']
 ): boolean {
   if (isFullRepoRelativePath(filePath)) return false;
+  if (pathAliasHints?.some((hint) => hint.kind === 'ambiguous-same-basename-candidates')) return false;
   const basename = path.posix.basename(filePath).toLowerCase();
-  return confirmedBasenameCounts.get(basename) === 1;
+  return (
+    (seenConfirmedBasenameCounts.get(basename) ?? 0) >= 1 &&
+    totalConfirmedBasenameCounts.get(basename) === 1
+  );
 }
 
 function recordConfirmedFullPathBasename(

--- a/src/docs/finder.ts
+++ b/src/docs/finder.ts
@@ -190,19 +190,37 @@ function validateDocPath(docPath: string, repoPath: string): void {
 }
 
 function collectExplicitPathCandidates(body: string): string[] {
-  const candidates = new Set<string>();
+  const candidates: Array<{ index: number; path: string }> = [];
 
   for (const match of body.matchAll(/`([^`\n]+)`/g)) {
     const normalized = normalizeExplicitPathCandidate(match[1]);
-    if (normalized) candidates.add(normalized);
+    if (normalized) candidates.push({ index: match.index ?? 0, path: normalized });
   }
 
+  let offset = 0;
   for (const line of body.split('\n')) {
     const normalized = normalizeBulletPathCandidate(line);
-    if (normalized) candidates.add(normalized);
+    if (normalized) {
+      const lineIndex = line.indexOf(normalized);
+      candidates.push({
+        index: offset + (lineIndex >= 0 ? lineIndex : 0),
+        path: normalized,
+      });
+    }
+    offset += line.length + 1;
   }
 
-  return [...candidates];
+  candidates.sort((a, b) => a.index - b.index);
+
+  const deduped: string[] = [];
+  const seen = new Set<string>();
+  for (const candidate of candidates) {
+    if (seen.has(candidate.path)) continue;
+    seen.add(candidate.path);
+    deduped.push(candidate.path);
+  }
+
+  return deduped;
 }
 
 async function collectConfirmedFullPathBasenameCounts(

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -1937,17 +1937,19 @@ test('spec plan keeps basename-only missing diagnostics when no confirmed full p
   assert.match(promptResult.stderr, /Not found: variant-section-dynamic\.tsx; path alias hint: possible moved path src\/ui\/components\/pdp\/variant-section-dynamic\.tsx \(same basename; not a confirmed issue reference\)/);
 });
 
-test('spec plan preserves ambiguity when repeated basename could refer to multiple confirmed full paths', async (t) => {
+test('spec plan preserves ambiguity when a repeated basename is between multiple confirmed full paths', async (t) => {
   const fixture = await createExplicitPathPlanFixture(t, {
     issueNumber: 164,
     title: 'Keep ambiguous basename diagnostics when multiple confirmed full paths share a basename',
     bodyLines: [
       'Confirmed references:',
       '- `src/ui/components/pdp/variant-section-dynamic.tsx`',
-      '- `src/mobile/components/pdp/variant-section-dynamic.tsx`',
       '',
-      'Ambiguous shorthand mention that should stay diagnostic:',
+      'Ambiguous shorthand mention before a second confirmed full path:',
       '- `variant-section-dynamic.tsx`',
+      '',
+      'Second confirmed reference:',
+      '- `src/mobile/components/pdp/variant-section-dynamic.tsx`',
     ],
     config: {
       discovery: {
@@ -1977,6 +1979,51 @@ test('spec plan preserves ambiguity when repeated basename could refer to multip
 
   assert.match(promptIssueSources, /`src\/ui\/components\/pdp\/variant-section-dynamic\.tsx` — issue-mentioned; mentioned in issue/);
   assert.match(promptIssueSources, /`src\/mobile\/components\/pdp\/variant-section-dynamic\.tsx` — issue-mentioned; mentioned in issue/);
+  assert.match(promptMissing, /`variant-section-dynamic\.tsx` — not found \(issue-mentioned; mentioned in issue; path alias hint: ambiguous same basename candidates \(2\): /);
+  assert.match(promptMissing, /src\/ui\/components\/pdp\/variant-section-dynamic\.tsx/);
+  assert.match(promptMissing, /src\/mobile\/components\/pdp\/variant-section-dynamic\.tsx/);
+  assert.match(promptResult.stderr, /Not found: variant-section-dynamic\.tsx; path alias hint: ambiguous same basename candidates \(2\): /);
+});
+
+test('spec plan keeps basename ambiguity when another confirmed full path appears later in the issue', async (t) => {
+  const fixture = await createExplicitPathPlanFixture(t, {
+    issueNumber: 164,
+    title: 'Keep basename ambiguity when later full path introduces a second confirmed candidate',
+    bodyLines: [
+      'First confirmed reference:',
+      '- `src/ui/components/pdp/variant-section-dynamic.tsx`',
+      '',
+      'Shorthand mention before the second confirmed path:',
+      '- `variant-section-dynamic.tsx`',
+      '',
+      'Later confirmed reference with the same basename:',
+      '- `src/mobile/components/pdp/variant-section-dynamic.tsx`',
+    ],
+    config: {
+      discovery: {
+        docs: [],
+        source: [],
+        max_docs: 5,
+        max_source_files: 5,
+      },
+    },
+    repoFiles: {
+      'src/ui/components/pdp/variant-section-dynamic.tsx':
+        'export const desktopVariantSectionDynamic = "DESKTOP_VARIANT_SECTION_DYNAMIC_SENTINEL";\n',
+      'src/mobile/components/pdp/variant-section-dynamic.tsx':
+        'export const mobileVariantSectionDynamic = "MOBILE_VARIANT_SECTION_DYNAMIC_SENTINEL";\n',
+    },
+  });
+
+  const promptResult = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'],
+    { env: fixture.env }
+  );
+
+  assert.equal(promptResult.code, 0, promptResult.stderr);
+
+  const promptMissing = sectionBetween(promptResult.stdout, '## 5. Missing Files', '## 6. Instructions');
+
   assert.match(promptMissing, /`variant-section-dynamic\.tsx` — not found \(issue-mentioned; mentioned in issue; path alias hint: ambiguous same basename candidates \(2\): /);
   assert.match(promptMissing, /src\/ui\/components\/pdp\/variant-section-dynamic\.tsx/);
   assert.match(promptMissing, /src\/mobile\/components\/pdp\/variant-section-dynamic\.tsx/);

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -1844,6 +1844,145 @@ test('spec plan adds deterministic path alias hints for missing issue-mentioned 
   assert.doesNotMatch(fullMissing, /MOVED_FOO_SENTINEL|FIRST_BAR_SENTINEL|SECOND_BAR_SENTINEL/);
 });
 
+test('spec plan de-dupes missing basename diagnostics when the same issue already confirmed a full path', async (t) => {
+  const fixture = await createExplicitPathPlanFixture(t, {
+    issueNumber: 164,
+    title: 'De-dupe repeated basename after confirmed full path',
+    bodyLines: [
+      'Confirmed storefront reference:',
+      '- `src/ui/components/pdp/variant-section-dynamic.tsx`',
+      '',
+      'Later shorthand mention that should not become another missing diagnostic:',
+      '- `variant-section-dynamic.tsx`',
+    ],
+    config: {
+      discovery: {
+        docs: [],
+        source: [],
+        max_docs: 5,
+        max_source_files: 5,
+      },
+    },
+    repoFiles: {
+      'src/ui/components/pdp/variant-section-dynamic.tsx':
+        'export const variantSectionDynamic = "VARIANT_SECTION_DYNAMIC_SENTINEL";\n',
+    },
+  });
+
+  const promptResult = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'],
+    { env: fixture.env }
+  );
+  const fullResult = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run'],
+    { env: fixture.env }
+  );
+
+  assert.equal(promptResult.code, 0, promptResult.stderr);
+  assert.equal(fullResult.code, 0, fullResult.stderr);
+
+  const promptIssueSources = sectionBetween(promptResult.stdout, '### Issue-Mentioned Source Files', '### Auto-Discovered Docs');
+  const promptMissing = sectionBetween(promptResult.stdout, '## 5. Missing Files', '## 6. Instructions');
+  const fullIssueSources = sectionBetween(fullResult.stdout, '## 5. Issue-Mentioned Source Files', '## 6. Auto-Discovered Documentation');
+  const fullMissing = sectionBetween(fullResult.stdout, '## 9. Missing Files', '## 10. Suggested Verification Checklist');
+
+  assert.match(promptIssueSources, /`src\/ui\/components\/pdp\/variant-section-dynamic\.tsx` — issue-mentioned; mentioned in issue/);
+  assert.match(fullIssueSources, /### src\/ui\/components\/pdp\/variant-section-dynamic\.tsx\n\n_source: issue-mentioned; mentioned in issue_/);
+  assert.doesNotMatch(promptMissing, /variant-section-dynamic\.tsx/);
+  assert.doesNotMatch(fullMissing, /variant-section-dynamic\.tsx/);
+  assert.doesNotMatch(promptResult.stderr, /Not found: variant-section-dynamic\.tsx/);
+});
+
+test('spec plan keeps basename-only missing diagnostics when no confirmed full path covers the reference', async (t) => {
+  const fixture = await createExplicitPathPlanFixture(t, {
+    issueNumber: 164,
+    title: 'Keep basename-only missing diagnostics without confirmed full path coverage',
+    bodyLines: [
+      'Only shorthand mention is available:',
+      '- `variant-section-dynamic.tsx`',
+    ],
+    config: {
+      discovery: {
+        docs: [],
+        source: [],
+        max_docs: 5,
+        max_source_files: 5,
+      },
+    },
+    repoFiles: {
+      'src/ui/components/pdp/variant-section-dynamic.tsx':
+        'export const variantSectionDynamic = "VARIANT_SECTION_DYNAMIC_SENTINEL";\n',
+    },
+  });
+
+  const promptResult = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'],
+    { env: fixture.env }
+  );
+  const fullResult = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run'],
+    { env: fixture.env }
+  );
+
+  assert.equal(promptResult.code, 0, promptResult.stderr);
+  assert.equal(fullResult.code, 0, fullResult.stderr);
+
+  const promptIssueSources = sectionBetween(promptResult.stdout, '### Issue-Mentioned Source Files', '### Auto-Discovered Docs');
+  const promptMissing = sectionBetween(promptResult.stdout, '## 5. Missing Files', '## 6. Instructions');
+  const fullMissing = sectionBetween(fullResult.stdout, '## 9. Missing Files', '## 10. Suggested Verification Checklist');
+
+  assert.doesNotMatch(promptIssueSources, /variant-section-dynamic\.tsx/);
+  assert.match(promptMissing, /`variant-section-dynamic\.tsx` — not found \(issue-mentioned; mentioned in issue; path alias hint: possible moved path `src\/ui\/components\/pdp\/variant-section-dynamic\.tsx` \(same basename; not a confirmed issue reference\)\)/);
+  assert.match(fullMissing, /`variant-section-dynamic\.tsx` — not found \(issue-mentioned; mentioned in issue; path alias hint: possible moved path `src\/ui\/components\/pdp\/variant-section-dynamic\.tsx` \(same basename; not a confirmed issue reference\)\)/);
+  assert.match(promptResult.stderr, /Not found: variant-section-dynamic\.tsx; path alias hint: possible moved path src\/ui\/components\/pdp\/variant-section-dynamic\.tsx \(same basename; not a confirmed issue reference\)/);
+});
+
+test('spec plan preserves ambiguity when repeated basename could refer to multiple confirmed full paths', async (t) => {
+  const fixture = await createExplicitPathPlanFixture(t, {
+    issueNumber: 164,
+    title: 'Keep ambiguous basename diagnostics when multiple confirmed full paths share a basename',
+    bodyLines: [
+      'Confirmed references:',
+      '- `src/ui/components/pdp/variant-section-dynamic.tsx`',
+      '- `src/mobile/components/pdp/variant-section-dynamic.tsx`',
+      '',
+      'Ambiguous shorthand mention that should stay diagnostic:',
+      '- `variant-section-dynamic.tsx`',
+    ],
+    config: {
+      discovery: {
+        docs: [],
+        source: [],
+        max_docs: 5,
+        max_source_files: 5,
+      },
+    },
+    repoFiles: {
+      'src/ui/components/pdp/variant-section-dynamic.tsx':
+        'export const desktopVariantSectionDynamic = "DESKTOP_VARIANT_SECTION_DYNAMIC_SENTINEL";\n',
+      'src/mobile/components/pdp/variant-section-dynamic.tsx':
+        'export const mobileVariantSectionDynamic = "MOBILE_VARIANT_SECTION_DYNAMIC_SENTINEL";\n',
+    },
+  });
+
+  const promptResult = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'],
+    { env: fixture.env }
+  );
+
+  assert.equal(promptResult.code, 0, promptResult.stderr);
+
+  const promptIssueSources = sectionBetween(promptResult.stdout, '### Issue-Mentioned Source Files', '### Auto-Discovered Docs');
+  const promptMissing = sectionBetween(promptResult.stdout, '## 5. Missing Files', '## 6. Instructions');
+
+  assert.match(promptIssueSources, /`src\/ui\/components\/pdp\/variant-section-dynamic\.tsx` — issue-mentioned; mentioned in issue/);
+  assert.match(promptIssueSources, /`src\/mobile\/components\/pdp\/variant-section-dynamic\.tsx` — issue-mentioned; mentioned in issue/);
+  assert.match(promptMissing, /`variant-section-dynamic\.tsx` — not found \(issue-mentioned; mentioned in issue; path alias hint: ambiguous same basename candidates \(2\): /);
+  assert.match(promptMissing, /src\/ui\/components\/pdp\/variant-section-dynamic\.tsx/);
+  assert.match(promptMissing, /src\/mobile\/components\/pdp\/variant-section-dynamic\.tsx/);
+  assert.match(promptResult.stderr, /Not found: variant-section-dynamic\.tsx; path alias hint: ambiguous same basename candidates \(2\): /);
+});
+
 test('spec plan distinguishes missing files from existing paths that cannot be read', async (t) => {
   const fixture = await createExplicitPathPlanFixture(t, {
     issueNumber: 74,

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -1893,6 +1893,53 @@ test('spec plan de-dupes missing basename diagnostics when the same issue alread
   assert.doesNotMatch(promptResult.stderr, /Not found: variant-section-dynamic\.tsx/);
 });
 
+test('spec plan de-dupes basename diagnostics when a plain bullet full path appears before an inline basename mention', async (t) => {
+  const fixture = await createExplicitPathPlanFixture(t, {
+    issueNumber: 164,
+    title: 'De-dupe mixed-format repeated basename after confirmed full path',
+    bodyLines: [
+      'Confirmed storefront reference as a plain bullet:',
+      '- src/ui/components/pdp/variant-section-dynamic.tsx',
+      '',
+      'Later shorthand inline mention that should not become another missing diagnostic:',
+      'Please keep `variant-section-dynamic.tsx` aligned with the confirmed component path.',
+    ],
+    config: {
+      discovery: {
+        docs: [],
+        source: [],
+        max_docs: 5,
+        max_source_files: 5,
+      },
+    },
+    repoFiles: {
+      'src/ui/components/pdp/variant-section-dynamic.tsx':
+        'export const variantSectionDynamic = "VARIANT_SECTION_DYNAMIC_SENTINEL";\n',
+    },
+  });
+
+  const promptResult = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'],
+    { env: fixture.env }
+  );
+  const fullResult = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run'],
+    { env: fixture.env }
+  );
+
+  assert.equal(promptResult.code, 0, promptResult.stderr);
+  assert.equal(fullResult.code, 0, fullResult.stderr);
+
+  const promptIssueSources = sectionBetween(promptResult.stdout, '### Issue-Mentioned Source Files', '### Auto-Discovered Docs');
+  const promptMissing = sectionBetween(promptResult.stdout, '## 5. Missing Files', '## 6. Instructions');
+  const fullMissing = sectionBetween(fullResult.stdout, '## 9. Missing Files', '## 10. Suggested Verification Checklist');
+
+  assert.match(promptIssueSources, /`src\/ui\/components\/pdp\/variant-section-dynamic\.tsx` — issue-mentioned; mentioned in issue/);
+  assert.doesNotMatch(promptMissing, /variant-section-dynamic\.tsx/);
+  assert.doesNotMatch(fullMissing, /variant-section-dynamic\.tsx/);
+  assert.doesNotMatch(promptResult.stderr, /Not found: variant-section-dynamic\.tsx/);
+});
+
 test('spec plan keeps basename-only missing diagnostics when no confirmed full path covers the reference', async (t) => {
   const fixture = await createExplicitPathPlanFixture(t, {
     issueNumber: 164,
@@ -1983,6 +2030,46 @@ test('spec plan preserves ambiguity when a repeated basename is between multiple
   assert.match(promptMissing, /src\/ui\/components\/pdp\/variant-section-dynamic\.tsx/);
   assert.match(promptMissing, /src\/mobile\/components\/pdp\/variant-section-dynamic\.tsx/);
   assert.match(promptResult.stderr, /Not found: variant-section-dynamic\.tsx; path alias hint: ambiguous same basename candidates \(2\): /);
+});
+
+test('spec plan de-dupes an inline basename after an earlier plain bullet full path', async (t) => {
+  const fixture = await createExplicitPathPlanFixture(t, {
+    issueNumber: 164,
+    title: 'De-dupe inline basename after plain bullet full path',
+    bodyLines: [
+      'Confirmed storefront reference as a plain bullet:',
+      '- src/ui/components/pdp/variant-section-dynamic.tsx',
+      '',
+      'Later inline shorthand mention that should not become another missing diagnostic:',
+      'The silent fail is in `variant-section-dynamic.tsx`.',
+    ],
+    config: {
+      discovery: {
+        docs: [],
+        source: [],
+        max_docs: 5,
+        max_source_files: 5,
+      },
+    },
+    repoFiles: {
+      'src/ui/components/pdp/variant-section-dynamic.tsx':
+        'export const variantSectionDynamic = "VARIANT_SECTION_DYNAMIC_SENTINEL";\n',
+    },
+  });
+
+  const promptResult = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'],
+    { env: fixture.env }
+  );
+
+  assert.equal(promptResult.code, 0, promptResult.stderr);
+
+  const promptIssueSources = sectionBetween(promptResult.stdout, '### Issue-Mentioned Source Files', '### Auto-Discovered Docs');
+  const promptMissing = sectionBetween(promptResult.stdout, '## 5. Missing Files', '## 6. Instructions');
+
+  assert.match(promptIssueSources, /`src\/ui\/components\/pdp\/variant-section-dynamic\.tsx` — issue-mentioned; mentioned in issue/);
+  assert.doesNotMatch(promptMissing, /variant-section-dynamic\.tsx/);
+  assert.doesNotMatch(promptResult.stderr, /Not found: variant-section-dynamic\.tsx/);
 });
 
 test('spec plan keeps basename ambiguity when another confirmed full path appears later in the issue', async (t) => {


### PR DESCRIPTION
## Summary

- 修正 issue-mentioned reference diagnostics：當同一個 issue 已 confirmed 一個 full repo-relative path，後續 bare basename mention 不再被當成獨立 missing reference。
- 保留 basename-only reference 在沒有 confirmed full path 時的既有 missing / alias hint 行為。
- 保留多個 confirmed full paths 共用同 basename 時的 ambiguity diagnostic，避免 unsafe assignment。
- 依 Codex auto review 補強 interleaved order regression：full path -> bare basename -> second full path 仍保留 ambiguity。
- 依 CodeRabbit findings 修正 candidate extraction order：inline code 與 plain bullet paths 依 issue text position 合併排序，避免 mixed-format references 破壞 first-seen ordering。
- 補充 `docs/references.md` 說明這個 dedupe / ambiguity 行為。

## Scope

- `src/docs/finder.ts`：在 explicit issue references 解析時先建立 confirmed full-path basename coverage，再決定 missing diagnostics；ambiguous alias candidates 不會被 suppress。
- `tests/cli.integration.test.ts`：新增 #164 shaped regression tests，涵蓋 confirmed full path + repeated basename、basename-only missing、ambiguous same-basename cases、interleaved full-path / basename ordering、以及 plain bullet full path + later inline basename mixed-format ordering。
- `docs/references.md`：最小文件更新。

## Non-goals

- 不處理 #163 classifier false positives。
- 不處理 #165 checkout-related source discovery。
- 不處理 #166 nested checklist parsing。
- 不新增 hidden LLM、semantic RAG、vector search。
- 不改 CLI command / flag。
- 不改 config schema。
- 不修改 `nurockplayer/storefront` 或 `nurockplayer/tachiya`。

## Validation

- `node --test tests/cli.integration.test.ts --test-name-pattern "dedupes missing basename|keeps basename-only|preserves ambiguity|keeps basename ambiguity"`：pass（RED 階段曾先確認 dedupe case 失敗，修正後 pass）
- `node --test tests/cli.integration.test.ts --test-name-pattern "inline basename after an earlier plain bullet"`：pass
- `git diff --check`：pass
- `pnpm build`：pass
- `pnpm test`：pass（95/95）

## Issue evidence

- Linked issue: Closes #164
- Issue evidence comment: https://github.com/Erick52106/spec-injector/issues/164#issuecomment-4366354243
- Source dogfood evidence: https://github.com/Erick52106/spec-injector/issues/151#issuecomment-4366262826
- Commit hash / HEAD: `55bffd0956bc17dd0b22dbe961b9d4555ca305c9`

## Review finding assessment

- Codex auto review P2: adopted as regression coverage. The implementation now guards ambiguous same-basename candidates before suppressing basename diagnostics, and tests cover interleaved full-path / basename ordering.
- CodeRabbit finding 1: adopted. Candidate extraction now preserves issue text order across inline-code and plain bullet path candidates.
- CodeRabbit finding 2: adopted. Added mixed-format regression where a plain bullet full path precedes a later inline basename mention.

## Follow-up notes

- 若 human 接續處理，建議 #163 / #165 / #166 分開保持獨立 scope。
