### PR TITLE
feat(workflow): add PR and implementation evidence consistency checker

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -264,6 +264,10 @@ PR body 應以繁體中文為主。若 PR body 主要使用英文，reviewer 應
 
 After backfill, use `gh pr view` or equivalent to confirm the PR body is non-empty and contains the evidence URL and commit hash.
 
+Repo-local PR / evidence consistency check 可在 source issue implementation evidence comment 已存在、且 PR body 已 backfill 後執行 `spec evidence-check`。此 checker deterministic 且 read-only：missing linked issue、missing evidence URL、evidence URL 指到錯 issue、stale PR body HEAD、expected HEAD mismatch、vague validation evidence、draft state、failing / pending checks、或 missing review finding assessment 都可能回報 warning / fail / needs-human-review。它不得 auto-edit PR、issue comments、labels、review threads、merge state 或 issue state。
+
+若 `spec evidence-check` 回報 stale HEAD 或 stale evidence，merge readiness 前必須 stop-and-report。刷新 evidence 仍是 human / implementer workflow step，不是 automatic remediation loop。CodeRabbit / Codex review summaries 仍只是 auxiliary signals；evidence consistency pass 不等於 review approval。
+
 ## Issue Evidence Validation Reporting
 
 The source issue implementation evidence comment must include:

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -65,6 +65,19 @@ spec preflight --repo "$PWD" --target-repo <target-repo-path>
 
 此檢查只回報 target repo 狀態與 safety reminder，不得修改 target repo、不得建立 target repo `.spec-injector/`、不得在 target repo 建 branch / commit / PR。
 
+PR 建立、source issue evidence comment 留下、且 PR body 回填 evidence URL 後，可執行 repo-local evidence consistency checker：
+
+```bash
+spec evidence-check \
+  --pr <pr-number-or-url> \
+  --repo <owner/name> \
+  --expected-head <latest-head-sha>
+```
+
+`spec evidence-check` 是 read-only workflow guardrail。它只讀取 PR body、source issue comments、latest PR HEAD、review evidence 與 `gh pr checks` summary，report `PASS` / `WARNING` / `FAIL` / `NEEDS-HUMAN-REVIEW` 類結果；它不 auto-fix PR body、不修改 issue comments、不 resolve review threads、不 merge、不 close issue。若 checker 回報 stale HEAD、stale evidence URL、CI failure、或 review finding assessment 缺失，應 stop-and-report，由 human / implementer 決定如何刷新 evidence 或拆 follow-up。
+
+CodeRabbit / Codex auto review findings 只能作為 auxiliary signals。`spec evidence-check` 可提醒 review finding assessment 是否存在，但不代表 approval，也不取代 human merge decision。
+
 ## Worktree naming
 
 建議命名：

--- a/src/cli/evidence-check.ts
+++ b/src/cli/evidence-check.ts
@@ -84,7 +84,7 @@ export async function evidenceCheck(opts: EvidenceCheckOptions): Promise<void> {
       '--repo',
       context.repo,
       '--json',
-      'name,state,conclusion,bucket,link',
+      'name,state,bucket,link',
     ], 'Could not read PR checks.', []);
 
     const report = buildReport({

--- a/src/cli/evidence-check.ts
+++ b/src/cli/evidence-check.ts
@@ -42,11 +42,13 @@ type CheckPayload = {
 };
 
 const HASH_PATTERN = /\b[0-9a-f]{7,40}\b/gi;
-const ISSUE_REF_PATTERN = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b|#(\d+)/gi;
+const LINKED_ISSUE_PATTERN = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/gi;
 const EVIDENCE_URL_PATTERN = /https:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/issues\/(\d+)#issuecomment-\d+/gi;
 const SINGLE_EVIDENCE_URL_PATTERN = /^https:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/issues\/(\d+)#issuecomment-\d+$/i;
 const REVIEW_ASSESSMENT_PATTERN = /\b(?:adopted|not adopted|optional polish|noise \/ not applicable|needs human review)\b/i;
 const EXACT_VALIDATION_COMMAND_PATTERN = /`?(?:git diff --check|pnpm build|pnpm test|pnpm lint|pnpm typecheck|node --test(?:\s+[^`\n]+)?|tsc(?:\s+[^`\n]+)?|npm test)`?/i;
+const ACTIONABLE_REVIEW_PATTERN = /\b(?:actionable comments|inline comments|potential issue|bug|fail(?:s|ure)?|stale|missing|incorrect|wrong|fix|change|update|replace|avoid|require|should|must|nit)\b/i;
+const NON_ACTIONABLE_REVIEW_PATTERN = /\b(?:lgtm|looks good(?: to me)?|approved|no actionable|summary|walkthrough|automated review suggestions|about codex in github|review in progress|currently processing|release notes|finishing touches)\b/i;
 
 export async function evidenceCheck(opts: EvidenceCheckOptions): Promise<void> {
   try {
@@ -62,7 +64,7 @@ export async function evidenceCheck(opts: EvidenceCheckOptions): Promise<void> {
       'number,url,body,headRefName,headRefOid,isDraft,reviews',
     ], 'Could not read PR metadata.');
     const body = pr.body ?? '';
-    const linkedIssue = parseExpectedIssue(opts.issue, body);
+    const linkedIssue = parseLinkedIssue(body);
     const evidenceUrl = opts.evidenceUrl ?? findEvidenceUrl(body);
     const issue = linkedIssue
       ? readJson<IssuePayload>([
@@ -92,7 +94,7 @@ export async function evidenceCheck(opts: EvidenceCheckOptions): Promise<void> {
       issue,
       body,
       linkedIssue,
-      expectedIssue: opts.issue ? Number.parseInt(opts.issue, 10) : null,
+      expectedIssue: parseIssueOption(opts.issue),
       evidenceUrl,
       expectedEvidenceUrl: opts.evidenceUrl,
       expectedHead: opts.expectedHead,
@@ -293,7 +295,7 @@ function buildReport(input: {
     checks.push(pass('Draft state', 'ready for review', 'PR is not draft', 'Continue normal review workflow.'));
   }
 
-  const reviewFindings = input.pr.reviews?.filter((review) => (review.body ?? '').trim().length > 0) ?? [];
+  const reviewFindings = input.pr.reviews?.filter(isActionableReview) ?? [];
   if (reviewFindings.length > 0 && !REVIEW_ASSESSMENT_PATTERN.test(input.body)) {
     checks.push(needsHumanReview(
       'Review finding assessment',
@@ -381,16 +383,27 @@ function checkCi(checks: CheckPayload[]): EvidenceCheck[] {
   return result;
 }
 
-function parseExpectedIssue(issueOption: string | undefined, body: string): number | null {
-  if (issueOption) {
-    const parsed = Number.parseInt(issueOption, 10);
-    return Number.isFinite(parsed) ? parsed : null;
-  }
-
-  const match = [...body.matchAll(ISSUE_REF_PATTERN)]
-    .map((item) => item[1] ?? item[2])
+function parseLinkedIssue(body: string): number | null {
+  const match = [...body.matchAll(LINKED_ISSUE_PATTERN)]
+    .map((item) => item[1])
     .find(Boolean);
   return match ? Number.parseInt(match, 10) : null;
+}
+
+function parseIssueOption(issueOption: string | undefined): number | null {
+  if (!issueOption) return null;
+  const parsed = Number.parseInt(issueOption, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function isActionableReview(review: { body?: string; state?: string }): boolean {
+  const body = (review.body ?? '').trim();
+  if (body.length === 0) return false;
+  if ((review.state ?? '').toUpperCase() === 'APPROVED') return false;
+  if (NON_ACTIONABLE_REVIEW_PATTERN.test(body) && !/\b(?:actionable comments|inline comments|potential issue)\b/i.test(body)) {
+    return false;
+  }
+  return ACTIONABLE_REVIEW_PATTERN.test(body);
 }
 
 function findEvidenceUrl(body: string): string | null {

--- a/src/cli/evidence-check.ts
+++ b/src/cli/evidence-check.ts
@@ -1,0 +1,495 @@
+import { run } from '../utils/shell.js';
+
+type Severity = 'pass' | 'warning' | 'fail' | 'needs-human-review';
+
+type EvidenceCheck = {
+  severity: Severity;
+  item: string;
+  evidence: string;
+  reason: string;
+  action: string;
+};
+
+type EvidenceCheckOptions = {
+  pr: string;
+  repo?: string;
+  issue?: string;
+  expectedHead?: string;
+  evidenceUrl?: string;
+};
+
+type PullRequestPayload = {
+  number?: number;
+  url?: string;
+  body?: string;
+  headRefName?: string;
+  headRefOid?: string;
+  isDraft?: boolean;
+  reviews?: Array<{ body?: string; state?: string; author?: { login?: string } }>;
+};
+
+type IssuePayload = {
+  number?: number;
+  url?: string;
+  comments?: Array<{ url?: string; body?: string }>;
+};
+
+type CheckPayload = {
+  name?: string;
+  state?: string;
+  conclusion?: string;
+  bucket?: string;
+};
+
+const HASH_PATTERN = /\b[0-9a-f]{7,40}\b/gi;
+const ISSUE_REF_PATTERN = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b|#(\d+)/gi;
+const EVIDENCE_URL_PATTERN = /https:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/issues\/(\d+)#issuecomment-\d+/gi;
+const SINGLE_EVIDENCE_URL_PATTERN = /^https:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/issues\/(\d+)#issuecomment-\d+$/i;
+const REVIEW_ASSESSMENT_PATTERN = /\b(?:adopted|not adopted|optional polish|noise \/ not applicable|needs human review)\b/i;
+const EXACT_VALIDATION_COMMAND_PATTERN = /`?(?:git diff --check|pnpm build|pnpm test|pnpm lint|pnpm typecheck|node --test(?:\s+[^`\n]+)?|tsc(?:\s+[^`\n]+)?|npm test)`?/i;
+
+export async function evidenceCheck(opts: EvidenceCheckOptions): Promise<void> {
+  try {
+    const context = resolveContext(opts);
+    const pr = readJson<PullRequestPayload>([
+      'gh',
+      'pr',
+      'view',
+      context.prRef,
+      '--repo',
+      context.repo,
+      '--json',
+      'number,url,body,headRefName,headRefOid,isDraft,reviews',
+    ], 'Could not read PR metadata.');
+    const body = pr.body ?? '';
+    const linkedIssue = parseExpectedIssue(opts.issue, body);
+    const evidenceUrl = opts.evidenceUrl ?? findEvidenceUrl(body);
+    const issue = linkedIssue
+      ? readJson<IssuePayload>([
+        'gh',
+        'issue',
+        'view',
+        String(linkedIssue),
+        '--repo',
+        context.repo,
+        '--json',
+        'number,url,comments',
+      ], 'Could not read linked issue comments.')
+      : null;
+    const checks = readJson<CheckPayload[]>([
+      'gh',
+      'pr',
+      'checks',
+      context.prRef,
+      '--repo',
+      context.repo,
+      '--json',
+      'name,state,conclusion,bucket,link',
+    ], 'Could not read PR checks.', []);
+
+    const report = buildReport({
+      pr,
+      issue,
+      body,
+      linkedIssue,
+      expectedIssue: opts.issue ? Number.parseInt(opts.issue, 10) : null,
+      evidenceUrl,
+      expectedEvidenceUrl: opts.evidenceUrl,
+      expectedHead: opts.expectedHead,
+      checks,
+    });
+
+    printReport(report);
+
+    if (report.overall === 'fail' || report.overall === 'needs-human-review') {
+      process.exit(1);
+    }
+  } catch (err) {
+    console.error(`✗ Evidence check failed: ${(err as Error).message}`);
+    process.exit(1);
+  }
+}
+
+function resolveContext(opts: EvidenceCheckOptions): { prRef: string; repo: string } {
+  const prUrlMatch = opts.pr.match(/^https:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/);
+  const repo = opts.repo ?? prUrlMatch?.[1];
+  const prRef = prUrlMatch?.[2] ?? opts.pr;
+
+  if (!repo) {
+    throw new Error('--repo is required when --pr is not a GitHub PR URL.');
+  }
+
+  return { prRef, repo };
+}
+
+function buildReport(input: {
+  pr: PullRequestPayload;
+  issue: IssuePayload | null;
+  body: string;
+  linkedIssue: number | null;
+  expectedIssue: number | null;
+  evidenceUrl: string | null;
+  expectedEvidenceUrl?: string;
+  expectedHead?: string;
+  checks: CheckPayload[];
+}): { overall: Severity; checks: EvidenceCheck[] } {
+  const checks: EvidenceCheck[] = [];
+  const latestHead = input.pr.headRefOid ?? '';
+  const evidenceComment = input.evidenceUrl && input.issue
+    ? input.issue.comments?.find((comment) => comment.url === input.evidenceUrl)
+    : undefined;
+  const combinedEvidence = [input.body, evidenceComment?.body ?? ''].join('\n');
+
+  if (input.linkedIssue) {
+    checks.push(pass(
+      'PR body linked issue',
+      `#${input.linkedIssue}`,
+      'linked issue reference found',
+      'Continue using this source issue as the evidence anchor.'
+    ));
+  } else {
+    checks.push(fail(
+      'PR body linked issue',
+      'none',
+      'source issue reference is missing',
+      'Stop and add a human-reviewed linked issue reference such as Closes #<issue>.'
+    ));
+  }
+
+  if (input.expectedIssue && input.linkedIssue && input.expectedIssue !== input.linkedIssue) {
+    checks.push(fail(
+      'Expected issue',
+      `expected #${input.expectedIssue}, found #${input.linkedIssue}`,
+      'linked issue does not match --issue',
+      'Stop and confirm the correct source issue before editing PR metadata.'
+    ));
+  }
+
+  checkRequiredSections(input.body).forEach((check) => checks.push(check));
+
+  if (!input.evidenceUrl) {
+    checks.push(fail(
+      'Issue evidence URL',
+      'none',
+      'issue evidence URL is missing',
+      'Post source issue implementation evidence, then backfill the permanent comment URL into the PR body.'
+    ));
+  } else {
+    const urlIssue = parseIssueNumberFromEvidenceUrl(input.evidenceUrl);
+    if (input.expectedEvidenceUrl && input.evidenceUrl !== input.expectedEvidenceUrl) {
+      checks.push(fail(
+        'Issue evidence URL',
+        input.evidenceUrl,
+        'evidence URL does not match --evidence-url',
+        'Stop and confirm which implementation evidence comment is authoritative.'
+      ));
+    } else if (input.linkedIssue && urlIssue !== input.linkedIssue) {
+      checks.push(fail(
+        'Issue evidence URL',
+        input.evidenceUrl,
+        'evidence URL points to a different issue',
+        'Stop and backfill the source issue evidence comment URL; do not auto-edit the PR body.'
+      ));
+    } else {
+      checks.push(pass(
+        'Issue evidence URL',
+        input.evidenceUrl,
+        'evidence URL points to linked issue',
+        'Use this URL for PR body evidence readback.'
+      ));
+    }
+  }
+
+  if (input.evidenceUrl && evidenceComment) {
+    checks.push(pass(
+      'Issue evidence comment',
+      input.evidenceUrl,
+      'issue evidence comment exists',
+      'Keep this comment aligned with latest HEAD before merge readiness.'
+    ));
+  } else if (input.evidenceUrl) {
+    checks.push(fail(
+      'Issue evidence comment',
+      input.evidenceUrl,
+      'issue evidence comment was not found on the linked issue',
+      'Stop and verify the source issue comment URL before merge readiness.'
+    ));
+  }
+
+  const prUrl = input.pr.url ?? '';
+  if (evidenceComment?.body) {
+    const evidenceBody = evidenceComment.body;
+    const missing = [
+      [prUrl, 'PR URL'],
+      [input.pr.headRefName ?? '', 'branch'],
+      [latestHead, 'commit hash / HEAD'],
+    ].filter(([needle]) => needle && !evidenceBody.includes(needle));
+    if (missing.length === 0 && hasValidationSummary(evidenceBody)) {
+      checks.push(pass(
+        'Issue evidence content',
+        'PR URL, branch, HEAD, validation',
+        'issue evidence contains required implementation fields',
+        'No issue mutation is needed.'
+      ));
+    } else {
+      checks.push(fail(
+        'Issue evidence content',
+        missing.map(([, label]) => label).concat(hasValidationSummary(evidenceBody) ? [] : ['validation summary']).join(', ') || 'incomplete',
+        'issue evidence comment is incomplete or stale',
+        'Stop and ask a human to refresh implementation evidence; checker will not edit comments.'
+      ));
+    }
+  }
+
+  if (input.expectedHead && input.expectedHead !== latestHead) {
+    checks.push(fail(
+      'Expected HEAD',
+      `expected ${input.expectedHead}, latest ${latestHead}`,
+      'expected HEAD does not match latest PR head',
+      'Stop and re-read PR state before continuing.'
+    ));
+  }
+
+  if (latestHead && input.body.includes(latestHead)) {
+    checks.push(pass(
+      'PR body HEAD freshness',
+      latestHead,
+      'PR body HEAD matches latest PR head',
+      'Evidence is aligned with the current PR head.'
+    ));
+  } else if (latestHead) {
+    checks.push(fail(
+      'PR body HEAD freshness',
+      findHashes(input.body).join(', ') || 'no hash',
+      'PR body HEAD is stale',
+      'Stop and refresh evidence after validating the latest HEAD; do not auto-update the PR body.'
+    ));
+  }
+
+  if (hasExactValidationCommand(combinedEvidence)) {
+    checks.push(pass(
+      'Validation evidence',
+      validationMatches(combinedEvidence).join(', '),
+      'validation evidence lists exact commands',
+      'Keep command/result evidence in PR body or issue evidence.'
+    ));
+  } else {
+    checks.push(warning(
+      'Validation evidence',
+      'no exact command found',
+      'validation evidence needs exact commands',
+      'Replace vague wording such as tests pass with concrete commands and results.'
+    ));
+  }
+
+  if (input.pr.isDraft) {
+    checks.push(warning(
+      'Draft state',
+      'draft',
+      'PR is draft',
+      'Ready-for-review / merge-readiness flow should wait until PR is not draft.'
+    ));
+  } else {
+    checks.push(pass('Draft state', 'ready for review', 'PR is not draft', 'Continue normal review workflow.'));
+  }
+
+  const reviewFindings = input.pr.reviews?.filter((review) => (review.body ?? '').trim().length > 0) ?? [];
+  if (reviewFindings.length > 0 && !REVIEW_ASSESSMENT_PATTERN.test(input.body)) {
+    checks.push(needsHumanReview(
+      'Review finding assessment',
+      `${reviewFindings.length} review finding(s)`,
+      'review findings need assessment',
+      'Classify findings as adopted / not adopted / optional polish / noise / needs human review before merge.'
+    ));
+  } else if (reviewFindings.length > 0) {
+    checks.push(pass(
+      'Review finding assessment',
+      `${reviewFindings.length} review finding(s)`,
+      'review finding assessment vocabulary found',
+      'Confirm written rationale exists before resolving any thread.'
+    ));
+  }
+
+  checkCi(input.checks).forEach((check) => checks.push(check));
+
+  return {
+    overall: summarizeOverall(checks),
+    checks,
+  };
+}
+
+function checkRequiredSections(body: string): EvidenceCheck[] {
+  const groups: Array<[string, RegExp, string]> = [
+    ['Summary section', /^##+\s*(Summary|摘要)/im, 'Summary'],
+    ['Scope section', /^##+\s*(Scope|範圍|實作範圍)/im, 'Scope'],
+    ['Non-goals section', /^##+\s*(Non-goals|Non goals|非目標|不處理)/im, 'Non-goals'],
+    ['Validation section', /^##+\s*(Validation|Tests \/ validation|Tests|驗證|測試)/im, 'Validation'],
+    ['Implementation Evidence section', /^##+\s*(Implementation Evidence|Issue evidence|Evidence|實作證據|Issue evidence)/im, 'Implementation Evidence'],
+  ];
+
+  return groups.map(([item, pattern, expected]) => {
+    if (pattern.test(body)) {
+      return pass(item, expected, 'required PR body section found', 'Keep the section content fresh.');
+    }
+    return fail(item, expected, 'required PR body section is missing', 'Stop and add the missing section manually.');
+  });
+}
+
+function checkCi(checks: CheckPayload[]): EvidenceCheck[] {
+  if (checks.length === 0) {
+    return [warning(
+      'CI / checks',
+      'no checks returned',
+      'CI checks summary is unavailable',
+      'Confirm whether CI is unavailable, pending, or not applicable before merge readiness.'
+    )];
+  }
+
+  const failed = checks.filter((check) =>
+    /fail|failure|cancel|timed_out|action_required/i.test(`${check.bucket ?? ''} ${check.conclusion ?? ''} ${check.state ?? ''}`)
+  );
+  const pending = checks.filter((check) =>
+    /pending|queued|in_progress|waiting|requested/i.test(`${check.bucket ?? ''} ${check.conclusion ?? ''} ${check.state ?? ''}`)
+  );
+  const result: EvidenceCheck[] = [];
+
+  if (failed.length > 0) {
+    result.push(fail(
+      'CI / checks',
+      failed.map((check) => check.name ?? '<unnamed>').join(', '),
+      'CI checks contain failures',
+      'Stop and inspect failing checks; do not treat review bots as approval.'
+    ));
+  } else {
+    result.push(pass(
+      'CI / checks',
+      checks.map((check) => check.name ?? '<unnamed>').join(', '),
+      'no failing CI checks reported',
+      'Still verify required checks are for the latest HEAD.'
+    ));
+  }
+
+  if (pending.length > 0) {
+    result.push(warning(
+      'Pending checks',
+      pending.map((check) => check.name ?? '<unnamed>').join(', '),
+      'checks are pending',
+      'Wait for required checks or record a human-reviewed reason before merge readiness.'
+    ));
+  }
+
+  return result;
+}
+
+function parseExpectedIssue(issueOption: string | undefined, body: string): number | null {
+  if (issueOption) {
+    const parsed = Number.parseInt(issueOption, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  const match = [...body.matchAll(ISSUE_REF_PATTERN)]
+    .map((item) => item[1] ?? item[2])
+    .find(Boolean);
+  return match ? Number.parseInt(match, 10) : null;
+}
+
+function findEvidenceUrl(body: string): string | null {
+  return [...body.matchAll(EVIDENCE_URL_PATTERN)][0]?.[0] ?? null;
+}
+
+function parseIssueNumberFromEvidenceUrl(url: string): number | null {
+  const match = url.match(SINGLE_EVIDENCE_URL_PATTERN);
+  return match?.[3] ? Number.parseInt(match[3], 10) : null;
+}
+
+function findHashes(value: string): string[] {
+  return [...value.matchAll(HASH_PATTERN)].map((match) => match[0]);
+}
+
+function hasExactValidationCommand(value: string): boolean {
+  return EXACT_VALIDATION_COMMAND_PATTERN.test(value) || /\bskipped\b.+\b(package\.json|script|missing|not available)\b/i.test(value);
+}
+
+function hasValidationSummary(value: string): boolean {
+  return /\b(validation|tests?|驗證|測試)\b/i.test(value);
+}
+
+function validationMatches(value: string): string[] {
+  const commands = new Set<string>();
+  for (const match of value.matchAll(new RegExp(EXACT_VALIDATION_COMMAND_PATTERN, 'gi'))) {
+    commands.add(match[0].replace(/^`|`$/g, ''));
+  }
+  if (commands.size === 0 && /\bskipped\b.+\b(package\.json|script|missing|not available)\b/i.test(value)) {
+    commands.add('skipped validation reason');
+  }
+  return [...commands];
+}
+
+function readJson<T>(argv: string[], errorMessage: string, fallback?: T): T {
+  const result = run(argv);
+  if (result.exitCode !== 0 && result.stdout.trim() === '') {
+    if (fallback !== undefined) {
+      return fallback;
+    }
+    throw new Error(`${errorMessage} ${result.stderr.trim() || result.stdout.trim()}`);
+  }
+
+  try {
+    return JSON.parse(result.stdout) as T;
+  } catch {
+    if (fallback !== undefined) {
+      return fallback;
+    }
+    throw new Error(`${errorMessage} Unexpected JSON output.`);
+  }
+}
+
+function summarizeOverall(checks: EvidenceCheck[]): Severity {
+  if (checks.some((check) => check.severity === 'fail')) {
+    return 'fail';
+  }
+  if (checks.some((check) => check.severity === 'needs-human-review')) {
+    return 'needs-human-review';
+  }
+  if (checks.some((check) => check.severity === 'warning')) {
+    return 'warning';
+  }
+  return 'pass';
+}
+
+function printReport(report: { overall: Severity; checks: EvidenceCheck[] }): void {
+  const counts = {
+    pass: report.checks.filter((check) => check.severity === 'pass').length,
+    warning: report.checks.filter((check) => check.severity === 'warning').length,
+    fail: report.checks.filter((check) => check.severity === 'fail').length,
+    needsHumanReview: report.checks.filter((check) => check.severity === 'needs-human-review').length,
+  };
+
+  console.log(
+    `Evidence check summary: ${report.overall.toUpperCase()} ` +
+    `(${counts.pass} pass, ${counts.warning} warning, ${counts.fail} fail, ${counts.needsHumanReview} needs-human-review)`
+  );
+
+  for (const check of report.checks) {
+    console.log(
+      `[${check.severity.toUpperCase()}] ${check.item} — ` +
+      `evidence: ${check.evidence}; reason: ${check.reason}; suggested human action: ${check.action}`
+    );
+  }
+}
+
+function pass(item: string, evidence: string, reason: string, action: string): EvidenceCheck {
+  return { severity: 'pass', item, evidence, reason, action };
+}
+
+function warning(item: string, evidence: string, reason: string, action: string): EvidenceCheck {
+  return { severity: 'warning', item, evidence, reason, action };
+}
+
+function fail(item: string, evidence: string, reason: string, action: string): EvidenceCheck {
+  return { severity: 'fail', item, evidence, reason, action };
+}
+
+function needsHumanReview(item: string, evidence: string, reason: string, action: string): EvidenceCheck {
+  return { severity: 'needs-human-review', item, evidence, reason, action };
+}

--- a/src/cli/evidence-check.ts
+++ b/src/cli/evidence-check.ts
@@ -114,7 +114,11 @@ export async function evidenceCheck(opts: EvidenceCheckOptions): Promise<void> {
 
 function resolveContext(opts: EvidenceCheckOptions): { prRef: string; repo: string } {
   const prUrlMatch = opts.pr.match(/^https:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/);
-  const repo = opts.repo ?? prUrlMatch?.[1];
+  const urlRepo = prUrlMatch?.[1];
+  if (opts.repo && urlRepo && opts.repo !== urlRepo) {
+    throw new Error('--repo must match the repository encoded in --pr.');
+  }
+  const repo = urlRepo ?? opts.repo;
   const prRef = prUrlMatch?.[2] ?? opts.pr;
 
   if (!repo) {

--- a/src/cli/evidence-check.ts
+++ b/src/cli/evidence-check.ts
@@ -48,7 +48,8 @@ const SINGLE_EVIDENCE_URL_PATTERN = /^https:\/\/github\.com\/([^/\s]+)\/([^/\s]+
 const REVIEW_ASSESSMENT_PATTERN = /\b(?:adopted|not adopted|optional polish|noise \/ not applicable|needs human review)\b/i;
 const EXACT_VALIDATION_COMMAND_PATTERN = /`?(?:git diff --check|pnpm build|pnpm test|pnpm lint|pnpm typecheck|node --test(?:\s+[^`\n]+)?|tsc(?:\s+[^`\n]+)?|npm test)`?/i;
 const ACTIONABLE_REVIEW_PATTERN = /\b(?:actionable comments|inline comments|potential issue|bug|fail(?:s|ure)?|stale|missing|incorrect|wrong|fix|change|update|replace|avoid|require|should|must|nit)\b/i;
-const NON_ACTIONABLE_REVIEW_PATTERN = /\b(?:lgtm|looks good(?: to me)?|approved|no actionable|summary|walkthrough|automated review suggestions|about codex in github|review in progress|currently processing|release notes|finishing touches)\b/i;
+const PURE_NON_ACTIONABLE_REVIEW_PATTERN = /^(?:lgtm|looks good(?: to me)?|approved)$/i;
+const EXPLICIT_NO_ACTIONABLE_REVIEW_PATTERN = /\bno actionable(?: comments?| findings?)\b/i;
 
 export async function evidenceCheck(opts: EvidenceCheckOptions): Promise<void> {
   try {
@@ -78,7 +79,7 @@ export async function evidenceCheck(opts: EvidenceCheckOptions): Promise<void> {
         'number,url,comments',
       ], 'Could not read linked issue comments.')
       : null;
-    const checks = readJson<CheckPayload[]>([
+    const checksRead = readJsonResult<CheckPayload[]>([
       'gh',
       'pr',
       'checks',
@@ -87,7 +88,7 @@ export async function evidenceCheck(opts: EvidenceCheckOptions): Promise<void> {
       context.repo,
       '--json',
       'name,state,bucket,link',
-    ], 'Could not read PR checks.', []);
+    ], 'Could not read PR checks.');
 
     const report = buildReport({
       pr,
@@ -98,7 +99,8 @@ export async function evidenceCheck(opts: EvidenceCheckOptions): Promise<void> {
       evidenceUrl,
       expectedEvidenceUrl: opts.evidenceUrl,
       expectedHead: opts.expectedHead,
-      checks,
+      checks: checksRead.value ?? [],
+      checksReadError: checksRead.error,
     });
 
     printReport(report);
@@ -138,6 +140,7 @@ function buildReport(input: {
   expectedEvidenceUrl?: string;
   expectedHead?: string;
   checks: CheckPayload[];
+  checksReadError?: string;
 }): { overall: Severity; checks: EvidenceCheck[] } {
   const checks: EvidenceCheck[] = [];
   const latestHead = input.pr.headRefOid ?? '';
@@ -223,8 +226,8 @@ function buildReport(input: {
   }
 
   const prUrl = input.pr.url ?? '';
-  if (evidenceComment?.body) {
-    const evidenceBody = evidenceComment.body;
+  if (evidenceComment) {
+    const evidenceBody = evidenceComment.body ?? '';
     const missing = [
       [prUrl, 'PR URL'],
       [input.pr.headRefName ?? '', 'branch'],
@@ -316,7 +319,7 @@ function buildReport(input: {
     ));
   }
 
-  checkCi(input.checks).forEach((check) => checks.push(check));
+  checkCi(input.checks, input.checksReadError).forEach((check) => checks.push(check));
 
   return {
     overall: summarizeOverall(checks),
@@ -341,7 +344,16 @@ function checkRequiredSections(body: string): EvidenceCheck[] {
   });
 }
 
-function checkCi(checks: CheckPayload[]): EvidenceCheck[] {
+function checkCi(checks: CheckPayload[], checksReadError?: string): EvidenceCheck[] {
+  if (checksReadError) {
+    return [fail(
+      'CI / checks',
+      checksReadError,
+      'could not read CI checks summary',
+      'Stop and re-read PR checks manually; do not treat missing check data as merge-ready evidence.'
+    )];
+  }
+
   if (checks.length === 0) {
     return [warning(
       'CI / checks',
@@ -403,10 +415,8 @@ function parseIssueOption(issueOption: string | undefined): number | null {
 function isActionableReview(review: { body?: string; state?: string }): boolean {
   const body = (review.body ?? '').trim();
   if (body.length === 0) return false;
-  if ((review.state ?? '').toUpperCase() === 'APPROVED') return false;
-  if (NON_ACTIONABLE_REVIEW_PATTERN.test(body) && !/\b(?:actionable comments|inline comments|potential issue)\b/i.test(body)) {
-    return false;
-  }
+  if (PURE_NON_ACTIONABLE_REVIEW_PATTERN.test(body)) return false;
+  if (EXPLICIT_NO_ACTIONABLE_REVIEW_PATTERN.test(body)) return false;
   return ACTIONABLE_REVIEW_PATTERN.test(body);
 }
 
@@ -458,6 +468,19 @@ function readJson<T>(argv: string[], errorMessage: string, fallback?: T): T {
       return fallback;
     }
     throw new Error(`${errorMessage} Unexpected JSON output.`);
+  }
+}
+
+function readJsonResult<T>(argv: string[], errorMessage: string): { value?: T; error?: string } {
+  const result = run(argv);
+  if (result.exitCode !== 0) {
+    return { error: `${errorMessage} ${result.stderr.trim() || result.stdout.trim()}`.trim() };
+  }
+
+  try {
+    return { value: JSON.parse(result.stdout) as T };
+  } catch {
+    return { error: `${errorMessage} Unexpected JSON output.` };
   }
 }
 

--- a/src/cli/evidence-check.ts
+++ b/src/cli/evidence-check.ts
@@ -65,7 +65,7 @@ export async function evidenceCheck(opts: EvidenceCheckOptions): Promise<void> {
     ], 'Could not read PR metadata.');
     const body = pr.body ?? '';
     const linkedIssue = parseLinkedIssue(body);
-    const evidenceUrl = opts.evidenceUrl ?? findEvidenceUrl(body);
+    const evidenceUrl = findEvidenceUrl(body);
     const issue = linkedIssue
       ? readJson<IssuePayload>([
         'gh',

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -144,6 +144,36 @@ Safety:
     await preflight(opts);
   });
 
+// evidence-check subcommand
+program
+  .command('evidence-check')
+  .description('Run read-only PR and implementation evidence consistency checks')
+  .requiredOption('--pr <number-or-url>', 'Pull request number or URL to inspect')
+  .option('--repo <owner/name>', 'GitHub repository owner/name; inferred from PR URL when possible')
+  .option('--issue <number>', 'Expected linked source issue number')
+  .option('--expected-head <sha>', 'Expected latest PR head SHA')
+  .option('--evidence-url <url>', 'Expected source issue implementation evidence comment URL')
+  .addHelpText('after', `
+Checks:
+  - PR body linked issue, required sections, evidence URL, and HEAD freshness
+  - source issue evidence comment presence and validation evidence
+  - draft state, review finding assessment, and CI/check summary
+
+Safety:
+  Read-only guardrail. Does not edit PRs, edit/close issues, comment, merge, or resolve review threads.
+  Stale HEAD or stale evidence should trigger stop-and-report before merge readiness.
+`)
+  .action(async (opts: {
+    pr: string;
+    repo?: string;
+    issue?: string;
+    expectedHead?: string;
+    evidenceUrl?: string;
+  }) => {
+    const { evidenceCheck } = await import('./evidence-check.js');
+    await evidenceCheck(opts);
+  });
+
 program.parseAsync(process.argv).catch((err: unknown) => {
   console.error(`✗ ${(err as Error).message}`);
   process.exit(1);

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -946,6 +946,76 @@ test('spec evidence-check fails when the PR body is missing the issue evidence U
   assertNoGhMutationCommands(ghLog);
 });
 
+test('spec evidence-check does not let --issue satisfy a missing PR body closing reference', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t, {
+    prBody: [
+      '## Summary',
+      'ok',
+      '## Scope',
+      'ok',
+      '## Non-goals',
+      'ok',
+      '## Validation',
+      '- `git diff --check` ✅',
+      '- `pnpm build` ✅',
+      '- `pnpm test` ✅',
+      '## Implementation Evidence',
+      '- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/109#issuecomment-1090001',
+      '- Latest HEAD: 1234567890abcdef1234567890abcdef12345678',
+    ].join('\n'),
+  });
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', String(fixture.prNumber),
+    '--repo', fixture.repo,
+    '--issue', '109',
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stdout, /Evidence check summary:\s+FAIL/i);
+  assert.match(result.stdout, /source issue reference is missing/i);
+  assertNoRawStackTrace(result);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec evidence-check prefers closing keyword issue over earlier bare issue mentions', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t, {
+    prBody: [
+      'Mention #110 as a non-goal.',
+      '',
+      'Closes #109',
+      '## Summary',
+      'ok',
+      '## Scope',
+      'ok',
+      '## Non-goals',
+      'Do not handle #110.',
+      '## Validation',
+      '- `git diff --check` ✅',
+      '- `pnpm build` ✅',
+      '- `pnpm test` ✅',
+      '## Implementation Evidence',
+      '- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/109#issuecomment-1090001',
+      '- Latest HEAD: 1234567890abcdef1234567890abcdef12345678',
+    ].join('\n'),
+  });
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', String(fixture.prNumber),
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Evidence check summary:\s+PASS/i);
+  assert.match(result.stdout, /PR body linked issue .*#109/i);
+  assert.doesNotMatch(result.stdout, /different issue/i);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
 test('spec evidence-check fails when the evidence URL points to a different issue', async (t) => {
   const wrongEvidenceUrl = 'https://github.com/Erick52106/spec-injector/issues/999#issuecomment-1090001';
   const fixture = await createEvidenceCheckFixture(t, {
@@ -1115,6 +1185,42 @@ test('spec evidence-check requires review finding assessment when review finding
   assert.notEqual(result.code, 0);
   assert.match(result.stdout, /Evidence check summary:\s+NEEDS-HUMAN-REVIEW/i);
   assert.match(result.stdout, /review findings need assessment/i);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec evidence-check ignores non-actionable approved review text without requiring assessment', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t, {
+    reviews: [
+      { author: { login: 'reviewer' }, state: 'APPROVED', body: 'LGTM' },
+    ],
+    prBody: [
+      'Closes #109',
+      '## Summary',
+      'ok',
+      '## Scope',
+      'ok',
+      '## Non-goals',
+      'ok',
+      '## Validation',
+      '- `git diff --check` ✅',
+      '- `pnpm build` ✅',
+      '- `pnpm test` ✅',
+      '## Implementation Evidence',
+      '- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/109#issuecomment-1090001',
+      '- Latest HEAD: 1234567890abcdef1234567890abcdef12345678',
+    ].join('\n'),
+  });
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', String(fixture.prNumber),
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Evidence check summary:\s+PASS/i);
+  assert.doesNotMatch(result.stdout, /review findings need assessment/i);
   const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
   assertNoGhMutationCommands(ghLog);
 });

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -915,6 +915,70 @@ test('spec evidence-check passes for complete PR and issue evidence without muta
   assertNoGhMutationCommands(ghLog);
 });
 
+test('spec evidence-check accepts a full PR URL when --repo matches the encoded repository', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t);
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', `https://github.com/${fixture.repo}/pull/${fixture.prNumber}`,
+    '--repo', fixture.repo,
+    '--expected-head', fixture.headSha,
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Evidence check summary:\s+PASS/i);
+  assert.equal(result.stderr, '');
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec evidence-check accepts a full PR URL without requiring --repo', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t);
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', `https://github.com/${fixture.repo}/pull/${fixture.prNumber}`,
+    '--expected-head', fixture.headSha,
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Evidence check summary:\s+PASS/i);
+  assert.equal(result.stderr, '');
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec evidence-check fails when --repo conflicts with the repository encoded in a PR URL', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t);
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', `https://github.com/${fixture.repo}/pull/${fixture.prNumber}`,
+    '--repo', 'owner-b/repo-b',
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stderr, /--repo must match the repository encoded in --pr/i);
+  assertNoRawStackTrace(result);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec evidence-check still requires --repo when --pr is not a GitHub PR URL', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t);
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', String(fixture.prNumber),
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stderr, /--repo is required when --pr is not a GitHub PR URL/i);
+  assertNoRawStackTrace(result);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
 test('spec evidence-check fails when the PR body is missing the issue evidence URL', async (t) => {
   const fixture = await createEvidenceCheckFixture(t, {
     prBody: [

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -8,6 +8,7 @@ import { renderTemplate } from '../dist/template/renderer.js';
 import { repoRoot, runCommand, runSpec } from './helpers/cli.ts';
 import {
   createExplicitPathPlanFixture,
+  createEvidenceCheckFixture,
   createExternalConfigPlanFixture,
   createFailingGitEnv,
   createMissingPath,
@@ -27,6 +28,7 @@ import {
   assertFileExists,
   assertFileMissing,
   assertNoGitMutationCommands,
+  assertNoGhMutationCommands,
   assertNoCleanupCommands,
   assertNoRawStackTrace,
   assertOrderedSubstrings,
@@ -622,6 +624,7 @@ test('spec --help lists deterministic CLI purpose and available commands', async
   assert.match(result.stdout, /\bplan\b/);
   assert.match(result.stdout, /\bconfig\b/);
   assert.match(result.stdout, /\bclean\b/);
+  assert.match(result.stdout, /\bevidence-check\b/);
   assert.match(result.stdout, /help \[command\]/i);
 });
 
@@ -679,6 +682,13 @@ test('spec plan/config/clean help describe AI-facing usage and safety constraint
   assert.match(preflightHelp.stdout, /expected worktree root/i);
   assert.match(preflightHelp.stdout, /target repo/i);
   assert.match(preflightHelp.stdout, /does not auto-fix/i);
+
+  const evidenceCheckHelp = await runSpec(['evidence-check', '--help']);
+  assert.equal(evidenceCheckHelp.code, 0, evidenceCheckHelp.stderr);
+  assert.match(evidenceCheckHelp.stdout, /implementation evidence consistency/i);
+  assert.match(evidenceCheckHelp.stdout, /--pr <number-or-url>/);
+  assert.match(evidenceCheckHelp.stdout, /--expected-head <sha>/);
+  assert.match(evidenceCheckHelp.stdout, /read-only guardrail/i);
 });
 
 test('spec preflight passes for a clean dedicated worktree and avoids mutating git state', async (t) => {
@@ -882,6 +892,231 @@ test('spec preflight warns when the target repo is dirty and keeps the boundary 
   const gitLog = (await readGhLog(fixture.gitLogPath)).join('\n');
   assertNoGitMutationCommands(gitLog);
   await assertFileMissing(path.join(targetRepoDir, '.spec-injector'));
+});
+
+test('spec evidence-check passes for complete PR and issue evidence without mutating GitHub state', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t);
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', String(fixture.prNumber),
+    '--repo', fixture.repo,
+    '--expected-head', fixture.headSha,
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Evidence check summary:\s+PASS/i);
+  assert.match(result.stdout, /linked issue reference found/i);
+  assert.match(result.stdout, /issue evidence comment exists/i);
+  assert.match(result.stdout, /PR body HEAD matches latest PR head/i);
+  assert.match(result.stdout, /validation evidence lists exact commands/i);
+  assert.equal(result.stderr, '');
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec evidence-check fails when the PR body is missing the issue evidence URL', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t, {
+    prBody: [
+      'Closes #109',
+      '## Summary',
+      'ok',
+      '## Scope',
+      'ok',
+      '## Non-goals',
+      'ok',
+      '## Validation',
+      '- `pnpm test` ✅',
+      '## Implementation Evidence',
+      '- Latest HEAD: 1234567890abcdef1234567890abcdef12345678',
+    ].join('\n'),
+  });
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', String(fixture.prNumber),
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stdout, /Evidence check summary:\s+FAIL/i);
+  assert.match(result.stdout, /issue evidence URL is missing/i);
+  assertNoRawStackTrace(result);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec evidence-check fails when the evidence URL points to a different issue', async (t) => {
+  const wrongEvidenceUrl = 'https://github.com/Erick52106/spec-injector/issues/999#issuecomment-1090001';
+  const fixture = await createEvidenceCheckFixture(t, {
+    prBody: [
+      'Closes #109',
+      '## Summary',
+      'ok',
+      '## Scope',
+      'ok',
+      '## Non-goals',
+      'ok',
+      '## Validation',
+      '- `git diff --check` ✅',
+      '- `pnpm build` ✅',
+      '- `pnpm test` ✅',
+      '## Implementation Evidence',
+      `- Issue evidence comment URL: ${wrongEvidenceUrl}`,
+      '- Latest HEAD: 1234567890abcdef1234567890abcdef12345678',
+    ].join('\n'),
+  });
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', String(fixture.prNumber),
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stdout, /Evidence check summary:\s+FAIL/i);
+  assert.match(result.stdout, /evidence URL points to a different issue/i);
+  assertNoRawStackTrace(result);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec evidence-check fails on stale PR body commit hash and expected HEAD mismatch', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t, {
+    headSha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    prBody: [
+      'Closes #109',
+      '## Summary',
+      'ok',
+      '## Scope',
+      'ok',
+      '## Non-goals',
+      'ok',
+      '## Validation',
+      '- `git diff --check` ✅',
+      '- `pnpm build` ✅',
+      '- `pnpm test` ✅',
+      '## Implementation Evidence',
+      '- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/109#issuecomment-1090001',
+      '- Latest HEAD: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    ].join('\n'),
+  });
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', String(fixture.prNumber),
+    '--repo', fixture.repo,
+    '--expected-head', 'cccccccccccccccccccccccccccccccccccccccc',
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stdout, /Evidence check summary:\s+FAIL/i);
+  assert.match(result.stdout, /expected HEAD does not match latest PR head/i);
+  assert.match(result.stdout, /PR body HEAD is stale/i);
+  assertNoRawStackTrace(result);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec evidence-check warns for vague validation evidence and draft PRs', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t, {
+    isDraft: true,
+    issueComments: [{
+      url: 'https://github.com/Erick52106/spec-injector/issues/109#issuecomment-1090001',
+      body: [
+        '## Implementation evidence',
+        '- PR URL: https://github.com/Erick52106/spec-injector/pull/1091',
+        '- Branch: feat/pr-evidence-consistency-checker-109',
+        '- Commit hash / HEAD: 1234567890abcdef1234567890abcdef12345678',
+        '- Tests / validation: tests pass.',
+      ].join('\n'),
+    }],
+    prBody: [
+      'Closes #109',
+      '## Summary',
+      'ok',
+      '## Scope',
+      'ok',
+      '## Non-goals',
+      'ok',
+      '## Validation',
+      'Tests pass.',
+      '## Implementation Evidence',
+      '- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/109#issuecomment-1090001',
+      '- Latest HEAD: 1234567890abcdef1234567890abcdef12345678',
+    ].join('\n'),
+  });
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', String(fixture.prNumber),
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Evidence check summary:\s+WARNING/i);
+  assert.match(result.stdout, /PR is draft/i);
+  assert.match(result.stdout, /validation evidence needs exact commands/i);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec evidence-check fails failing CI and warns on pending checks', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t, {
+    checks: [
+      { name: 'build', state: 'COMPLETED', conclusion: 'FAILURE', bucket: 'fail' },
+      { name: 'CodeRabbit', state: 'PENDING', conclusion: '', bucket: 'pending' },
+    ],
+  });
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', String(fixture.prNumber),
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stdout, /Evidence check summary:\s+FAIL/i);
+  assert.match(result.stdout, /CI checks contain failures/i);
+  assert.match(result.stdout, /checks are pending/i);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec evidence-check requires review finding assessment when review findings exist', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t, {
+    reviews: [
+      { author: { login: 'coderabbitai' }, state: 'COMMENTED', body: 'Potential stale evidence finding.' },
+    ],
+    prBody: [
+      'Closes #109',
+      '## Summary',
+      'ok',
+      '## Scope',
+      'ok',
+      '## Non-goals',
+      'ok',
+      '## Validation',
+      '- `git diff --check` ✅',
+      '- `pnpm build` ✅',
+      '- `pnpm test` ✅',
+      '## Implementation Evidence',
+      '- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/109#issuecomment-1090001',
+      '- Latest HEAD: 1234567890abcdef1234567890abcdef12345678',
+    ].join('\n'),
+  });
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', String(fixture.prNumber),
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stdout, /Evidence check summary:\s+NEEDS-HUMAN-REVIEW/i);
+  assert.match(result.stdout, /review findings need assessment/i);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
 });
 
 test('spec init scaffolds config files with default discovery settings', async (t) => {

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -1222,6 +1222,55 @@ test('spec evidence-check fails on stale PR body commit hash and expected HEAD m
   assertNoGhMutationCommands(ghLog);
 });
 
+test('spec evidence-check fails when issue evidence comment body is empty', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t, {
+    issueComments: [{
+      url: 'https://github.com/Erick52106/spec-injector/issues/109#issuecomment-1090001',
+      body: '',
+    }],
+  });
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', String(fixture.prNumber),
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stdout, /Evidence check summary:\s+FAIL/i);
+  assert.match(result.stdout, /issue evidence comment is incomplete or stale/i);
+  assert.match(result.stdout, /PR URL, branch, commit hash \/ HEAD, validation summary/i);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec evidence-check fails when issue evidence comment lacks required fields', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t, {
+    issueComments: [{
+      url: 'https://github.com/Erick52106/spec-injector/issues/109#issuecomment-1090001',
+      body: [
+        '## Implementation evidence',
+        '- PR URL: https://github.com/Erick52106/spec-injector/pull/1091',
+        '- Tests / validation:',
+        '- `pnpm test` ✅',
+      ].join('\n'),
+    }],
+  });
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', String(fixture.prNumber),
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stdout, /Evidence check summary:\s+FAIL/i);
+  assert.match(result.stdout, /issue evidence comment is incomplete or stale/i);
+  assert.match(result.stdout, /branch, commit hash \/ HEAD/i);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
 test('spec evidence-check warns for vague validation evidence and draft PRs', async (t) => {
   const fixture = await createEvidenceCheckFixture(t, {
     isDraft: true,
@@ -1265,6 +1314,69 @@ test('spec evidence-check warns for vague validation evidence and draft PRs', as
   assertNoGhMutationCommands(ghLog);
 });
 
+test('spec evidence-check keeps empty successful checks distinct from checks read failures', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t, {
+    checks: [],
+  });
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', String(fixture.prNumber),
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Evidence check summary:\s+WARNING/i);
+  assert.match(result.stdout, /no checks returned/i);
+  assert.doesNotMatch(result.stdout, /Could not read PR checks/i);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec evidence-check fails when checks command cannot be read', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t, {
+    checksCommand: {
+      exitCode: 1,
+      stderr: 'checks API unavailable',
+    },
+  });
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', String(fixture.prNumber),
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stdout, /Evidence check summary:\s+FAIL/i);
+  assert.match(result.stdout, /Could not read PR checks/i);
+  assert.doesNotMatch(result.stdout, /no checks returned/i);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec evidence-check fails when checks command returns malformed JSON', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t, {
+    checksCommand: {
+      stdout: '{not-json',
+    },
+  });
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', String(fixture.prNumber),
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stdout, /Evidence check summary:\s+FAIL/i);
+  assert.match(result.stdout, /Could not read PR checks/i);
+  assert.match(result.stdout, /Unexpected JSON output/i);
+  assert.doesNotMatch(result.stdout, /no checks returned/i);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
 test('spec evidence-check fails failing CI and warns on pending checks', async (t) => {
   const fixture = await createEvidenceCheckFixture(t, {
     checks: [
@@ -1291,6 +1403,42 @@ test('spec evidence-check requires review finding assessment when review finding
   const fixture = await createEvidenceCheckFixture(t, {
     reviews: [
       { author: { login: 'coderabbitai' }, state: 'COMMENTED', body: 'Potential stale evidence finding.' },
+    ],
+    prBody: [
+      'Closes #109',
+      '## Summary',
+      'ok',
+      '## Scope',
+      'ok',
+      '## Non-goals',
+      'ok',
+      '## Validation',
+      '- `git diff --check` ✅',
+      '- `pnpm build` ✅',
+      '- `pnpm test` ✅',
+      '## Implementation Evidence',
+      '- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/109#issuecomment-1090001',
+      '- Latest HEAD: 1234567890abcdef1234567890abcdef12345678',
+    ].join('\n'),
+  });
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', String(fixture.prNumber),
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stdout, /Evidence check summary:\s+NEEDS-HUMAN-REVIEW/i);
+  assert.match(result.stdout, /review findings need assessment/i);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec evidence-check treats approved actionable review body as needing assessment', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t, {
+    reviews: [
+      { author: { login: 'reviewer' }, state: 'APPROVED', body: 'Approved, but fix stale HEAD before merge.' },
     ],
     prBody: [
       'Closes #109',
@@ -1355,6 +1503,63 @@ test('spec evidence-check ignores non-actionable approved review text without re
   assert.equal(result.code, 0, result.stderr);
   assert.match(result.stdout, /Evidence check summary:\s+PASS/i);
   assert.doesNotMatch(result.stdout, /review findings need assessment/i);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec evidence-check ignores commented summary-only bot wrapper without requiring assessment', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t, {
+    reviews: [
+      { author: { login: 'coderabbitai' }, state: 'COMMENTED', body: 'Walkthrough summary only. No actionable comments.' },
+    ],
+    prBody: [
+      'Closes #109',
+      '## Summary',
+      'ok',
+      '## Scope',
+      'ok',
+      '## Non-goals',
+      'ok',
+      '## Validation',
+      '- `git diff --check` ✅',
+      '- `pnpm build` ✅',
+      '- `pnpm test` ✅',
+      '## Implementation Evidence',
+      '- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/109#issuecomment-1090001',
+      '- Latest HEAD: 1234567890abcdef1234567890abcdef12345678',
+    ].join('\n'),
+  });
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', String(fixture.prNumber),
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Evidence check summary:\s+PASS/i);
+  assert.doesNotMatch(result.stdout, /review findings need assessment/i);
+  assert.doesNotMatch(result.stdout, /review finding assessment vocabulary found/i);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec evidence-check accepts actionable review body when assessment vocabulary exists', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t, {
+    reviews: [
+      { author: { login: 'coderabbitai' }, state: 'COMMENTED', body: 'Potential issue: fix stale evidence before merge.' },
+    ],
+  });
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', String(fixture.prNumber),
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Evidence check summary:\s+PASS/i);
+  assert.match(result.stdout, /review finding assessment vocabulary found/i);
   const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
   assertNoGhMutationCommands(ghLog);
 });

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -946,6 +946,76 @@ test('spec evidence-check fails when the PR body is missing the issue evidence U
   assertNoGhMutationCommands(ghLog);
 });
 
+test('spec evidence-check fails when --evidence-url is provided but PR body omits evidence URL', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t, {
+    prBody: [
+      'Closes #109',
+      '## Summary',
+      'ok',
+      '## Scope',
+      'ok',
+      '## Non-goals',
+      'ok',
+      '## Validation',
+      '- `git diff --check` ✅',
+      '- `pnpm build` ✅',
+      '- `pnpm test` ✅',
+      '## Implementation Evidence',
+      '- Latest HEAD: 1234567890abcdef1234567890abcdef12345678',
+    ].join('\n'),
+  });
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', String(fixture.prNumber),
+    '--repo', fixture.repo,
+    '--evidence-url', fixture.evidenceUrl,
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stdout, /Evidence check summary:\s+FAIL/i);
+  assert.match(result.stdout, /issue evidence URL is missing/i);
+  assertNoRawStackTrace(result);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec evidence-check fails when PR body evidence URL differs from --evidence-url', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t);
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', String(fixture.prNumber),
+    '--repo', fixture.repo,
+    '--evidence-url', 'https://github.com/Erick52106/spec-injector/issues/109#issuecomment-9999999',
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stdout, /Evidence check summary:\s+FAIL/i);
+  assert.match(result.stdout, /evidence URL does not match --evidence-url/i);
+  assertNoRawStackTrace(result);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec evidence-check accepts --evidence-url when it matches the PR body evidence URL', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t);
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', String(fixture.prNumber),
+    '--repo', fixture.repo,
+    '--evidence-url', fixture.evidenceUrl,
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Evidence check summary:\s+PASS/i);
+  assert.match(result.stdout, /evidence URL points to linked issue/i);
+  assert.equal(result.stderr, '');
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
 test('spec evidence-check does not let --issue satisfy a missing PR body closing reference', async (t) => {
   const fixture = await createEvidenceCheckFixture(t, {
     prBody: [

--- a/tests/helpers/assertions.ts
+++ b/tests/helpers/assertions.ts
@@ -60,6 +60,26 @@ export function assertNoGitMutationCommands(value: string): void {
   }
 }
 
+export function assertNoGhMutationCommands(value: string): void {
+  const lines = value.split('\n').map((line) => line.trim()).filter(Boolean);
+  for (const line of lines) {
+    const [resource, action] = line.split(/\s+/);
+    const command = `${resource ?? ''} ${action ?? ''}`.toLowerCase();
+    assert.ok(![
+      'issue edit',
+      'issue close',
+      'issue comment',
+      'pr edit',
+      'pr merge',
+      'pr comment',
+    ].includes(command), `Unexpected mutating gh command: ${line}`);
+    assert.ok(
+      !(resource?.toLowerCase() === 'api' && /\b(?:PATCH|POST|DELETE)\b/i.test(line)),
+      `Unexpected mutating gh api command: ${line}`
+    );
+  }
+}
+
 export function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -31,6 +31,26 @@ type PreflightFixture = {
   gitLogPath: string;
 };
 
+type EvidenceCheckFixture = {
+  env: NodeJS.ProcessEnv;
+  ghLogPath: string;
+  prNumber: number;
+  repo: string;
+  issueNumber: number;
+  headSha: string;
+  evidenceUrl: string;
+};
+
+type EvidenceCheckFixtureOptions = {
+  prBody?: string;
+  issueComments?: Array<{ url: string; body: string }>;
+  headSha?: string;
+  expectedPrRef?: string;
+  isDraft?: boolean;
+  checks?: Array<{ name: string; state?: string; conclusion?: string; bucket?: string }>;
+  reviews?: Array<{ author?: { login?: string }; body?: string; state?: string; submittedAt?: string }>;
+};
+
 type ExplicitPathPlanFixtureOptions = {
   issueNumber?: number;
   title: string;
@@ -179,6 +199,94 @@ export async function createPreflightFixture(
     branchName,
     env: gitSpy.env,
     gitLogPath: gitSpy.logPath,
+  };
+}
+
+export async function createEvidenceCheckFixture(
+  t: TestLifecycle,
+  options: EvidenceCheckFixtureOptions = {}
+): Promise<EvidenceCheckFixture> {
+  const repo = 'Erick52106/spec-injector';
+  const prNumber = 1091;
+  const issueNumber = 109;
+  const headSha = options.headSha ?? '1234567890abcdef1234567890abcdef12345678';
+  const evidenceUrl = `https://github.com/${repo}/issues/${issueNumber}#issuecomment-1090001`;
+  const prUrl = `https://github.com/${repo}/pull/${prNumber}`;
+  const branch = 'feat/pr-evidence-consistency-checker-109';
+  const defaultValidation = [
+    '- `git diff --check` ✅',
+    '- `pnpm build` ✅',
+    '- `pnpm test` ✅',
+  ].join('\n');
+  const prBody = options.prBody ?? [
+    `Closes #${issueNumber}`,
+    '',
+    '## Summary',
+    '- 新增 repo-local evidence checker。',
+    '',
+    '## Scope',
+    '- 只做 read-only consistency check。',
+    '',
+    '## Non-goals',
+    '- 不 auto-fix、不 merge。',
+    '',
+    '## Validation',
+    defaultValidation,
+    '',
+    '## Review finding assessment',
+    '- noise / not applicable: no actionable review findings.',
+    '',
+    '## Implementation Evidence',
+    `- Issue evidence comment URL: ${evidenceUrl}`,
+    `- Latest HEAD: ${headSha}`,
+    '',
+    '## Follow-up notes',
+    '- JSON output 留待後續。',
+  ].join('\n');
+  const issueComments = options.issueComments ?? [{
+    url: evidenceUrl,
+    body: [
+      '## Implementation evidence',
+      `- PR URL: ${prUrl}`,
+      `- Branch: ${branch}`,
+      `- Commit hash / HEAD: ${headSha}`,
+      '- Tests / validation:',
+      defaultValidation,
+      '- Scope / non-goals: read-only checker; no auto-fix.',
+    ].join('\n'),
+  }];
+  const fakeGh = await createFakeEvidenceGh(t, {
+    repo,
+    prNumber,
+    issueNumber,
+    pr: {
+      number: prNumber,
+      url: prUrl,
+      body: prBody,
+      headRefName: branch,
+      headRefOid: headSha,
+      isDraft: options.isDraft ?? false,
+      reviews: options.reviews ?? [],
+    },
+    issue: {
+      number: issueNumber,
+      url: `https://github.com/${repo}/issues/${issueNumber}`,
+      comments: issueComments,
+    },
+    checks: options.checks ?? [
+      { name: 'build', state: 'COMPLETED', conclusion: 'SUCCESS', bucket: 'pass' },
+    ],
+    expectedPrRef: options.expectedPrRef ?? String(prNumber),
+  });
+
+  return {
+    env: fakeGh.env,
+    ghLogPath: fakeGh.logPath,
+    prNumber,
+    repo,
+    issueNumber,
+    headSha,
+    evidenceUrl,
   };
 }
 
@@ -342,6 +450,93 @@ process.stdout.write(fs.readFileSync(process.env.FAKE_GH_RESPONSE_FILE, 'utf8'))
       FAKE_GH_LOG: logPath,
       FAKE_GH_EXPECT_REF: '57',
       FAKE_GH_EXPECT_REPO: 'Erick52106/spec-injector',
+    },
+    logPath,
+  };
+}
+
+async function createFakeEvidenceGh(
+  t: TestLifecycle,
+  payload: {
+    repo: string;
+    prNumber: number;
+    issueNumber: number;
+    pr: Record<string, unknown>;
+    issue: Record<string, unknown>;
+    checks: Array<Record<string, unknown>>;
+    expectedPrRef: string;
+  }
+): Promise<{
+  env: NodeJS.ProcessEnv;
+  logPath: string;
+}> {
+  const binDir = await fs.mkdtemp(path.join(os.tmpdir(), 'spec-injector-evidence-gh-'));
+  t.after(async () => {
+    await fs.rm(binDir, { recursive: true, force: true });
+  });
+
+  const payloadPath = path.join(binDir, 'evidence.json');
+  const logPath = path.join(binDir, 'gh.log');
+  const ghPath = path.join(binDir, 'gh');
+
+  await fs.writeFile(payloadPath, JSON.stringify(payload), 'utf8');
+  await fs.writeFile(logPath, '', 'utf8');
+  await fs.writeFile(ghPath, `#!/usr/bin/env node
+import fs from 'node:fs';
+
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.FAKE_GH_LOG, args.join(' ') + '\\n', 'utf8');
+const payload = JSON.parse(fs.readFileSync(process.env.FAKE_GH_PAYLOAD_FILE, 'utf8'));
+
+function requireRepo() {
+  const repoFlagIndex = args.indexOf('--repo');
+  if (repoFlagIndex === -1 || args[repoFlagIndex + 1] !== payload.repo) {
+    console.error('Unexpected repo flag: ' + args.join(' '));
+    process.exit(1);
+  }
+}
+
+if (args[0] === 'pr' && args[1] === 'view') {
+  requireRepo();
+  if (args[2] !== payload.expectedPrRef) {
+    console.error('Unexpected PR ref: ' + args[2]);
+    process.exit(1);
+  }
+  process.stdout.write(JSON.stringify(payload.pr));
+  process.exit(0);
+}
+
+if (args[0] === 'issue' && args[1] === 'view') {
+  requireRepo();
+  if (args[2] !== String(payload.issueNumber)) {
+    console.error('Unexpected issue ref: ' + args[2]);
+    process.exit(1);
+  }
+  process.stdout.write(JSON.stringify(payload.issue));
+  process.exit(0);
+}
+
+if (args[0] === 'pr' && args[1] === 'checks') {
+  requireRepo();
+  if (args[2] !== payload.expectedPrRef) {
+    console.error('Unexpected checks PR ref: ' + args[2]);
+    process.exit(1);
+  }
+  process.stdout.write(JSON.stringify(payload.checks));
+  process.exit(0);
+}
+
+console.error('Unsupported gh invocation: ' + args.join(' '));
+process.exit(1);
+`, 'utf8');
+  await fs.chmod(ghPath, 0o755);
+
+  return {
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+      FAKE_GH_PAYLOAD_FILE: payloadPath,
+      FAKE_GH_LOG: logPath,
     },
     logPath,
   };

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -48,6 +48,7 @@ type EvidenceCheckFixtureOptions = {
   expectedPrRef?: string;
   isDraft?: boolean;
   checks?: Array<{ name: string; state?: string; conclusion?: string; bucket?: string }>;
+  checksCommand?: { exitCode?: number; stdout?: string; stderr?: string };
   reviews?: Array<{ author?: { login?: string }; body?: string; state?: string; submittedAt?: string }>;
 };
 
@@ -276,6 +277,7 @@ export async function createEvidenceCheckFixture(
     checks: options.checks ?? [
       { name: 'build', state: 'COMPLETED', conclusion: 'SUCCESS', bucket: 'pass' },
     ],
+    checksCommand: options.checksCommand,
     expectedPrRef: options.expectedPrRef ?? String(prNumber),
   });
 
@@ -464,6 +466,7 @@ async function createFakeEvidenceGh(
     pr: Record<string, unknown>;
     issue: Record<string, unknown>;
     checks: Array<Record<string, unknown>>;
+    checksCommand?: { exitCode?: number; stdout?: string; stderr?: string };
     expectedPrRef: string;
   }
 ): Promise<{
@@ -521,6 +524,15 @@ if (args[0] === 'pr' && args[1] === 'checks') {
   if (args[2] !== payload.expectedPrRef) {
     console.error('Unexpected checks PR ref: ' + args[2]);
     process.exit(1);
+  }
+  if (payload.checksCommand) {
+    if (payload.checksCommand.stdout !== undefined) {
+      process.stdout.write(payload.checksCommand.stdout);
+    }
+    if (payload.checksCommand.stderr !== undefined) {
+      process.stderr.write(payload.checksCommand.stderr);
+    }
+    process.exit(payload.checksCommand.exitCode ?? 0);
   }
   process.stdout.write(JSON.stringify(payload.checks));
   process.exit(0);


### PR DESCRIPTION
Closes #109

## Summary
- 新增 repo-local `spec evidence-check` CLI command，將 PR body、source issue evidence comment、latest PR HEAD、validation evidence、review finding assessment 與 CI/check summary 轉成 deterministic read-only guardrail。
- 補上 fake `gh` fixture 與整合測試，涵蓋 pass、missing evidence URL、wrong issue URL、stale HEAD、expected HEAD mismatch、vague validation、draft PR、CI fail/pending、review finding assessment missing，以及 GitHub mutation invariant。
- 最小更新 `docs/workflow.md` / `docs/validation.md`，說明 checker 只 report / fail / stop-and-report，不 auto-fix、不 merge、不修改 issue/PR/review thread。

## Scope
- CLI command: `spec evidence-check`
- Read-only `gh pr view` / `gh issue view` / `gh pr checks` metadata parsing
- Human-readable `PASS` / `WARNING` / `FAIL` / `NEEDS-HUMAN-REVIEW` output
- Mocked `gh` tests and helper assertions
- Workflow / validation docs for PR evidence consistency guardrail

## Non-goals
- 不處理 #110 label / milestone audit checker。
- 不做 #150 label taxonomy proposal / migration。
- 不 auto-fix PR body、不 auto-update issue comments、不 auto-resolve review threads。
- 不 auto-merge、不 auto-close issue。
- 不新增 hosted dashboard / control plane / daemon / remediation loop。
- 不改 config schema、不新增 JSON/protocol output。
- Tests 不依賴真實 GitHub API / network。

## Validation
- `node --test --test-name-pattern "spec evidence-check|spec --help|spec plan/config/clean help" tests/cli.integration.test.ts` ✅ (27 tests)
- `git diff --check` ✅
- `pnpm build` ✅
- `pnpm test` ✅ (156 tests)
- `pnpm lint`: skipped，`package.json` 沒有 `lint` script。
- `pnpm typecheck`: skipped，`package.json` 沒有 `typecheck` script；`pnpm build` 已執行 `tsc`。

## Review Finding Assessment
| Finding | Classification | Action | Rationale |
|---|---|---|---|
| Codex auto review: approval / summary review should not trigger finding gate | adopted | 修正 | 新增 non-actionable review filter，`APPROVED` / `LGTM` / summary-only wrapper 不會觸發 `NEEDS-HUMAN-REVIEW`；仍保留 actionable review body gate。 |
| Codex auto review: closing keyword should anchor linked issue | adopted | 修正 | Linked issue 改成只從 PR body closing keyword parse；`--issue` 只作 expected issue 比對，不會替 missing `Closes #...` 補過。 |
| CodeRabbit: parse PR body's linked issue independently from `--issue` | adopted | 修正 | 同上，補 regression 測 `--issue` 不能讓 missing PR body link pass，且 early bare `#110` 不會覆蓋 `Closes #109`。 |
| CodeRabbit: require exact validation commands in PR body and issue evidence separately | not adopted | 不採納 | #109 明確允許「PR body 或 issue evidence」列出 exact validation commands；本 PR 維持 pooled command evidence，但 issue evidence content 仍需有 validation summary，避免擴 scope 改成更嚴格 workflow contract。 |
| CodeRabbit: do not treat every non-empty review body as actionable | adopted | 修正 | 新增 review predicate，排除 `APPROVED` / `LGTM` / summary / walkthrough / in-progress wrappers，並要求 actionable tokens。 |
| CodeRabbit: --evidence-url bypasses PR body evidence URL enforcement | adopted | 修正 | `--evidence-url` 改為 expected value；canonical evidence URL 永遠只從 PR body 解析。PR body 缺 URL 即使有 flag 仍 fail，PR body URL 與 flag mismatch 也 fail；新增 missing / mismatch / match regression tests。 |
| CodeRabbit: --repo conflicts with PR URL repository | adopted | 修正 | `resolveContext()` 現在會拒絕 `--repo` 與 `--pr` URL 內 repository 不一致的情況，不再靜默 override；新增 full URL matching / URL-only / conflicting repo / numeric PR without repo regression tests。 |
| CodeRabbit: checks read failure collapsed into empty checks | adopted | 修正 | `gh pr checks` command failure / malformed JSON 現在會成為 explicit `FAIL`，不會被 fallback 成 `[]`；成功回傳 empty checks 仍維持 warning。 |
| CodeRabbit: empty evidence comment skips content check | adopted | 修正 | evidence comment 只要存在就會執行 PR URL / branch / HEAD / validation completeness checks；空 body 會 fail 為 incomplete / stale evidence。 |
| CodeRabbit: approved review actionable body ignored | adopted | 修正 | 移除 `APPROVED` state unconditional bypass；`LGTM` / pure approval / no actionable comments 仍非 actionable，但 `Approved, but fix stale HEAD before merge` 會觸發 assessment gate。 |
| CodeRabbit pre-merge check: Docstring Coverage warning | noise / not applicable | 不採納 | Repo 目前沒有 docstring coverage validation gate，既有 CLI code 也不是 docstring-first style；#109 scope 是 evidence checker guardrail，不為 bot coverage warning 擴 scope。 |

## Implementation Evidence
- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/109#issuecomment-4370590117
- Latest HEAD: `3aac48ffd2bb4f5fec4b946c8dcbb60e196cb2fd`
- Branch: `feat/pr-evidence-consistency-checker-109`
- Scope guard: 只做 #109 first implementation / minimum viable PR evidence consistency checker，不擴到 #110、#150、auto-fix、merge bot、control plane、或 remediation loop。

## Follow-up notes
- 這是 first implementation，先提供 human-readable checker；JSON/protocol output、review thread GraphQL freshness、以及更完整的 CodeRabbit/Codex thread-level freshness 可拆 follow-up。
- 若後續要做 labels / milestones / taxonomy audit，建議維持在 #110 / #150，不混入本 PR。




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new spec evidence-check CLI command to validate PR/issue evidence consistency as a deterministic, read-only guardrail.

* **Documentation**
  * Added guidance on when/how evidence-check runs, its read-only scope, stop-and-report rules for stale evidence/HEAD, and that a pass ≠ review approval.

* **Tests**
  * Expanded integration tests for evidence-check scenarios, help text, input validation, CI/review handling; added a no-mutation assertion and test fixtures for evidence scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
