### PR TITLE
feat(workflow): add preflight checks for isolated worktree task execution

### DIFF
--- a/docs/internal-workflow-contract.md
+++ b/docs/internal-workflow-contract.md
@@ -4,6 +4,8 @@
 
 本文件是 #147 的 design-only proposal，定義 `spec-injector` repo 自身使用的 internal machine-readable workflow contract vocabulary。
 
+目前已有第一個 narrow consumer：repo-local、human-readable 的 `spec preflight` checker。它只實作 #108 所需的 bounded preflight subset，用來檢查 main repo / worktree / branch / target repo safety guardrails；它不把本文件變成 runtime schema、JSON output protocol、hosted control plane 或 remediation automation。
+
 它的第一用途是維持 `spec-injector` 專案本身的 AI-assisted development workflow consistency，讓未來 #108 / #109 / #110 這類 repo-local workflow guardrail checkers 有共同規格來源。
 
 Dogfood finding、review blocker、CI failure、target repo safety near miss 與 evidence freshness gap 如何進入 follow-up issue / regression / closeout loop，見 [harness-gap-loop.md](harness-gap-loop.md)。該 loop 使用本文件的 risk-tier、validation、evidence 與 review vocabulary，但不新增 runtime contract。

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -130,6 +130,7 @@ Required:
 - `pnpm build`
 - `pnpm test`
 - CLI smoke checks, such as `node bin/spec.js --help` or relevant command help.
+- For workflow guardrail commands such as `spec preflight`, review human-readable pass / warning / fail wording and confirm the command does not auto-fix git or target repo state.
 
 Required review checks:
 
@@ -137,6 +138,7 @@ Required review checks:
 - Exit code, stderr, and stdout behavior are documented when changed.
 - New command or flag exists only when explicitly scoped by the issue.
 - Runtime behavior remains deterministic and inspectable.
+- Workflow guardrail commands remain repo-local safety tooling, not hosted control plane, daemon, merge bot, or remediation loop.
 
 ### 7. Tooling / package manager / Node changes
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -46,6 +46,25 @@ git status
 
 Worktree 狀態必須 clean 才能實作。之後的 edit / test / commit / push / PR 都在該 worktree 內完成。
 
+若本地已安裝 repo-local CLI，可在 dedicated worktree 內先執行 human-readable preflight：
+
+```bash
+spec preflight \
+  --repo "$PWD" \
+  --expected-branch <branch-name> \
+  --expected-worktree-root ~/.config/superpowers/worktrees/spec-injector
+```
+
+`spec preflight` 是 repo-local workflow guardrail。它只做 deterministic read-only checks，report `pass` / `warning` / `fail` / `needs-human-review` 類結果，不自動 `stash`、`clean`、`reset`、`checkout` 或修復任何狀態。若 main repo dirty、current worktree dirty、current checkout 其實是 main worktree、或 branch / worktree expectation 不符，應 stop-and-report，再由 human / implementer 決定下一步。
+
+若同時需要 read-only target repo safety 提醒，可加上：
+
+```bash
+spec preflight --repo "$PWD" --target-repo <target-repo-path>
+```
+
+此檢查只回報 target repo 狀態與 safety reminder，不得修改 target repo、不得建立 target repo `.spec-injector/`、不得在 target repo 建 branch / commit / PR。
+
 ## Worktree naming
 
 建議命名：

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -114,6 +114,36 @@ Safety:
     await clean(opts);
   });
 
+// preflight subcommand
+program
+  .command('preflight')
+  .description('Run repo-local preflight checks for isolated worktree task execution')
+  .option('--repo <path>', 'Path to the current implementation worktree (default: CWD)')
+  .option('--expected-branch <name>', 'Expected current branch name for the dedicated worktree')
+  .option('--expected-worktree-root <path>', 'Expected parent directory for dedicated worktrees')
+  .option('--target-repo <path>', 'Optional target repo path for read-only safety checks')
+  .addHelpText('after', `
+Checks:
+  - main repo clean / synced status
+  - dedicated worktree vs main worktree
+  - current branch and worktree cleanliness
+  - expected branch and expected worktree root / naming
+  - optional target repo read-only safety reminder
+
+Safety:
+  Does not auto-fix, stash, clean, reset, checkout, or mutate target repos.
+  Failing checks should trigger stop-and-report before implementation continues.
+`)
+  .action(async (opts: {
+    repo?: string;
+    expectedBranch?: string;
+    expectedWorktreeRoot?: string;
+    targetRepo?: string;
+  }) => {
+    const { preflight } = await import('./preflight.js');
+    await preflight(opts);
+  });
+
 program.parseAsync(process.argv).catch((err: unknown) => {
   console.error(`✗ ${(err as Error).message}`);
   process.exit(1);

--- a/src/cli/preflight.ts
+++ b/src/cli/preflight.ts
@@ -32,7 +32,7 @@ export async function preflight(opts: PreflightOptions): Promise<void> {
     const report = buildPreflightReport(repoPath, opts);
     printReport(report);
 
-    if (report.overall === 'fail') {
+    if (report.overall === 'fail' || report.overall === 'needs-human-review') {
       process.exit(1);
     }
   } catch (err) {
@@ -53,6 +53,7 @@ function buildPreflightReport(repoPath: string, opts: PreflightOptions): {
   const mainRepoPath = canonicalizePath(
     requireGitString(getMainWorktreePath(repoPath), 'Could not determine main repo worktree path.')
   );
+  const mainBranch = requireGitString(getCurrentBranch(mainRepoPath), 'Could not determine main repo branch.');
 
   const mainState = getWorktreeState(mainRepoPath);
   if (mainState.kind === 'clean') {
@@ -65,12 +66,21 @@ function buildPreflightReport(repoPath: string, opts: PreflightOptions): {
     checks.push(needsHumanReview('unable to determine main repo worktree state', mainState.message));
   }
 
+  if (mainBranch === 'main') {
+    checks.push(pass('main repo worktree is on main', mainBranch));
+  } else {
+    checks.push(fail(
+      'main repo worktree is not on main',
+      `Expected main but found ${mainBranch}. Stop and report; do not auto-checkout.`
+    ));
+  }
+
   const upstreamState = getUpstreamState(mainRepoPath);
   if (upstreamState.kind === 'up-to-date') {
-    checks.push(pass('main repo is up to date with origin/main', upstreamState.upstream));
+    checks.push(pass(`main repo is up to date with ${upstreamState.upstream}`, upstreamState.upstream));
   } else if (upstreamState.kind === 'diverged') {
     checks.push(fail(
-      'main repo is not up to date with origin/main',
+      `main repo is not up to date with ${upstreamState.upstream}`,
       `${upstreamState.upstream} ahead=${upstreamState.ahead}, behind=${upstreamState.behind}.`
     ));
   } else if (upstreamState.kind === 'no-upstream') {

--- a/src/cli/preflight.ts
+++ b/src/cli/preflight.ts
@@ -1,0 +1,260 @@
+import path from 'path';
+import fs from 'fs';
+import { ensureRepoPath } from '../utils/fs.js';
+import {
+  getCurrentBranch,
+  getGitTopLevel,
+  getMainWorktreePath,
+  getUpstreamState,
+  getWorktreeState,
+} from '../utils/git.js';
+
+type PreflightSeverity = 'pass' | 'warning' | 'fail' | 'needs-human-review';
+
+type PreflightCheck = {
+  severity: PreflightSeverity;
+  summary: string;
+  detail: string;
+};
+
+type PreflightOptions = {
+  repo?: string;
+  expectedBranch?: string;
+  expectedWorktreeRoot?: string;
+  targetRepo?: string;
+};
+
+export async function preflight(opts: PreflightOptions): Promise<void> {
+  const repoPath = canonicalizePath(path.resolve(opts.repo ?? process.cwd()));
+
+  try {
+    ensureRepoPath(repoPath);
+    const report = buildPreflightReport(repoPath, opts);
+    printReport(report);
+
+    if (report.overall === 'fail') {
+      process.exit(1);
+    }
+  } catch (err) {
+    console.error(`✗ Preflight failed: ${(err as Error).message}`);
+    process.exit(1);
+  }
+}
+
+function buildPreflightReport(repoPath: string, opts: PreflightOptions): {
+  overall: PreflightSeverity;
+  checks: PreflightCheck[];
+} {
+  const checks: PreflightCheck[] = [];
+  const currentTopLevel = canonicalizePath(
+    requireGitString(getGitTopLevel(repoPath), 'Could not determine current git worktree path.')
+  );
+  const currentBranch = requireGitString(getCurrentBranch(repoPath), 'Could not determine current branch.');
+  const mainRepoPath = canonicalizePath(
+    requireGitString(getMainWorktreePath(repoPath), 'Could not determine main repo worktree path.')
+  );
+
+  const mainState = getWorktreeState(mainRepoPath);
+  if (mainState.kind === 'clean') {
+    checks.push(pass('main repo worktree is clean', mainRepoPath));
+  } else if (mainState.kind === 'dirty') {
+    checks.push(fail('main repo worktree is dirty', 'Stop and report; do not auto-stash, clean, or reset.'));
+  } else if (mainState.kind === 'not-git') {
+    checks.push(needsHumanReview('main repo worktree is not a git repo', mainRepoPath));
+  } else {
+    checks.push(needsHumanReview('unable to determine main repo worktree state', mainState.message));
+  }
+
+  const upstreamState = getUpstreamState(mainRepoPath);
+  if (upstreamState.kind === 'up-to-date') {
+    checks.push(pass('main repo is up to date with origin/main', upstreamState.upstream));
+  } else if (upstreamState.kind === 'diverged') {
+    checks.push(fail(
+      'main repo is not up to date with origin/main',
+      `${upstreamState.upstream} ahead=${upstreamState.ahead}, behind=${upstreamState.behind}.`
+    ));
+  } else if (upstreamState.kind === 'no-upstream') {
+    checks.push(warning(
+      'main repo has no upstream configured',
+      'Needs human review before assuming main is synced.'
+    ));
+  } else if (upstreamState.kind === 'not-git') {
+    checks.push(needsHumanReview('main repo is not a git repo', mainRepoPath));
+  } else {
+    checks.push(needsHumanReview('unable to determine main repo upstream state', upstreamState.message));
+  }
+
+  if (currentTopLevel === mainRepoPath) {
+    checks.push(fail(
+      'current checkout is the main repo worktree',
+      'Implementation must run from a dedicated worktree.'
+    ));
+  } else {
+    checks.push(pass('current worktree is dedicated', currentTopLevel));
+  }
+
+  if (opts.expectedBranch) {
+    if (currentBranch === opts.expectedBranch) {
+      checks.push(pass('current branch matches expected branch', currentBranch));
+    } else {
+      checks.push(fail(
+        'current branch does not match expected branch',
+        `Expected ${opts.expectedBranch} but found ${currentBranch}.`
+      ));
+    }
+  } else {
+    checks.push(pass('current branch detected', currentBranch));
+  }
+
+  const currentState = getWorktreeState(currentTopLevel);
+  if (currentState.kind === 'clean') {
+    checks.push(pass('current worktree is clean', currentTopLevel));
+  } else if (currentState.kind === 'dirty') {
+    checks.push(fail(
+      'current worktree is dirty',
+      'Stop and report; do not auto-stash, clean, or reset.'
+    ));
+  } else if (currentState.kind === 'not-git') {
+    checks.push(needsHumanReview('current worktree is not a git repo', currentTopLevel));
+  } else {
+    checks.push(needsHumanReview('unable to determine current worktree state', currentState.message));
+  }
+
+  if (opts.expectedWorktreeRoot) {
+    const expectedRoot = canonicalizePath(path.resolve(opts.expectedWorktreeRoot));
+    const expectedPath = opts.expectedBranch
+      ? path.join(expectedRoot, toWorktreeSlug(opts.expectedBranch))
+      : null;
+
+    if (expectedPath && currentTopLevel === expectedPath) {
+      checks.push(pass('current worktree path matches expected location/naming', currentTopLevel));
+    } else if (isWithinRoot(currentTopLevel, expectedRoot)) {
+      const detail = expectedPath
+        ? `Current path ${currentTopLevel} stays under ${expectedRoot}, but expected ${expectedPath}.`
+        : `Current path ${currentTopLevel} stays under ${expectedRoot}.`;
+      checks.push(warning('current worktree path needs naming review', detail));
+    } else {
+      checks.push(warning(
+        'current worktree path is outside the expected worktree root',
+        `Expected root ${expectedRoot}, found ${currentTopLevel}.`
+      ));
+    }
+  } else {
+    checks.push(pass('current worktree path detected', currentTopLevel));
+  }
+
+  if (opts.targetRepo) {
+    const targetRepoPath = canonicalizePath(path.resolve(opts.targetRepo));
+    ensureRepoPath(targetRepoPath);
+    const targetState = getWorktreeState(targetRepoPath);
+    if (targetState.kind === 'clean') {
+      checks.push(pass(
+        'target repo is clean',
+        'Read-only only unless explicitly authorized; do not create or modify target repo .spec-injector/.'
+      ));
+    } else if (targetState.kind === 'dirty') {
+      checks.push(warning(
+        'target repo is dirty',
+        'Read-only only unless explicitly authorized; do not create or modify target repo .spec-injector/.'
+      ));
+    } else if (targetState.kind === 'not-git') {
+      checks.push(warning(
+        'target repo is not a git repo',
+        'Read-only only unless explicitly authorized; do not create or modify target repo .spec-injector/.'
+      ));
+    } else {
+      checks.push(needsHumanReview('unable to determine target repo worktree state', targetState.message));
+    }
+  }
+
+  return {
+    overall: summarizeOverall(checks),
+    checks,
+  };
+}
+
+function requireGitString(
+  result:
+    | { kind: 'ok'; value: string }
+    | { kind: 'not-git' }
+    | { kind: 'unknown'; message: string },
+  errorMessage: string
+): string {
+  if (result.kind === 'ok' && result.value) {
+    return result.value;
+  }
+
+  if (result.kind === 'not-git') {
+    throw new Error(`${errorMessage} Repo is not a git worktree.`);
+  }
+
+  if (result.kind === 'unknown') {
+    throw new Error(`${errorMessage} ${result.message}`);
+  }
+
+  throw new Error(errorMessage);
+}
+
+function summarizeOverall(checks: PreflightCheck[]): PreflightSeverity {
+  if (checks.some((check) => check.severity === 'fail')) {
+    return 'fail';
+  }
+  if (checks.some((check) => check.severity === 'needs-human-review')) {
+    return 'needs-human-review';
+  }
+  if (checks.some((check) => check.severity === 'warning')) {
+    return 'warning';
+  }
+  return 'pass';
+}
+
+function printReport(report: { overall: PreflightSeverity; checks: PreflightCheck[] }): void {
+  const counts = {
+    pass: report.checks.filter((check) => check.severity === 'pass').length,
+    warning: report.checks.filter((check) => check.severity === 'warning').length,
+    fail: report.checks.filter((check) => check.severity === 'fail').length,
+    needsHumanReview: report.checks.filter((check) => check.severity === 'needs-human-review').length,
+  };
+
+  console.log(
+    `Preflight summary: ${report.overall.toUpperCase()} ` +
+    `(${counts.pass} pass, ${counts.warning} warning, ${counts.fail} fail, ${counts.needsHumanReview} needs-human-review)`
+  );
+
+  for (const check of report.checks) {
+    console.log(`[${check.severity.toUpperCase()}] ${check.summary} — ${check.detail}`);
+  }
+}
+
+function pass(summary: string, detail: string): PreflightCheck {
+  return { severity: 'pass', summary, detail };
+}
+
+function warning(summary: string, detail: string): PreflightCheck {
+  return { severity: 'warning', summary, detail };
+}
+
+function fail(summary: string, detail: string): PreflightCheck {
+  return { severity: 'fail', summary, detail };
+}
+
+function needsHumanReview(summary: string, detail: string): PreflightCheck {
+  return { severity: 'needs-human-review', summary, detail };
+}
+
+function toWorktreeSlug(branchName: string): string {
+  return branchName.replace(/[\\/]+/g, '-');
+}
+
+function isWithinRoot(candidatePath: string, rootPath: string): boolean {
+  const relativePath = path.relative(rootPath, candidatePath);
+  return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath));
+}
+
+function canonicalizePath(filePath: string): string {
+  try {
+    return fs.realpathSync.native(filePath);
+  } catch {
+    return path.resolve(filePath);
+  }
+}

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1,8 +1,21 @@
+import path from 'path';
 import { run } from './shell.js';
 
 export type WorktreeState =
   | { kind: 'clean' }
   | { kind: 'dirty' }
+  | { kind: 'not-git' }
+  | { kind: 'unknown'; message: string };
+
+export type GitStringResult =
+  | { kind: 'ok'; value: string }
+  | { kind: 'not-git' }
+  | { kind: 'unknown'; message: string };
+
+export type UpstreamState =
+  | { kind: 'up-to-date'; upstream: string; ahead: 0; behind: 0 }
+  | { kind: 'diverged'; upstream: string; ahead: number; behind: number }
+  | { kind: 'no-upstream' }
   | { kind: 'not-git' }
   | { kind: 'unknown'; message: string };
 
@@ -24,6 +37,89 @@ export function getWorktreeState(repoPath: string): WorktreeState {
   return { kind: 'unknown', message };
 }
 
+export function getCurrentBranch(repoPath: string): GitStringResult {
+  return readGitString(repoPath, ['git', 'branch', '--show-current']);
+}
+
+export function getGitTopLevel(repoPath: string): GitStringResult {
+  return readGitString(repoPath, ['git', 'rev-parse', '--show-toplevel']);
+}
+
+export function getMainWorktreePath(repoPath: string): GitStringResult {
+  const commonDir = readGitString(repoPath, ['git', 'rev-parse', '--git-common-dir']);
+  if (commonDir.kind !== 'ok') {
+    return commonDir;
+  }
+
+  const resolvedCommonDir = path.resolve(repoPath, commonDir.value);
+  return { kind: 'ok', value: path.dirname(resolvedCommonDir) };
+}
+
+export function getUpstreamState(repoPath: string): UpstreamState {
+  const upstream = run(
+    ['git', 'rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'],
+    { cwd: repoPath }
+  );
+
+  if (upstream.exitCode !== 0) {
+    const message = `${upstream.stderr}\n${upstream.stdout}`.trim();
+    if (isNotGitRepository(message)) {
+      return { kind: 'not-git' };
+    }
+    if (hasNoUpstream(message)) {
+      return { kind: 'no-upstream' };
+    }
+    return { kind: 'unknown', message };
+  }
+
+  const upstreamRef = upstream.stdout.trim();
+  const counts = run(
+    ['git', 'rev-list', '--left-right', '--count', `${upstreamRef}...HEAD`],
+    { cwd: repoPath }
+  );
+
+  if (counts.exitCode !== 0) {
+    const message = `${counts.stderr}\n${counts.stdout}`.trim();
+    if (isNotGitRepository(message)) {
+      return { kind: 'not-git' };
+    }
+    return { kind: 'unknown', message };
+  }
+
+  const [behindRaw, aheadRaw] = counts.stdout.trim().split(/\s+/);
+  const behind = Number.parseInt(behindRaw ?? '', 10);
+  const ahead = Number.parseInt(aheadRaw ?? '', 10);
+
+  if (!Number.isFinite(ahead) || !Number.isFinite(behind)) {
+    return { kind: 'unknown', message: `Unexpected upstream divergence output: ${counts.stdout.trim()}` };
+  }
+
+  if (ahead === 0 && behind === 0) {
+    return { kind: 'up-to-date', upstream: upstreamRef, ahead: 0, behind: 0 };
+  }
+
+  return { kind: 'diverged', upstream: upstreamRef, ahead, behind };
+}
+
+function readGitString(repoPath: string, argv: string[]): GitStringResult {
+  const result = run(argv, { cwd: repoPath });
+
+  if (result.exitCode === 0) {
+    return { kind: 'ok', value: result.stdout.trim() };
+  }
+
+  const message = `${result.stderr}\n${result.stdout}`.trim();
+  if (isNotGitRepository(message)) {
+    return { kind: 'not-git' };
+  }
+
+  return { kind: 'unknown', message };
+}
+
 function isNotGitRepository(message: string): boolean {
   return /not a git repository/i.test(message);
+}
+
+function hasNoUpstream(message: string): boolean {
+  return /no upstream configured|no upstream branch|has no upstream branch/i.test(message);
 }

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { classifyDomains, classifyDomainsWithEvidence } from '../dist/classifier/domain.js';
 import { config as runConfigCommand } from '../dist/cli/config.js';
 import { renderTemplate } from '../dist/template/renderer.js';
-import { repoRoot, runSpec } from './helpers/cli.ts';
+import { repoRoot, runCommand, runSpec } from './helpers/cli.ts';
 import {
   createExplicitPathPlanFixture,
   createExternalConfigPlanFixture,
@@ -96,6 +96,45 @@ async function createReadFailureEnv(
   return {
     ...baseEnv,
     NODE_OPTIONS: [existingNodeOptions, `--import=${preloadPath}`].filter(Boolean).join(' '),
+  };
+}
+
+async function createStatusFailingGitEnv(
+  t: { after(fn: () => void | Promise<void>): void },
+  baseEnv: NodeJS.ProcessEnv,
+  failCwd: string
+): Promise<{ env: NodeJS.ProcessEnv; logPath: string }> {
+  const binDir = await fs.mkdtemp(path.join(path.dirname(createMissingPath()), 'spec-injector-status-failing-git-'));
+  t.after(async () => {
+    await fs.rm(binDir, { recursive: true, force: true });
+  });
+
+  const realGitPath = (await runCommand('which', ['git'], repoRoot)).stdout.trim();
+  const logPath = path.join(binDir, 'git.log');
+  const gitPath = path.join(binDir, 'git');
+
+  await fs.writeFile(logPath, '', 'utf8');
+  await fs.writeFile(gitPath, [
+    '#!/bin/sh',
+    'printf "%s\\n" "$*" >> "$FAKE_GIT_LOG"',
+    'if [ "$PWD" = "$FAKE_GIT_FAIL_CWD" ] && [ "$1" = "status" ]; then',
+    '  echo "simulated git status failure" >&2',
+    '  exit 2',
+    'fi',
+    'exec "$FAKE_GIT_REAL" "$@"',
+    '',
+  ].join('\n'), 'utf8');
+  await fs.chmod(gitPath, 0o755);
+
+  return {
+    env: {
+      ...baseEnv,
+      PATH: `${binDir}${path.delimiter}${baseEnv.PATH ?? process.env.PATH ?? ''}`,
+      FAKE_GIT_FAIL_CWD: await fs.realpath(failCwd),
+      FAKE_GIT_LOG: logPath,
+      FAKE_GIT_REAL: realGitPath,
+    },
+    logPath,
   };
 }
 
@@ -665,6 +704,43 @@ test('spec preflight passes for a clean dedicated worktree and avoids mutating g
   assertNoGitMutationCommands(gitLog);
 });
 
+test('spec preflight reports the actual main upstream ref in sync summaries', async (t) => {
+  const fixture = await createPreflightFixture(t);
+  await runCommand('git', ['remote', 'rename', 'origin', 'upstream'], fixture.mainRepoDir);
+
+  const result = await runSpec([
+    'preflight',
+    '--repo', fixture.worktreeDir,
+    '--expected-branch', fixture.branchName,
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /main repo is up to date with upstream\/main/i);
+  assert.doesNotMatch(result.stdout, /main repo is up to date with origin\/main/i);
+  const gitLog = (await readGhLog(fixture.gitLogPath)).join('\n');
+  assertNoGitMutationCommands(gitLog);
+});
+
+test('spec preflight fails when the main repo worktree is not on main even if its upstream is current', async (t) => {
+  const fixture = await createPreflightFixture(t);
+  await runCommand('git', ['checkout', '-b', 'main-worktree-feature'], fixture.mainRepoDir);
+  await runCommand('git', ['push', '--set-upstream', 'origin', 'main-worktree-feature'], fixture.mainRepoDir);
+
+  const result = await runSpec([
+    'preflight',
+    '--repo', fixture.worktreeDir,
+    '--expected-branch', fixture.branchName,
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stdout, /Preflight summary:\s+FAIL/i);
+  assert.match(result.stdout, /main repo worktree is not on main/i);
+  assert.match(result.stdout, /found main-worktree-feature/i);
+  assertNoRawStackTrace(result);
+  const gitLog = (await readGhLog(fixture.gitLogPath)).join('\n');
+  assertNoGitMutationCommands(gitLog);
+});
+
 test('spec preflight fails when implementation runs from the main worktree', async (t) => {
   const fixture = await createPreflightFixture(t);
 
@@ -679,6 +755,8 @@ test('spec preflight fails when implementation runs from the main worktree', asy
   assert.match(result.stdout, /current checkout is the main repo worktree/i);
   assert.match(result.stdout, /implementation must run from a dedicated worktree/i);
   assertNoRawStackTrace(result);
+  const gitLog = (await readGhLog(fixture.gitLogPath)).join('\n');
+  assertNoGitMutationCommands(gitLog);
 });
 
 test('spec preflight fails when the main repo worktree is dirty', async (t) => {
@@ -696,6 +774,8 @@ test('spec preflight fails when the main repo worktree is dirty', async (t) => {
   assert.match(result.stdout, /main repo worktree is dirty/i);
   assert.match(result.stdout, /stop and report/i);
   assertNoRawStackTrace(result);
+  const gitLog = (await readGhLog(fixture.gitLogPath)).join('\n');
+  assertNoGitMutationCommands(gitLog);
 });
 
 test('spec preflight fails when current branch does not match the expected branch', async (t) => {
@@ -713,6 +793,8 @@ test('spec preflight fails when current branch does not match the expected branc
   assert.match(result.stdout, /feat\/some-other-branch/i);
   assert.match(result.stdout, new RegExp(escapeRegExp(fixture.branchName)));
   assertNoRawStackTrace(result);
+  const gitLog = (await readGhLog(fixture.gitLogPath)).join('\n');
+  assertNoGitMutationCommands(gitLog);
 });
 
 test('spec preflight fails when the dedicated worktree is dirty', async (t) => {
@@ -730,6 +812,8 @@ test('spec preflight fails when the dedicated worktree is dirty', async (t) => {
   assert.match(result.stdout, /current worktree is dirty/i);
   assert.match(result.stdout, /do not auto-stash, clean, or reset/i);
   assertNoRawStackTrace(result);
+  const gitLog = (await readGhLog(fixture.gitLogPath)).join('\n');
+  assertNoGitMutationCommands(gitLog);
 });
 
 test('spec preflight warns when the main repo has no upstream configured', async (t) => {
@@ -745,6 +829,33 @@ test('spec preflight warns when the main repo has no upstream configured', async
   assert.match(result.stdout, /Preflight summary:\s+WARNING/i);
   assert.match(result.stdout, /main repo has no upstream configured/i);
   assert.match(result.stdout, /needs human review/i);
+  const gitLog = (await readGhLog(fixture.gitLogPath)).join('\n');
+  assertNoGitMutationCommands(gitLog);
+});
+
+test('spec preflight exits non-zero when a check needs human review', async (t) => {
+  const fixture = await createPreflightFixture(t);
+  const targetRepoDir = await createTempRepo(t, 'spec-injector-target-status-failure-');
+  await writeRepoFiles(targetRepoDir, {
+    'README.md': '# Target Status Failure Fixture\n',
+  });
+  await initCleanGitRepo(targetRepoDir);
+  const gitSpy = await createStatusFailingGitEnv(t, fixture.env, targetRepoDir);
+
+  const result = await runSpec([
+    'preflight',
+    '--repo', fixture.worktreeDir,
+    '--expected-branch', fixture.branchName,
+    '--target-repo', targetRepoDir,
+  ], { env: gitSpy.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stdout, /Preflight summary:\s+NEEDS-HUMAN-REVIEW/i);
+  assert.match(result.stdout, /unable to determine target repo worktree state/i);
+  assertNoRawStackTrace(result);
+  const gitLog = (await readGhLog(gitSpy.logPath)).join('\n');
+  assertNoGitMutationCommands(gitLog);
+  await assertFileMissing(path.join(targetRepoDir, '.spec-injector'));
 });
 
 test('spec preflight warns when the target repo is dirty and keeps the boundary read-only', async (t) => {
@@ -768,6 +879,9 @@ test('spec preflight warns when the target repo is dirty and keeps the boundary 
   assert.match(result.stdout, /target repo is dirty/i);
   assert.match(result.stdout, /read-only only unless explicitly authorized/i);
   assert.match(result.stdout, /do not create or modify .*\.spec-injector/i);
+  const gitLog = (await readGhLog(fixture.gitLogPath)).join('\n');
+  assertNoGitMutationCommands(gitLog);
+  await assertFileMissing(path.join(targetRepoDir, '.spec-injector'));
 });
 
 test('spec init scaffolds config files with default discovery settings', async (t) => {

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -11,6 +11,7 @@ import {
   createExternalConfigPlanFixture,
   createFailingGitEnv,
   createMissingPath,
+  createPreflightFixture,
   createSpecPlanFixture,
   createTempRepo,
   initCleanGitRepo,
@@ -25,6 +26,7 @@ import {
   assertDirtyWarning,
   assertFileExists,
   assertFileMissing,
+  assertNoGitMutationCommands,
   assertNoCleanupCommands,
   assertNoRawStackTrace,
   assertOrderedSubstrings,
@@ -630,6 +632,142 @@ test('spec plan/config/clean help describe AI-facing usage and safety constraint
   assert.match(cleanHelp.stdout, /does not remove .*config\.json/i);
   assert.match(cleanHelp.stdout, /unrelated files/i);
   assert.match(cleanHelp.stdout, /--issue <number>/);
+
+  const preflightHelp = await runSpec(['preflight', '--help']);
+  assert.equal(preflightHelp.code, 0, preflightHelp.stderr);
+  assert.match(preflightHelp.stdout, /isolated worktree task execution/i);
+  assert.match(preflightHelp.stdout, /expected branch/i);
+  assert.match(preflightHelp.stdout, /expected worktree root/i);
+  assert.match(preflightHelp.stdout, /target repo/i);
+  assert.match(preflightHelp.stdout, /does not auto-fix/i);
+});
+
+test('spec preflight passes for a clean dedicated worktree and avoids mutating git state', async (t) => {
+  const fixture = await createPreflightFixture(t);
+
+  const result = await runSpec([
+    'preflight',
+    '--repo', fixture.worktreeDir,
+    '--expected-branch', fixture.branchName,
+    '--expected-worktree-root', path.dirname(fixture.worktreeDir),
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Preflight summary:\s+PASS/i);
+  assert.match(result.stdout, /main repo worktree is clean/i);
+  assert.match(result.stdout, /main repo is up to date with origin\/main/i);
+  assert.match(result.stdout, /current worktree is dedicated/i);
+  assert.match(result.stdout, /current worktree is clean/i);
+  assert.match(result.stdout, new RegExp(escapeRegExp(fixture.branchName)));
+  assert.equal(result.stderr, '');
+
+  const gitLog = (await readGhLog(fixture.gitLogPath)).join('\n');
+  assertNoGitMutationCommands(gitLog);
+});
+
+test('spec preflight fails when implementation runs from the main worktree', async (t) => {
+  const fixture = await createPreflightFixture(t);
+
+  const result = await runSpec([
+    'preflight',
+    '--repo', fixture.mainRepoDir,
+    '--expected-branch', 'main',
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stdout, /Preflight summary:\s+FAIL/i);
+  assert.match(result.stdout, /current checkout is the main repo worktree/i);
+  assert.match(result.stdout, /implementation must run from a dedicated worktree/i);
+  assertNoRawStackTrace(result);
+});
+
+test('spec preflight fails when the main repo worktree is dirty', async (t) => {
+  const fixture = await createPreflightFixture(t);
+  await fs.writeFile(path.join(fixture.mainRepoDir, 'main-dirty.txt'), 'dirty main\n', 'utf8');
+
+  const result = await runSpec([
+    'preflight',
+    '--repo', fixture.worktreeDir,
+    '--expected-branch', fixture.branchName,
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stdout, /Preflight summary:\s+FAIL/i);
+  assert.match(result.stdout, /main repo worktree is dirty/i);
+  assert.match(result.stdout, /stop and report/i);
+  assertNoRawStackTrace(result);
+});
+
+test('spec preflight fails when current branch does not match the expected branch', async (t) => {
+  const fixture = await createPreflightFixture(t);
+
+  const result = await runSpec([
+    'preflight',
+    '--repo', fixture.worktreeDir,
+    '--expected-branch', 'feat/some-other-branch',
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stdout, /Preflight summary:\s+FAIL/i);
+  assert.match(result.stdout, /current branch does not match expected branch/i);
+  assert.match(result.stdout, /feat\/some-other-branch/i);
+  assert.match(result.stdout, new RegExp(escapeRegExp(fixture.branchName)));
+  assertNoRawStackTrace(result);
+});
+
+test('spec preflight fails when the dedicated worktree is dirty', async (t) => {
+  const fixture = await createPreflightFixture(t);
+  await fs.writeFile(path.join(fixture.worktreeDir, 'worktree-dirty.txt'), 'dirty worktree\n', 'utf8');
+
+  const result = await runSpec([
+    'preflight',
+    '--repo', fixture.worktreeDir,
+    '--expected-branch', fixture.branchName,
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stdout, /Preflight summary:\s+FAIL/i);
+  assert.match(result.stdout, /current worktree is dirty/i);
+  assert.match(result.stdout, /do not auto-stash, clean, or reset/i);
+  assertNoRawStackTrace(result);
+});
+
+test('spec preflight warns when the main repo has no upstream configured', async (t) => {
+  const fixture = await createPreflightFixture(t, { withUpstream: false });
+
+  const result = await runSpec([
+    'preflight',
+    '--repo', fixture.worktreeDir,
+    '--expected-branch', fixture.branchName,
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Preflight summary:\s+WARNING/i);
+  assert.match(result.stdout, /main repo has no upstream configured/i);
+  assert.match(result.stdout, /needs human review/i);
+});
+
+test('spec preflight warns when the target repo is dirty and keeps the boundary read-only', async (t) => {
+  const fixture = await createPreflightFixture(t);
+  const targetRepoDir = await createTempRepo(t, 'spec-injector-target-repo-');
+  await writeRepoFiles(targetRepoDir, {
+    'README.md': '# Target Repo Fixture\n',
+  });
+  await initCleanGitRepo(targetRepoDir);
+  await fs.writeFile(path.join(targetRepoDir, 'dirty-target.txt'), 'target repo dirty\n', 'utf8');
+
+  const result = await runSpec([
+    'preflight',
+    '--repo', fixture.worktreeDir,
+    '--expected-branch', fixture.branchName,
+    '--target-repo', targetRepoDir,
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Preflight summary:\s+WARNING/i);
+  assert.match(result.stdout, /target repo is dirty/i);
+  assert.match(result.stdout, /read-only only unless explicitly authorized/i);
+  assert.match(result.stdout, /do not create or modify .*\.spec-injector/i);
 });
 
 test('spec init scaffolds config files with default discovery settings', async (t) => {

--- a/tests/helpers/assertions.ts
+++ b/tests/helpers/assertions.ts
@@ -29,6 +29,11 @@ export function assertNoCleanupCommands(value: string): void {
   assert.doesNotMatch(value, /\breset\b/i);
 }
 
+export function assertNoGitMutationCommands(value: string): void {
+  assertNoCleanupCommands(value);
+  assert.doesNotMatch(value, /\bcheckout\b/i);
+}
+
 export function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/tests/helpers/assertions.ts
+++ b/tests/helpers/assertions.ts
@@ -31,7 +31,33 @@ export function assertNoCleanupCommands(value: string): void {
 
 export function assertNoGitMutationCommands(value: string): void {
   assertNoCleanupCommands(value);
-  assert.doesNotMatch(value, /\bcheckout\b/i);
+  const mutatingSubcommands = new Set([
+    'add',
+    'checkout',
+    'cherry-pick',
+    'commit',
+    'merge',
+    'mv',
+    'push',
+    'rebase',
+    'revert',
+    'rm',
+    'switch',
+  ]);
+
+  const lines = value.split('\n').map((line) => line.trim()).filter(Boolean);
+  for (const line of lines) {
+    const [subcommand, nestedSubcommand] = line.split(/\s+/);
+    assert.ok(
+      !mutatingSubcommands.has(subcommand?.toLowerCase() ?? ''),
+      `Unexpected mutating git command: ${line}`
+    );
+    assert.notEqual(
+      `${subcommand ?? ''} ${nestedSubcommand ?? ''}`.toLowerCase(),
+      'worktree add',
+      `Unexpected mutating git command: ${line}`
+    );
+  }
 }
 
 export function escapeRegExp(value: string): string {

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -23,6 +23,14 @@ type PlanFixture = {
   taskPackagePath: string;
 };
 
+type PreflightFixture = {
+  mainRepoDir: string;
+  worktreeDir: string;
+  branchName: string;
+  env: NodeJS.ProcessEnv;
+  gitLogPath: string;
+};
+
 type ExplicitPathPlanFixtureOptions = {
   issueNumber?: number;
   title: string;
@@ -127,6 +135,50 @@ export async function createSpecPlanFixture(t: TestLifecycle): Promise<PlanFixtu
     ghLogPath: fakeGh.logPath,
     issueUrl: issue.url,
     taskPackagePath: path.join(repoDir, '.spec-injector', 'out', 'issue-57-task-package.md'),
+  };
+}
+
+export async function createPreflightFixture(
+  t: TestLifecycle,
+  options: {
+    branchName?: string;
+    worktreeName?: string;
+    withUpstream?: boolean;
+  } = {}
+): Promise<PreflightFixture> {
+  const branchName = options.branchName ?? 'feat/worktree-preflight-checker-108';
+  const worktreeName = options.worktreeName ?? 'feat-worktree-preflight-checker-108';
+  const mainRepoDir = await createTempRepo(t, 'spec-injector-preflight-main-');
+  const worktreeParentDir = await createTempRepo(t, 'spec-injector-preflight-worktrees-');
+  const worktreeDir = path.join(worktreeParentDir, worktreeName);
+
+  await writeRepoFiles(mainRepoDir, {
+    'README.md': '# Preflight Fixture\n',
+  });
+
+  await runCommand('git', ['init', '--initial-branch=main'], mainRepoDir);
+  await runCommand('git', ['config', 'user.email', 'spec-injector@example.test'], mainRepoDir);
+  await runCommand('git', ['config', 'user.name', 'Spec Injector Test'], mainRepoDir);
+  await runCommand('git', ['add', '.'], mainRepoDir);
+  await runCommand('git', ['commit', '-m', 'Initial fixture commit'], mainRepoDir);
+
+  if (options.withUpstream ?? true) {
+    const remoteDir = await createTempRepo(t, 'spec-injector-preflight-remote-');
+    await runCommand('git', ['init', '--bare', remoteDir], mainRepoDir);
+    await runCommand('git', ['remote', 'add', 'origin', remoteDir], mainRepoDir);
+    await runCommand('git', ['push', '--set-upstream', 'origin', 'main'], mainRepoDir);
+  }
+
+  await runCommand('git', ['worktree', 'add', '-b', branchName, worktreeDir, 'main'], mainRepoDir);
+
+  const gitSpy = await createGitSpyEnv(t, process.env);
+
+  return {
+    mainRepoDir,
+    worktreeDir,
+    branchName,
+    env: gitSpy.env,
+    gitLogPath: gitSpy.logPath,
   };
 }
 
@@ -313,6 +365,39 @@ export async function createFailingGitEnv(t: TestLifecycle, baseEnv: NodeJS.Proc
   return {
     ...baseEnv,
     PATH: `${binDir}${path.delimiter}${baseEnv.PATH ?? process.env.PATH ?? ''}`,
+  };
+}
+
+async function createGitSpyEnv(t: TestLifecycle, baseEnv: NodeJS.ProcessEnv): Promise<{
+  env: NodeJS.ProcessEnv;
+  logPath: string;
+}> {
+  const binDir = await fs.mkdtemp(path.join(os.tmpdir(), 'spec-injector-git-spy-'));
+  t.after(async () => {
+    await fs.rm(binDir, { recursive: true, force: true });
+  });
+
+  const realGitPath = (await runCommand('which', ['git'], process.cwd())).stdout.trim();
+  const logPath = path.join(binDir, 'git.log');
+  const gitPath = path.join(binDir, 'git');
+
+  await fs.writeFile(logPath, '', 'utf8');
+  await fs.writeFile(gitPath, [
+    '#!/bin/sh',
+    'printf "%s\\n" "$*" >> "$FAKE_GIT_LOG"',
+    'exec "$FAKE_GIT_REAL" "$@"',
+    '',
+  ].join('\n'), 'utf8');
+  await fs.chmod(gitPath, 0o755);
+
+  return {
+    env: {
+      ...baseEnv,
+      PATH: `${binDir}${path.delimiter}${baseEnv.PATH ?? process.env.PATH ?? ''}`,
+      FAKE_GIT_LOG: logPath,
+      FAKE_GIT_REAL: realGitPath,
+    },
+    logPath,
   };
 }
 


### PR DESCRIPTION
Closes #108

## Summary
- 新增 repo-local `spec preflight` CLI command，將 isolated worktree task execution 的核心 guardrails 轉成 machine-checkable human-readable checks。
- 檢查 main repo clean / sync、main repo 是否仍在 `main`、dedicated worktree vs main worktree、expected branch、current worktree clean state、expected worktree root / naming，以及 optional target repo read-only safety。
- 補上 temp git repo + worktree + git command log 的整合測試，並以最小 docs 更新說明 command 邊界與 stop-and-report 行為。

## Scope
- repo-local CLI preflight command: `spec preflight`
- read-only git state helpers for branch / worktree / upstream checks
- CLI integration tests and fixture helpers for deterministic preflight coverage
- workflow docs update for preflight usage and validation expectations
- review follow-up: adopted CodeRabbit / Codex findings around preflight safety and correctness

## Non-goals
- 不新增 hosted control plane、daemon、agent orchestration、merge bot、remediation loop。
- 不改 config schema、不新增 JSON output protocol、不做 auto-fix。
- 不修改 target repo、不建立 target repo `.spec-injector/`、不在 target repo 建 branch / commit / PR。
- 不處理 #109 PR/evidence checker 或 #110 label audit checker。

## Validation
- `node --test --test-name-pattern "preflight" tests/cli.integration.test.ts` ✅ (10 preflight tests)
- `git diff --check` ✅
- `pnpm build` ✅
- `pnpm test` ✅ (131 tests)
- `pnpm lint`: skipped，`package.json` 沒有 `lint` script
- `pnpm typecheck`: skipped，`package.json` 沒有 `typecheck` script；`pnpm build` 已執行 `tsc`

## Review Finding Assessment
| Finding | Classification | Action | Rationale |
|---|---|---|---|
| Validate main branch before reporting origin/main sync | adopted | 修正 | preflight 現在先確認 main repo worktree checkout 在 `main`，若不是 `main` 直接 fail / stop-and-report；不會 auto-checkout 或 auto-pull。新增 feature-branch upstream-clean regression test。 |
| Treat needs-human-review as non-zero exit | adopted | 修正 | `fail` 與 `needs-human-review` 都會 exit non-zero，避免 scripted flow 繼續跑。新增 target status failure regression test。 |
| Avoid hard-coding origin/main in upstream status summaries | adopted | 修正 | upstream pass / diverged summary 改用 `upstreamState.upstream`，並新增 renamed remote `upstream/main` assertion。 |
| Broaden mutation-command coverage | adopted | 修正 | `assertNoGitMutationCommands` 改成 line/subcommand-aware，覆蓋 `checkout`、`switch`、`reset`、`clean`、`stash`、`commit`、`merge`、`rebase`、`cherry-pick`、`revert`、`push`、`worktree add`、`add`、`rm`、`mv`。 |
| Extend read-only invariant assertions | adopted | 修正 | PASS / FAIL / WARNING / NEEDS-HUMAN-REVIEW preflight paths 都 assert no git mutation commands；target repo tests also assert target `.spec-injector` remains absent。 |

## Implementation Evidence
- Original issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/108#issuecomment-4370217077
- Follow-up issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/108#issuecomment-4370331644
- Previous HEAD: `ab4eb3f17246ed37eb6f14d6656d119274b0f1f3`
- Latest HEAD: `8d71f983b412966a1e047122ad3521e7469e03cf`
- Scope guard: 只做 repo-local preflight guardrail review follow-up，不擴到 #109 / #110、control plane、或 target repo mutation。

## Follow-up notes
- 目前 `spec preflight` 維持 human-readable pass / warning / fail / needs-human-review style output；JSON / protocol output 仍留在後續 issue 討論。
- #109 PR / evidence / HEAD consistency checker 與 #110 label audit checker 仍應維持獨立 scope。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a repo-local "spec preflight" command for dedicated git worktrees that reports pass/warning/fail/needs-human-review and enforces read-only checks (does not auto-fix or mutate git state).
  * Validates branch, worktree location, cleanliness, and upstream sync; can optionally inspect a target repo in read-only mode.

* **Documentation**
  * Clarified workflow and review-check guidance for workflow guardrails and preflight behavior.

* **Tests**
  * Added integration tests and assertions ensuring preflight behavior, non-mutation, and user-facing messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->