### PR TITLE
fix(classifier): reduce tooling/database false positives for frontend form-action issues

### DIFF
--- a/docs/classifier.md
+++ b/docs/classifier.md
@@ -14,7 +14,7 @@ Classifier 不是 LLM、不是 architecture reviewer，也不是最終決策者�
 - label keyword 命中次之
 - body keyword 命中提供輔助 evidence
 - 最多回傳 5 個 domains
-- keyword matching 使用 deterministic token / phrase boundary，避免 `FormData` 誤中 `orm`、`client` 誤中 `cli` 這類 substring false positive
+- keyword matching 使用 deterministic token / phrase boundary，phrase 可跨 whitespace / hyphen，避免 `FormData` 誤中 `orm`、`client` 誤中 `cli` 這類 substring false positive
 
 支援的 domains 由 runtime 內建，例如 `frontend`、`backend`、`api`、`auth`、`database`、`infra`、`cloud-storage`、`blockchain`、`smart-contract`、`wallet`、`i18n`、`testing`、`docs`、`ci`、`tooling`。
 
@@ -54,7 +54,7 @@ Frontend / UI / PDP / add-to-cart / server action 類 issue 會優先依賴 `fro
 
 `database` domain 仍應由明確 database evidence 觸發，例如 `migration`、`schema`、`SQL`、`table`、`ORM`、`database transaction` 或具體 persistence wording。`FormData` 或一般 `form` wording 不應單獨觸發 database。
 
-`tooling` domain 仍應由明確 tooling evidence 觸發，例如 `lint config`、`test runner`、`CI workflow`、`package manager config`、`build script`。Package manager command text such as `pnpm build` / `pnpm test` 若只是 validation hint，不應單獨讓 issue 變成 tooling task。
+`tooling` domain 仍應由明確 tooling evidence 觸發，例如 `lint config`、`test runner`、`CI workflow`、`package manager config`、`build script`。Package manager command text such as `pnpm build` / `pnpm test` 若只是 validation hint，不應單獨讓 issue 變成 tooling task；但 `upgrade pnpm`、`package manager version`、`lockfile` / `workspace` maintenance 這類 deterministic maintenance context 仍應保留 `tooling`。
 
 ## Wallet / Blockchain Evidence
 

--- a/docs/classifier.md
+++ b/docs/classifier.md
@@ -14,6 +14,7 @@ Classifier 不是 LLM、不是 architecture reviewer，也不是最終決策者�
 - label keyword 命中次之
 - body keyword 命中提供輔助 evidence
 - 最多回傳 5 個 domains
+- keyword matching 使用 deterministic token / phrase boundary，避免 `FormData` 誤中 `orm`、`client` 誤中 `cli` 這類 substring false positive
 
 支援的 domains 由 runtime 內建，例如 `frontend`、`backend`、`api`、`auth`、`database`、`infra`、`cloud-storage`、`blockchain`、`smart-contract`、`wallet`、`i18n`、`testing`、`docs`、`ci`、`tooling`。
 
@@ -42,8 +43,18 @@ Generic product wording 需要小心處理。某些字在不同 domain 中都可
 - `block` / `hash` 單字容易出現在 generic engineering wording，應偏好 `block height`、`transaction hash`、`tx hash` 等更明確 evidence。
 - `address` 可以是 wallet address，也可以是 shipping address、email address 或 UI copy。
 - `send` / `receive` 可以是 wallet 動作，也可以是 messaging 或 notification。
+- `FormData` / `form` 可以是 frontend form action payload，不等於 database / ORM work。
+- `pnpm build` / `pnpm test` 可以是 validation hint，不等於 tooling task。
 
 原則是：generic wording 應弱於 legitimate domain evidence。
+
+## Frontend Form Actions And Tooling Hints
+
+Frontend / UI / PDP / add-to-cart / server action 類 issue 會優先依賴 `frontend`、`client component`、`server action`、`form action`、`add-to-cart` 等 deterministic signals。若 repo taxonomy 沒有更細的 checkout / storefront domain，runtime 會使用現有最接近的 `frontend` domain。
+
+`database` domain 仍應由明確 database evidence 觸發，例如 `migration`、`schema`、`SQL`、`table`、`ORM`、`database transaction` 或具體 persistence wording。`FormData` 或一般 `form` wording 不應單獨觸發 database。
+
+`tooling` domain 仍應由明確 tooling evidence 觸發，例如 `lint config`、`test runner`、`CI workflow`、`package manager config`、`build script`。Package manager command text such as `pnpm build` / `pnpm test` 若只是 validation hint，不應單獨讓 issue 變成 tooling task。
 
 ## Wallet / Blockchain Evidence
 

--- a/src/classifier/domain.ts
+++ b/src/classifier/domain.ts
@@ -22,7 +22,7 @@ export interface DomainClassificationResult {
 }
 
 const DOMAIN_KEYWORDS: Record<string, string[]> = {
-  frontend: ['ui', 'component', 'render', 'css', 'style', 'react', 'vue', 'angular', 'svelte', 'button', 'form', 'page', 'layout', 'responsive', 'animation', 'dom', 'html', 'tailwind', 'visual', 'design'],
+  frontend: ['frontend', 'ui', 'component', 'client component', 'server action', 'add-to-cart', 'form action', 'pdp', 'render', 'css', 'style', 'react', 'vue', 'angular', 'svelte', 'button', 'form', 'page', 'layout', 'responsive', 'animation', 'dom', 'html', 'tailwind', 'visual', 'design'],
   backend: ['server', 'service', 'handler', 'controller', 'middleware', 'worker', 'daemon', 'queue', 'job', 'cron', 'scheduler', 'grpc', 'rpc'],
   api: ['api', 'endpoint', 'rest', 'graphql', 'http', 'route', 'swagger', 'openapi', 'webhook', 'request', 'response'],
   auth: ['auth', 'login', 'logout', 'token', 'jwt', 'oauth', 'session', 'password', 'credential', 'permission', 'role', 'access', 'signup', 'register'],
@@ -40,6 +40,7 @@ const DOMAIN_KEYWORDS: Record<string, string[]> = {
 };
 
 const MAX_DOMAINS = 5;
+const WEAK_TOOLING_SIGNALS = ['npm', 'yarn', 'pnpm', 'bun'];
 const GENERIC_WALLET_SIGNALS = ['transactions', 'transaction'];
 const GENERIC_WALLET_REASON = 'generic product transaction wording';
 const GENERIC_API_CONTRACT_SIGNALS = ['contract'];
@@ -69,15 +70,17 @@ export function classifyDomainsWithEvidence(issue: Issue): DomainClassificationR
   for (const [domain, keywords] of Object.entries(DOMAIN_KEYWORDS)) {
     let score = 0;
     for (const kw of keywords) {
-      if (title.includes(kw)) score += 3;
-      if (labels.includes(kw)) score += 2;
-      if (body.includes(kw)) score += 1;
+      if (matchesTerm(title, kw)) score += 3;
+      if (matchesTerm(labels, kw)) score += 2;
+      if (matchesTerm(body, kw)) score += 1;
     }
     if (score > 0) {
       scores[domain] = score;
       evidenceByDomain.set(domain, collectEvidence(domain, keywords, fields));
     }
   }
+
+  suppressWeakToolingEvidence(scores, evidenceByDomain);
 
   const domains = Object.entries(scores)
     .sort((a, b) => b[1] - a[1])
@@ -100,7 +103,7 @@ function collectEvidence(
 
   for (const { source, value } of fields) {
     for (const term of keywords) {
-      if (value.includes(term)) evidence.push({ domain, term, source });
+      if (matchesTerm(value, term)) evidence.push({ domain, term, source });
     }
   }
 
@@ -139,7 +142,7 @@ function findRejectedSignal(
 ): RejectedDomainReason | undefined {
   for (const { source, value } of fields) {
     for (const signal of signals) {
-      if (value.includes(signal)) {
+      if (matchesTerm(value, signal)) {
         return {
           domain,
           signal,
@@ -153,12 +156,39 @@ function findRejectedSignal(
   return undefined;
 }
 
+function suppressWeakToolingEvidence(
+  scores: Record<string, number>,
+  evidenceByDomain: Map<string, DomainEvidence[]>
+): void {
+  const evidence = evidenceByDomain.get('tooling') ?? [];
+  if (evidence.length === 0) return;
+
+  const hasOnlyWeakToolingSignals = evidence.every((entry) => WEAK_TOOLING_SIGNALS.includes(entry.term));
+  if (!hasOnlyWeakToolingSignals) return;
+
+  delete scores.tooling;
+  evidenceByDomain.delete('tooling');
+}
+
+function matchesTerm(value: string, term: string): boolean {
+  if (term.startsWith('.')) {
+    return value.includes(term);
+  }
+
+  const escaped = term.trim().split(/\s+/).map(escapeRegExp).join('\\s+');
+  return new RegExp(`(^|[^a-z0-9])${escaped}([^a-z0-9]|$)`, 'i').test(value);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 function hasGenericApiContractContext(fields: Array<{ source: DomainEvidenceSource; value: string }>): boolean {
   const text = fields.map(({ value }) => value).join(' ');
-  return GENERIC_API_CONTRACT_CONTEXT.some((term) => text.includes(term));
+  return GENERIC_API_CONTRACT_CONTEXT.some((term) => matchesTerm(text, term));
 }
 
 function hasGenericDatabaseTransactionContext(fields: Array<{ source: DomainEvidenceSource; value: string }>): boolean {
   const text = fields.map(({ value }) => value).join(' ');
-  return GENERIC_DATABASE_TRANSACTION_CONTEXT.some((term) => text.includes(term));
+  return GENERIC_DATABASE_TRANSACTION_CONTEXT.some((term) => matchesTerm(text, term));
 }

--- a/src/classifier/domain.ts
+++ b/src/classifier/domain.ts
@@ -25,7 +25,7 @@ const DOMAIN_KEYWORDS: Record<string, string[]> = {
   frontend: ['frontend', 'ui', 'component', 'client component', 'server action', 'add-to-cart', 'form action', 'pdp', 'render', 'css', 'style', 'react', 'vue', 'angular', 'svelte', 'button', 'form', 'page', 'layout', 'responsive', 'animation', 'dom', 'html', 'tailwind', 'visual', 'design'],
   backend: ['server', 'service', 'handler', 'controller', 'middleware', 'worker', 'daemon', 'queue', 'job', 'cron', 'scheduler', 'grpc', 'rpc'],
   api: ['api', 'endpoint', 'rest', 'graphql', 'http', 'route', 'swagger', 'openapi', 'webhook', 'request', 'response'],
-  auth: ['auth', 'login', 'logout', 'token', 'jwt', 'oauth', 'session', 'password', 'credential', 'permission', 'role', 'access', 'signup', 'register'],
+  auth: ['auth', 'authentication', 'authorization', 'authorize', 'authorized', 'login', 'logout', 'token', 'jwt', 'oauth', 'session', 'password', 'credential', 'permission', 'role', 'access', 'signup', 'register'],
   database: ['database', 'db', 'sql', 'query', 'queries', 'migration', 'schema', 'table', 'column', 'model', 'data model', 'orm', 'repository layer', 'persistence', 'persisted', 'record storage', 'postgres', 'postgresql', 'mysql', 'sqlite', 'mongo', 'redis', 'index', 'prisma', 'drizzle', 'gorm'],
   infra: ['infra', 'deploy', 'docker', 'kubernetes', 'k8s', 'terraform', 'helm', 'nginx', 'network', 'devops', 'provision', 'cloud', 'vm', 'container'],
   'cloud-storage': ['s3', 'gcs', 'storage', 'bucket', 'upload', 'download', 'blob', 'cdn', 'file upload', 'asset', 'object storage'],
@@ -36,7 +36,7 @@ const DOMAIN_KEYWORDS: Record<string, string[]> = {
   testing: ['.spec.ts', '.spec.tsx', '.spec.js', '.spec.jsx', '.spec.mts', '.spec.mjs', '.spec.cts', '.spec.cjs', '.test.ts', '.test.tsx', '.test.js', '.test.jsx', '.test.mts', '.test.mjs', '.test.cts', '.test.cjs', 'test', 'unit', 'integration', 'e2e', 'mock', 'stub', 'coverage', 'jest', 'vitest', 'playwright', 'cypress', 'assert', 'fixture'],
   docs: ['docs', 'documentation', 'readme', 'guide', 'changelog', 'wiki', 'jsdoc', 'typedoc'],
   ci: ['ci', 'cd', 'pipeline', 'workflow', 'github action', 'jenkins', 'travis', 'circleci', 'build step', 'artifact', 'badge'],
-  tooling: ['lint', 'eslint', 'prettier', 'config', 'setup', 'cli', 'script', 'generator', 'plugin', 'npm', 'yarn', 'pnpm', 'bun'],
+  tooling: ['lint', 'eslint', 'prettier', 'config', 'setup', 'cli', 'script', 'generator', 'plugin', 'package manager', 'npm', 'yarn', 'pnpm', 'bun'],
 };
 
 const MAX_DOMAINS = 5;
@@ -165,6 +165,9 @@ function suppressWeakToolingEvidence(
 
   const hasOnlyWeakToolingSignals = evidence.every((entry) => WEAK_TOOLING_SIGNALS.includes(entry.term));
   if (!hasOnlyWeakToolingSignals) return;
+
+  const hasTitleOrLabelSignal = evidence.some((entry) => entry.source === 'title' || entry.source === 'labels');
+  if (hasTitleOrLabelSignal) return;
 
   delete scores.tooling;
   evidenceByDomain.delete('tooling');

--- a/src/classifier/domain.ts
+++ b/src/classifier/domain.ts
@@ -41,6 +41,13 @@ const DOMAIN_KEYWORDS: Record<string, string[]> = {
 
 const MAX_DOMAINS = 5;
 const WEAK_TOOLING_SIGNALS = ['npm', 'yarn', 'pnpm', 'bun'];
+const PACKAGE_MANAGER_PATTERN = '(?:npm|yarn|pnpm|bun)';
+const STRONG_PACKAGE_MANAGER_CONTEXT_PATTERNS = [
+  new RegExp(`\\b(?:upgrade|update|bump|configure|configured|configuring|migrate|switch)\\s+${PACKAGE_MANAGER_PATTERN}\\b`, 'i'),
+  new RegExp(`\\b${PACKAGE_MANAGER_PATTERN}\\s+(?:version|workspace|lockfile|config|configuration)\\b`, 'i'),
+  /\bpackage[\s-]+manager\b/i,
+  /\b(?:lockfile|workspace)\b/i,
+];
 const GENERIC_WALLET_SIGNALS = ['transactions', 'transaction'];
 const GENERIC_WALLET_REASON = 'generic product transaction wording';
 const GENERIC_API_CONTRACT_SIGNALS = ['contract'];
@@ -80,7 +87,7 @@ export function classifyDomainsWithEvidence(issue: Issue): DomainClassificationR
     }
   }
 
-  suppressWeakToolingEvidence(scores, evidenceByDomain);
+  suppressWeakToolingEvidence(scores, evidenceByDomain, fields);
 
   const domains = Object.entries(scores)
     .sort((a, b) => b[1] - a[1])
@@ -158,7 +165,8 @@ function findRejectedSignal(
 
 function suppressWeakToolingEvidence(
   scores: Record<string, number>,
-  evidenceByDomain: Map<string, DomainEvidence[]>
+  evidenceByDomain: Map<string, DomainEvidence[]>,
+  fields: Array<{ source: DomainEvidenceSource; value: string }>
 ): void {
   const evidence = evidenceByDomain.get('tooling') ?? [];
   if (evidence.length === 0) return;
@@ -169,8 +177,15 @@ function suppressWeakToolingEvidence(
   const hasTitleOrLabelSignal = evidence.some((entry) => entry.source === 'title' || entry.source === 'labels');
   if (hasTitleOrLabelSignal) return;
 
+  if (hasStrongPackageManagerContext(fields)) return;
+
   delete scores.tooling;
   evidenceByDomain.delete('tooling');
+}
+
+function hasStrongPackageManagerContext(fields: Array<{ source: DomainEvidenceSource; value: string }>): boolean {
+  const text = fields.map(({ value }) => value).join(' ');
+  return STRONG_PACKAGE_MANAGER_CONTEXT_PATTERNS.some((pattern) => pattern.test(text));
 }
 
 function matchesTerm(value: string, term: string): boolean {
@@ -178,7 +193,7 @@ function matchesTerm(value: string, term: string): boolean {
     return value.includes(term);
   }
 
-  const escaped = term.trim().split(/\s+/).map(escapeRegExp).join('\\s+');
+  const escaped = term.trim().split(/\s+/).map(escapeRegExp).join('[\\s-]+');
   return new RegExp(`(^|[^a-z0-9])${escaped}([^a-z0-9]|$)`, 'i').test(value);
 }
 

--- a/tests/classifier/domain.test.ts
+++ b/tests/classifier/domain.test.ts
@@ -113,6 +113,25 @@ test('legitimate testing evidence still triggers testing domain', () => {
   ));
 });
 
+test('auth stem wording still triggers auth after boundary matching', () => {
+  const result = classifyDomainsWithEvidence(issue({
+    title: 'Fix authentication authorization flow',
+    body: [
+      'Users can fail authorization after completing the authentication callback.',
+      'Keep session and permission behavior stable.',
+    ].join('\n'),
+    labels: [],
+  }));
+
+  assert.ok(result.domains.includes('auth'), `Expected auth in ${result.domains.join(', ')}`);
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'auth' && e.term === 'authentication' && e.source === 'title'
+  ));
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'auth' && e.term === 'authorization' && e.source === 'title'
+  ));
+});
+
 test('legitimate database evidence still triggers database domain', () => {
   const result = classifyDomainsWithEvidence(issue({
     title: 'Add migration SQL schema and table indexes',
@@ -181,6 +200,25 @@ test('pnpm validation and client wording do not alone make a tooling task', () =
   assert.ok(result.domains.includes('frontend'), `Expected frontend in ${result.domains.join(', ')}`);
   assert.ok(!result.domains.includes('tooling'), `Expected tooling to be absent from ${result.domains.join(', ')}`);
   assert.ok(!result.evidence.some((e) => e.domain === 'tooling'), `Expected no tooling evidence, got ${JSON.stringify(result.evidence)}`);
+});
+
+test('package manager maintenance still matches tooling when package manager is the task', () => {
+  const result = classifyDomainsWithEvidence(issue({
+    title: 'Upgrade pnpm package manager version',
+    body: [
+      'Update the package manager config for the repository.',
+      'Keep lockfile behavior stable.',
+    ].join('\n'),
+    labels: [],
+  }));
+
+  assert.ok(result.domains.includes('tooling'), `Expected tooling in ${result.domains.join(', ')}`);
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'tooling' && e.term === 'pnpm' && e.source === 'title'
+  ));
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'tooling' && e.term === 'package manager' && e.source === 'title'
+  ));
 });
 
 test('actual tooling issue still matches tooling', () => {

--- a/tests/classifier/domain.test.ts
+++ b/tests/classifier/domain.test.ts
@@ -132,6 +132,96 @@ test('legitimate database evidence still triggers database domain', () => {
   ));
 });
 
+test('frontend form-action wording does not match database from FormData or form alone', () => {
+  const result = classifyDomainsWithEvidence(issue({
+    title: 'Fix add-to-cart server action silent fail on PDP',
+    body: [
+      'The frontend add-to-cart flow uses a server action with FormData from a product form.',
+      'The client component renders useFormStatus and useActionState while the action silently fails.',
+      'Keep the fix focused on UI feedback and form-action behavior.',
+    ].join('\n'),
+    labels: ['frontend'],
+  }));
+
+  assert.ok(result.domains.includes('frontend'), `Expected frontend in ${result.domains.join(', ')}`);
+  assert.ok(!result.domains.includes('database'), `Expected database to be absent from ${result.domains.join(', ')}`);
+  assert.ok(!result.evidence.some((e) => e.domain === 'database'), `Expected no database evidence, got ${JSON.stringify(result.evidence)}`);
+});
+
+test('actual database issue still matches database after form-action suppression', () => {
+  const result = classifyDomainsWithEvidence(issue({
+    title: 'Add database migration for cart item table schema',
+    body: [
+      'Create SQL migration coverage for cart item records.',
+      'Update ORM transaction handling for the checkout table.',
+    ].join('\n'),
+    labels: ['backend'],
+  }));
+
+  assert.ok(result.domains.includes('database'), `Expected database in ${result.domains.join(', ')}`);
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'database' && e.term === 'migration' && e.source === 'title'
+  ));
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'database' && e.term === 'orm' && e.source === 'body'
+  ));
+});
+
+test('pnpm validation and client wording do not alone make a tooling task', () => {
+  const result = classifyDomainsWithEvidence(issue({
+    title: 'Fix client add-to-cart form feedback',
+    body: [
+      'The client component should show an error when the server action returns a silent failure.',
+      'Validation commands: pnpm build and pnpm test.',
+      'Do not change package scripts or build tooling.',
+    ].join('\n'),
+    labels: ['frontend'],
+  }));
+
+  assert.ok(result.domains.includes('frontend'), `Expected frontend in ${result.domains.join(', ')}`);
+  assert.ok(!result.domains.includes('tooling'), `Expected tooling to be absent from ${result.domains.join(', ')}`);
+  assert.ok(!result.evidence.some((e) => e.domain === 'tooling'), `Expected no tooling evidence, got ${JSON.stringify(result.evidence)}`);
+});
+
+test('actual tooling issue still matches tooling', () => {
+  const result = classifyDomainsWithEvidence(issue({
+    title: 'Update build script lint config and test runner',
+    body: [
+      'Adjust the package manager config for CI workflow setup.',
+      'Keep the pnpm script and eslint config aligned with the test runner.',
+    ].join('\n'),
+    labels: ['area:tooling'],
+  }));
+
+  assert.ok(result.domains.includes('tooling'), `Expected tooling in ${result.domains.join(', ')}`);
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'tooling' && e.term === 'script' && e.source === 'title'
+  ));
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'tooling' && e.term === 'config' && e.source === 'body'
+  ));
+});
+
+test('dogfood-shaped add-to-cart issue keeps frontend signal without database or tooling noise', () => {
+  const result = classifyDomainsWithEvidence(issue({
+    title: 'Storefront add-to-cart fails from product page server action',
+    body: [
+      'Implement the PDP add-to-cart form action for a storefront product page.',
+      'The React client component passes FormData into a server action and uses useFormStatus / useActionState.',
+      'The current UI can silently fail when cart state is not updated.',
+      'Suggested validation: pnpm build and pnpm test.',
+      'Do not mutate checkout, payment, package scripts, or target repo configuration.',
+    ].join('\n'),
+    labels: ['frontend'],
+  }));
+
+  assert.ok(result.domains.includes('frontend'), `Expected frontend in ${result.domains.join(', ')}`);
+  assert.ok(!result.domains.includes('database'), `Expected database to be absent from ${result.domains.join(', ')}`);
+  assert.ok(!result.domains.includes('tooling'), `Expected tooling to be absent from ${result.domains.join(', ')}`);
+  assert.ok(!result.evidence.some((e) => e.domain === 'database'), `Expected no database evidence, got ${JSON.stringify(result.evidence)}`);
+  assert.ok(!result.evidence.some((e) => e.domain === 'tooling'), `Expected no tooling evidence, got ${JSON.stringify(result.evidence)}`);
+});
+
 test('classification evidence and rejected reasons keep deterministic shape and ordering', () => {
   const sampleIssue = issue({
     title: 'Dashboard endpoint route transaction review',
@@ -158,6 +248,12 @@ test('classification evidence and rejected reasons keep deterministic shape and 
       signal: 'transaction',
       source: 'title',
       reason: 'generic product transaction wording',
+    },
+    {
+      domain: 'database',
+      signal: 'transaction',
+      source: 'title',
+      reason: 'generic transaction wording',
     },
   ]);
 });

--- a/tests/classifier/domain.test.ts
+++ b/tests/classifier/domain.test.ts
@@ -113,12 +113,12 @@ test('legitimate testing evidence still triggers testing domain', () => {
   ));
 });
 
-test('auth stem wording still triggers auth after boundary matching', () => {
+test('authentication wording still triggers auth after boundary matching', () => {
   const result = classifyDomainsWithEvidence(issue({
-    title: 'Fix authentication authorization flow',
+    title: 'Fix authentication callback flow',
     body: [
-      'Users can fail authorization after completing the authentication callback.',
-      'Keep session and permission behavior stable.',
+      'Users can fail after completing the authentication callback.',
+      'Keep credential behavior stable.',
     ].join('\n'),
     labels: [],
   }));
@@ -127,8 +127,40 @@ test('auth stem wording still triggers auth after boundary matching', () => {
   assert.ok(result.evidence.some((e) =>
     e.domain === 'auth' && e.term === 'authentication' && e.source === 'title'
   ));
+});
+
+test('authorization wording still triggers auth after boundary matching', () => {
+  const result = classifyDomainsWithEvidence(issue({
+    title: 'Fix authorization policy flow',
+    body: [
+      'Users can fail authorization after role changes.',
+      'Keep access behavior stable.',
+    ].join('\n'),
+    labels: [],
+  }));
+
+  assert.ok(result.domains.includes('auth'), `Expected auth in ${result.domains.join(', ')}`);
   assert.ok(result.evidence.some((e) =>
     e.domain === 'auth' && e.term === 'authorization' && e.source === 'title'
+  ));
+});
+
+test('explicit auth signals still trigger auth after boundary matching', () => {
+  const result = classifyDomainsWithEvidence(issue({
+    title: 'Fix login token session handling',
+    body: [
+      'Keep oauth credential and password behavior stable.',
+      'Do not change unrelated frontend copy.',
+    ].join('\n'),
+    labels: ['auth'],
+  }));
+
+  assert.ok(result.domains.includes('auth'), `Expected auth in ${result.domains.join(', ')}`);
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'auth' && e.term === 'login' && e.source === 'title'
+  ));
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'auth' && e.term === 'auth' && e.source === 'labels'
   ));
 });
 
@@ -167,6 +199,40 @@ test('frontend form-action wording does not match database from FormData or form
   assert.ok(!result.evidence.some((e) => e.domain === 'database'), `Expected no database evidence, got ${JSON.stringify(result.evidence)}`);
 });
 
+test('hyphenated frontend form-action wording still matches frontend', () => {
+  const result = classifyDomainsWithEvidence(issue({
+    title: 'Fix server-action form-action add-to-cart flow',
+    body: [
+      'The client-component renders PDP UI feedback.',
+      'Keep FormData handling deterministic.',
+    ].join('\n'),
+    labels: [],
+  }));
+
+  assert.ok(result.domains.includes('frontend'), `Expected frontend in ${result.domains.join(', ')}`);
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'frontend' && e.term === 'server action' && e.source === 'title'
+  ));
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'frontend' && e.term === 'form action' && e.source === 'title'
+  ));
+});
+
+test('FormData alone does not match orm or database by substring', () => {
+  const result = classifyDomainsWithEvidence(issue({
+    title: 'Handle FormData payload in server action',
+    body: [
+      'Parse FormData fields from a frontend form action.',
+      'Keep the UI response deterministic.',
+    ].join('\n'),
+    labels: ['frontend'],
+  }));
+
+  assert.ok(result.domains.includes('frontend'), `Expected frontend in ${result.domains.join(', ')}`);
+  assert.ok(!result.domains.includes('database'), `Expected database to be absent from ${result.domains.join(', ')}`);
+  assert.ok(!result.evidence.some((e) => e.domain === 'database' && e.term === 'orm'), `Expected no orm evidence, got ${JSON.stringify(result.evidence)}`);
+});
+
 test('actual database issue still matches database after form-action suppression', () => {
   const result = classifyDomainsWithEvidence(issue({
     title: 'Add database migration for cart item table schema',
@@ -202,6 +268,36 @@ test('pnpm validation and client wording do not alone make a tooling task', () =
   assert.ok(!result.evidence.some((e) => e.domain === 'tooling'), `Expected no tooling evidence, got ${JSON.stringify(result.evidence)}`);
 });
 
+test('client wording alone does not match cli or tooling by substring', () => {
+  const result = classifyDomainsWithEvidence(issue({
+    title: 'Fix client component form feedback',
+    body: [
+      'The client component should render clear UI feedback.',
+      'Keep the server action response visible to the page.',
+    ].join('\n'),
+    labels: ['frontend'],
+  }));
+
+  assert.ok(result.domains.includes('frontend'), `Expected frontend in ${result.domains.join(', ')}`);
+  assert.ok(!result.domains.includes('tooling'), `Expected tooling to be absent from ${result.domains.join(', ')}`);
+  assert.ok(!result.evidence.some((e) => e.domain === 'tooling' && e.term === 'cli'), `Expected no cli evidence, got ${JSON.stringify(result.evidence)}`);
+});
+
+test('run pnpm build validation wording alone does not match tooling', () => {
+  const result = classifyDomainsWithEvidence(issue({
+    title: 'Fix frontend form feedback',
+    body: [
+      'Run pnpm build and pnpm test as validation.',
+      'Keep the change focused on UI behavior.',
+    ].join('\n'),
+    labels: ['frontend'],
+  }));
+
+  assert.ok(result.domains.includes('frontend'), `Expected frontend in ${result.domains.join(', ')}`);
+  assert.ok(!result.domains.includes('tooling'), `Expected tooling to be absent from ${result.domains.join(', ')}`);
+  assert.ok(!result.evidence.some((e) => e.domain === 'tooling'), `Expected no tooling evidence, got ${JSON.stringify(result.evidence)}`);
+});
+
 test('package manager maintenance still matches tooling when package manager is the task', () => {
   const result = classifyDomainsWithEvidence(issue({
     title: 'Upgrade pnpm package manager version',
@@ -216,6 +312,70 @@ test('package manager maintenance still matches tooling when package manager is 
   assert.ok(result.evidence.some((e) =>
     e.domain === 'tooling' && e.term === 'pnpm' && e.source === 'title'
   ));
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'tooling' && e.term === 'package manager' && e.source === 'title'
+  ));
+});
+
+test('body-only package manager maintenance still matches tooling', () => {
+  const result = classifyDomainsWithEvidence(issue({
+    title: 'Dependency maintenance',
+    body: [
+      'Upgrade pnpm to 10.35.',
+      'Keep the lockfile stable after the package manager version bump.',
+    ].join('\n'),
+    labels: [],
+  }));
+
+  assert.ok(result.domains.includes('tooling'), `Expected tooling in ${result.domains.join(', ')}`);
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'tooling' && e.term === 'pnpm' && e.source === 'body'
+  ));
+});
+
+test('body-only upgrade pnpm wording still matches tooling without exact version hard-coding', () => {
+  const result = classifyDomainsWithEvidence(issue({
+    title: 'Dependency maintenance',
+    body: [
+      'Upgrade pnpm to 10.35.',
+      'Keep lockfile behavior stable after the version bump.',
+    ].join('\n'),
+    labels: [],
+  }));
+
+  assert.ok(result.domains.includes('tooling'), `Expected tooling in ${result.domains.join(', ')}`);
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'tooling' && e.term === 'pnpm' && e.source === 'body'
+  ));
+});
+
+test('package manager version wording matches tooling without a concrete manager name', () => {
+  const result = classifyDomainsWithEvidence(issue({
+    title: 'Update package manager version',
+    body: [
+      'Keep workspace install behavior stable.',
+      'Do not change runtime features.',
+    ].join('\n'),
+    labels: [],
+  }));
+
+  assert.ok(result.domains.includes('tooling'), `Expected tooling in ${result.domains.join(', ')}`);
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'tooling' && e.term === 'package manager' && e.source === 'title'
+  ));
+});
+
+test('hyphenated package-manager wording matches tooling', () => {
+  const result = classifyDomainsWithEvidence(issue({
+    title: 'Update package-manager version',
+    body: [
+      'Keep workspace install behavior stable.',
+      'Do not change runtime features.',
+    ].join('\n'),
+    labels: [],
+  }));
+
+  assert.ok(result.domains.includes('tooling'), `Expected tooling in ${result.domains.join(', ')}`);
   assert.ok(result.evidence.some((e) =>
     e.domain === 'tooling' && e.term === 'package manager' && e.source === 'title'
   ));


### PR DESCRIPTION
## Summary

- 修正 domain classifier 的 substring false positives，避免 `FormData` 誤中 `orm`、`client` 誤中 `cli`。
- 將 frontend form-action / PDP / add-to-cart / server action 類 wording 穩定導向現有最接近的 `frontend` domain。
- 補上 focused regression tests，確認 genuine `auth`、`database`、`tooling` signals 仍可命中。

## Scope

- 修改 `src/classifier/domain.ts` 的 deterministic keyword matching / weak tooling suppression。
- 新增 `tests/classifier/domain.test.ts` regression coverage。
- 最小更新 `docs/classifier.md` 說明 classifier 行為邊界。

## Non-goals

- 不處理 #164 reference basename dedupe。
- 不處理 #165 checkout-related source discovery。
- 不處理 #166 nested checklist parsing。
- 不改 reference extraction / alias hints。
- 不改 task package template、CLI command / flag、config schema。
- 不新增 hidden LLM、semantic classifier、RAG 或 vector search。
- 不修改 target repo / nurockplayer/storefront / nurockplayer/tachiya。

## Validation

- `pnpm install --frozen-lockfile`：pass，worktree dependency setup only。
- `pnpm build && node --test tests/classifier/domain.test.ts`：pass，23/23。
- `git diff --check`：pass。
- `pnpm build`：pass。
- `pnpm test`：pass，112/112。
- `pnpm lint`：skipped，`package.json` 沒有 `lint` script。
- `pnpm typecheck`：skipped，`package.json` 沒有 `typecheck` script。

## Review finding assessment

- Codex P1 `Keep stem keywords matchable after boundary check`：adopted。新增 `authentication` / `authorization` / explicit auth regressions，並保留 boundary matching 以避免 unsafe substring false positives。
- Codex P1 `Do not drop tooling when package-manager term is primary signal`：adopted。新增 package-manager maintenance regressions，並只 suppress validation-command noise。
- CodeRabbit minor hyphenated phrase comment：adopted as same boundary-matcher follow-up。Phrase matching now allows whitespace / hyphen separators, covering `server-action` / `form-action` / `package-manager` without returning to global substring matching。

## Implementation Evidence

- Issue evidence comment URL：https://github.com/Erick52106/spec-injector/issues/163#issuecomment-4366458473
- Commit hash / latest HEAD：80ecb6ac642d833e945116c08b467dd55db24de3
- Scope guard：本 PR 僅修改 classifier scoring / suppression / regression coverage 與最小 docs 說明。
- Source dogfood evidence：https://github.com/Erick52106/spec-injector/issues/151#issuecomment-4366262826

## Follow-up notes

- #165 checkout-related source discovery 與 #166 nested checklist parsing 仍是獨立 follow-up，未在本 PR 處理。
- 若未來要支援 checkout / storefront 更細 domain，應另開 taxonomy / custom-domain design issue；本 PR 只使用既有 `frontend` domain。

Closes #163
