### PR TITLE
fix(parser): preserve nested verification checklist subcases in generated prompt

### DIFF
--- a/docs/task-package.md
+++ b/docs/task-package.md
@@ -49,6 +49,8 @@ Prompt output 目前包含：
 - Instructions
 - Suggested verification checklist
 
+若 issue body 的 checklist item 底下有 nested subcases，output 應保留 parent checklist item 與 nested bullet hierarchy。這些 subcases 只來自 source issue body，不應由 runtime 推測或擴寫。
+
 Always-Read Files 會標示 reference source，讓 built-in preset references 與 repo `always_read` references 不會被混淆。Prompt output 以 compact path list 顯示 source label；full task package 會在每個 inline reference content 前加入 source metadata。
 
 Issue-mentioned references 會和 auto-discovered references 分開呈現。Issue-mentioned docs/source files 標示為 `issue-mentioned`，auto-discovered docs/source files 標示為 `auto-discovered`，讓 explicit issue signal 與 inferred discovery signal 不會混在同一個 section。

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -255,6 +255,7 @@ function extractIssueChecklist(body: string): string {
     if (!parentMatch) continue;
 
     const parentIndent = parentMatch[1]?.length ?? 0;
+    if (parentIndent > 0) continue;
     extracted.push(lines[index].replace(/[ \t]+$/u, ''));
 
     let nestedIndex = index + 1;
@@ -282,7 +283,7 @@ function extractIssueChecklist(body: string): string {
 }
 
 function isNestedChecklistSubcase(line: string): boolean {
-  return /^[ \t]+(?:-|\*|\d+\.) (?!\[ \] ).+/u.test(line);
+  return /^[ \t]+(?:-|\*|\d+\.) (?:\[[ xX]\] )?.+/u.test(line);
 }
 
 function renderReadIssueLabel(doc: DocSection): string {

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -205,10 +205,7 @@ function buildTemplateVars(
   issueSources: DocSection[],
   discoveredSources: DocSection[]
 ): TemplateVars {
-  const checklist = issue.body
-    .split('\n')
-    .filter((l) => l.trim().startsWith('- [ ]'))
-    .join('\n') || '(none found)';
+  const checklist = extractIssueChecklist(issue.body);
 
   const missingList = missingDocs.length > 0
     ? missingDocs.map((d) => `- \`${d.filePath}\` — ${renderReadIssueLabel(d)}${renderReadIssueMetadataSuffix(d)}`).join('\n')
@@ -247,6 +244,45 @@ function buildTemplateVars(
     repo_path: repoPath,
     generated_at: new Date().toISOString(),
   };
+}
+
+function extractIssueChecklist(body: string): string {
+  const lines = body.split('\n');
+  const extracted: string[] = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const parentMatch = lines[index]?.match(/^([ \t]*)- \[ \] .+/);
+    if (!parentMatch) continue;
+
+    const parentIndent = parentMatch[1]?.length ?? 0;
+    extracted.push(lines[index].replace(/[ \t]+$/u, ''));
+
+    let nestedIndex = index + 1;
+    while (nestedIndex < lines.length) {
+      const line = lines[nestedIndex] ?? '';
+      if (line.trim().length === 0) {
+        nestedIndex += 1;
+        continue;
+      }
+
+      const indentation = line.match(/^[ \t]*/u)?.[0].length ?? 0;
+      if (indentation <= parentIndent) break;
+
+      if (isNestedChecklistSubcase(line)) {
+        extracted.push(line.replace(/[ \t]+$/u, ''));
+      }
+
+      nestedIndex += 1;
+    }
+
+    index = nestedIndex - 1;
+  }
+
+  return extracted.join('\n') || '(none found)';
+}
+
+function isNestedChecklistSubcase(line: string): boolean {
+  return /^[ \t]+(?:-|\*|\d+\.) (?!\[ \] ).+/u.test(line);
 }
 
 function renderReadIssueLabel(doc: DocSection): string {

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -2378,6 +2378,70 @@ test('spec plan preserves nested verification checklist subcases in prompt and f
   assert.match(fullResult.stdout, /## 10\. Suggested Verification Checklist[\s\S]*    - deeper implementation note/);
 });
 
+test('spec plan preserves nested checkbox checklist subcases', async (t) => {
+  const fixture = await createExplicitPathPlanFixture(t, {
+    issueNumber: 166,
+    title: 'Preserve nested checkbox verification subcases',
+    bodyLines: [
+      'Verification checklist:',
+      '- [ ] parent verification item',
+      '  - [ ] checkbox subcase one',
+      '  - [ ] checkbox subcase two',
+    ],
+  });
+
+  const promptResult = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'],
+    { env: fixture.env }
+  );
+  const fullResult = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run'],
+    { env: fixture.env }
+  );
+
+  assert.equal(promptResult.code, 0, promptResult.stderr);
+  assert.equal(fullResult.code, 0, fullResult.stderr);
+
+  const promptChecklist = sectionBetween(promptResult.stdout, 'Suggested verification checklist:', 'Read the referenced files as needed');
+
+  assertOrderedSubstrings(promptChecklist, [
+    '- [ ] parent verification item',
+    '  - [ ] checkbox subcase one',
+    '  - [ ] checkbox subcase two',
+  ]);
+  assert.match(fullResult.stdout, /## 10\. Suggested Verification Checklist[\s\S]*- \[ \] parent verification item/);
+  assert.match(fullResult.stdout, /## 10\. Suggested Verification Checklist[\s\S]*  - \[ \] checkbox subcase one/);
+  assert.match(fullResult.stdout, /## 10\. Suggested Verification Checklist[\s\S]*  - \[ \] checkbox subcase two/);
+});
+
+test('spec plan preserves mixed nested checkbox and plain bullet checklist subcases', async (t) => {
+  const fixture = await createExplicitPathPlanFixture(t, {
+    issueNumber: 166,
+    title: 'Preserve mixed nested checkbox and bullet subcases',
+    bodyLines: [
+      'Verification checklist:',
+      '- [ ] parent verification item',
+      '  - [ ] checkbox subcase',
+      '  - plain bullet subcase',
+    ],
+  });
+
+  const promptResult = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'],
+    { env: fixture.env }
+  );
+
+  assert.equal(promptResult.code, 0, promptResult.stderr);
+
+  const promptChecklist = sectionBetween(promptResult.stdout, 'Suggested verification checklist:', 'Read the referenced files as needed');
+
+  assertOrderedSubstrings(promptChecklist, [
+    '- [ ] parent verification item',
+    '  - [ ] checkbox subcase',
+    '  - plain bullet subcase',
+  ]);
+});
+
 test('spec plan keeps flat verification checklist behavior stable', async (t) => {
   const fixture = await createExplicitPathPlanFixture(t, {
     issueNumber: 166,

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -2336,3 +2336,127 @@ test('spec plan tachigo-like fixture extracts explicit source files without misc
   assert.doesNotMatch(promptResult.stdout, /Missing Files[\s\S]*\/api\/v1\/dashboard\/settings/);
   assert.match(promptResult.stdout, /sources:\s*5/);
 });
+
+test('spec plan preserves nested verification checklist subcases in prompt and full output', async (t) => {
+  const fixture = await createExplicitPathPlanFixture(t, {
+    issueNumber: 166,
+    title: 'Preserve nested verification checklist subcases',
+    bodyLines: [
+      'Verification checklist:',
+      '- [ ] preserve parent verification item',
+      '  - first nested failure mode',
+      '  - second nested failure mode',
+      '    - deeper implementation note',
+      '- [ ] keep sibling verification item',
+    ],
+  });
+
+  const promptResult = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'],
+    { env: fixture.env }
+  );
+  const fullResult = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run'],
+    { env: fixture.env }
+  );
+
+  assert.equal(promptResult.code, 0, promptResult.stderr);
+  assert.equal(fullResult.code, 0, fullResult.stderr);
+
+  const promptChecklist = sectionBetween(promptResult.stdout, 'Suggested verification checklist:', 'Read the referenced files as needed');
+
+  assertOrderedSubstrings(promptChecklist, [
+    '- [ ] preserve parent verification item',
+    '  - first nested failure mode',
+    '  - second nested failure mode',
+    '    - deeper implementation note',
+    '- [ ] keep sibling verification item',
+  ]);
+  assert.match(fullResult.stdout, /## 10\. Suggested Verification Checklist[\s\S]*- \[ \] preserve parent verification item/);
+  assert.match(fullResult.stdout, /## 10\. Suggested Verification Checklist[\s\S]*  - first nested failure mode/);
+  assert.match(fullResult.stdout, /## 10\. Suggested Verification Checklist[\s\S]*  - second nested failure mode/);
+  assert.match(fullResult.stdout, /## 10\. Suggested Verification Checklist[\s\S]*    - deeper implementation note/);
+});
+
+test('spec plan keeps flat verification checklist behavior stable', async (t) => {
+  const fixture = await createExplicitPathPlanFixture(t, {
+    issueNumber: 166,
+    title: 'Keep flat checklist behavior stable',
+    bodyLines: [
+      'Validation checklist:',
+      '- [ ] run build before review',
+      '- [ ] run tests before review',
+    ],
+  });
+
+  const promptResult = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'],
+    { env: fixture.env }
+  );
+
+  assert.equal(promptResult.code, 0, promptResult.stderr);
+
+  const promptChecklist = sectionBetween(promptResult.stdout, 'Suggested verification checklist:', 'Read the referenced files as needed');
+
+  assert.match(promptChecklist, /- \[ \] run build before review/);
+  assert.match(promptChecklist, /- \[ \] run tests before review/);
+  assert.doesNotMatch(promptChecklist, /  - /);
+});
+
+test('spec plan does not promote unrelated nested prose bullets into verification checklist', async (t) => {
+  const fixture = await createExplicitPathPlanFixture(t, {
+    issueNumber: 166,
+    title: 'Keep unrelated nested prose bullets out of checklist extraction',
+    bodyLines: [
+      'Planning notes:',
+      '- parent prose bullet that should stay outside verification checklist',
+      '  - nested prose bullet that should stay outside verification checklist',
+      '- [ ] actual verification parent',
+      '  - expected nested verification subcase',
+    ],
+  });
+
+  const promptResult = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'],
+    { env: fixture.env }
+  );
+
+  assert.equal(promptResult.code, 0, promptResult.stderr);
+
+  const promptChecklist = sectionBetween(promptResult.stdout, 'Suggested verification checklist:', 'Read the referenced files as needed');
+
+  assert.doesNotMatch(promptChecklist, /parent prose bullet/);
+  assert.doesNotMatch(promptChecklist, /nested prose bullet that should stay outside verification checklist/);
+  assert.match(promptChecklist, /- \[ \] actual verification parent/);
+  assert.match(promptChecklist, /  - expected nested verification subcase/);
+});
+
+test('spec plan preserves dogfood-shaped silent fail checklist subcases', async (t) => {
+  const fixture = await createExplicitPathPlanFixture(t, {
+    issueNumber: 166,
+    title: 'Preserve brownfield dogfood verification subcases',
+    bodyLines: [
+      'Suggested regression coverage:',
+      '- [ ] silent fail / error handling for add-to-cart',
+      '  - checkout creation failure',
+      '  - GraphQL mutation error including `checkoutLinesAdd.errors`',
+      '  - unexpected exception',
+    ],
+  });
+
+  const promptResult = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'],
+    { env: fixture.env }
+  );
+
+  assert.equal(promptResult.code, 0, promptResult.stderr);
+
+  const promptChecklist = sectionBetween(promptResult.stdout, 'Suggested verification checklist:', 'Read the referenced files as needed');
+
+  assertOrderedSubstrings(promptChecklist, [
+    '- [ ] silent fail / error handling for add-to-cart',
+    '  - checkout creation failure',
+    '  - GraphQL mutation error including `checkoutLinesAdd.errors`',
+    '  - unexpected exception',
+  ]);
+});


### PR DESCRIPTION
Closes #166

## Summary
- 修正 `spec plan` 的 verification checklist extraction，保留 parent checklist item 底下的 nested subcases。
- 補強 nested checkbox child 的 extraction，避免 `- [ ] parent` 底下的 `  - [ ] subcase` 在 prompt / full output 中 silently disappear。
- 補上 focused regression tests，覆蓋 nested checklist、nested checkbox checklist、mixed nested checkbox/plain bullet、flat checklist 相容性、非 checklist nested bullets 不誤升格，以及 dogfood-shaped `silent fail` case。

## Scope
- `src/cli/plan.ts` 的 issue checklist extraction / rendering
- `tests/cli.integration.test.ts` 的 focused regression coverage
- `docs/task-package.md` 的既有最小說明維持不變

## Non-goals
- 不修改 GitHub issue loading behavior
- 不修改 CLI command / flag
- 不修改 config schema
- 不處理 #163、#164、#165、reference discovery / alias hints、task package 大改、hidden LLM / semantic interpretation / vector search

## Validation
- `node --test --test-name-pattern "checklist" tests/cli.integration.test.ts`
- `git diff --check`
- `pnpm build`
- `pnpm test`
- `lint` skipped: `package.json` 沒有 `lint` script
- `typecheck` skipped: `package.json` 沒有 `typecheck` script；本 repo 以 `pnpm build` 執行 `tsc`

## Review finding assessment
- Codex auto review `Keep nested checkbox items when extracting subcases`: `adopted`
  - 原因：這是有效 finding，屬於 #166 scope；原本 implementation 會保留 nested plain bullets，但會漏掉 nested checkbox children。
  - 修正：只允許 top-level `- [ ]` line 啟動 checklist block，並保留 nested subcases 中的 task-list children 與 plain bullets。

## Implementation Evidence
- latest HEAD: `26d1ceb4a432b4b4d6753b85787d79f7f27c0119`
- issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/166#issuecomment-4369737682
- previous evidence comment URL: https://github.com/Erick52106/spec-injector/issues/166#issuecomment-4369648634
- previous HEAD: `f90714a1b9edec1b74d8fca411ca8f2fe1894f0f`
- scope guard: 只處理 #166 的 parser / checklist extraction / prompt rendering gap 與 regression tests

## Source dogfood evidence
- #151 canonical dogfood report: https://github.com/Erick52106/spec-injector/issues/151#issuecomment-4366262826

## Follow-up notes
- 這次維持 deterministic source-trust boundary：只保留 source issue body 已存在的 nested subcases，不推測額外 failure modes。
- 目前 renderer 直接保留 nested bullet indentation；若未來要改輸出格式，應另外走 output-contract issue 與 regression 更新。
