### PR TITLE
feat(workflow): add read-only label audit checker

### DIFF
--- a/docs/internal-workflow-contract.md
+++ b/docs/internal-workflow-contract.md
@@ -4,9 +4,9 @@
 
 本文件是 #147 的 design-only proposal，定義 `spec-injector` repo 自身使用的 internal machine-readable workflow contract vocabulary。
 
-目前已有第一個 narrow consumer：repo-local、human-readable 的 `spec preflight` checker。它只實作 #108 所需的 bounded preflight subset，用來檢查 main repo / worktree / branch / target repo safety guardrails；它不把本文件變成 runtime schema、JSON output protocol、hosted control plane 或 remediation automation。
+目前已有多個 narrow consumers：repo-local、human-readable 的 `spec preflight`、`spec evidence-check` 與 `spec label-audit`。它們各自只實作 bounded workflow guardrail subset，用來檢查 worktree safety、PR evidence consistency 與 label / milestone metadata audit；它們不把本文件變成 runtime schema、JSON output protocol、hosted control plane 或 remediation automation。
 
-它的第一用途是維持 `spec-injector` 專案本身的 AI-assisted development workflow consistency，讓未來 #108 / #109 / #110 這類 repo-local workflow guardrail checkers 有共同規格來源。#110 label / milestone audit checker 應等 [label-taxonomy.md](label-taxonomy.md) 的 #150 taxonomy proposal 被接受後，再消費 accepted taxonomy；它不應在 taxonomy 未穩前自行發明 labels 或自動修改 metadata。
+它的第一用途是維持 `spec-injector` 專案本身的 AI-assisted development workflow consistency，讓 #108 / #109 / #110 這類 repo-local workflow guardrail checkers 有共同規格來源。#110 label / milestone audit checker 已在 [label-taxonomy.md](label-taxonomy.md) 的 #150 taxonomy proposal 被接受後，以 read-only guardrail 方式消費 accepted taxonomy；它不應自行發明 labels 或自動修改 metadata。
 
 Dogfood finding、review blocker、CI failure、target repo safety near miss 與 evidence freshness gap 如何進入 follow-up issue / regression / closeout loop，見 [harness-gap-loop.md](harness-gap-loop.md)。該 loop 使用本文件的 risk-tier、validation、evidence 與 review vocabulary，但不新增 runtime contract。
 

--- a/docs/label-taxonomy.md
+++ b/docs/label-taxonomy.md
@@ -2,9 +2,9 @@
 
 ## Purpose
 
-This document is a docs-only taxonomy proposal for Issue `#150`. It defines the `spec-injector` GitHub issue / PR label taxonomy, visual hierarchy, label usage rules, migration staging, and prerequisite rules that a future Issue `#110` label / milestone audit checker should consume.
+This document is a docs-only taxonomy proposal for Issue `#150`. It defines the `spec-injector` GitHub issue / PR label taxonomy, visual hierarchy, label usage rules, migration staging, and prerequisite rules that Issue `#110` now consumes via the read-only `spec label-audit` checker.
 
-This proposal does not modify GitHub labels, change label colors, rename / delete labels, mass-edit issues, migrate milestones, or implement the Issue `#110` checker.
+This proposal does not modify GitHub labels, change label colors, rename / delete labels, mass-edit issues, or migrate milestones. `spec label-audit` consumes these rules as report-only input; it still does not mutate metadata.
 
 `spec-injector` remains a deterministic request-to-context compiler for AI coding agents. The label taxonomy should support repo-local deterministic workflow, source trust, context compilation, and review evidence rather than repositioning the project as a GitHub Projects dashboard, hosted control plane, remediation bot, or roadmap platform.
 
@@ -31,7 +31,7 @@ Open issue distribution observed during this proposal:
 | Status | All 11 open issues carry `status:needs-design`, useful for backlog safety but too coarse for future checker behavior if left as the only active state. |
 | Roadmap layers | Layer 2 has 5 open issues, Layer 4 has 5 open issues, Layer 3 has 1 open issue, Layer 1 has 0 open issues. |
 
-Issue `#108` (`spec preflight`) and Issue `#109` (`spec evidence-check`) are merged and closed as completed. Issue `#110` remains open and should wait for this taxonomy to be accepted.
+Issue `#108` (`spec preflight`) and Issue `#109` (`spec evidence-check`) are merged and closed as completed. Issue `#110` now consumes this accepted taxonomy as a read-only audit checker.
 
 ## Problem Statement
 
@@ -360,7 +360,7 @@ Safety / rollback:
 
 ## Relationship To #110
 
-Issue `#110` should not implement until Issue `#150` taxonomy is accepted.
+Issue `#110` implemented only after Issue `#150` taxonomy was accepted, and should remain read-only.
 
 Issue `#110` should:
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -6,7 +6,7 @@
 
 本文件是 workflow 規範，不是 automated checker。若某張 issue 需要新增 CI、script、runtime behavior、CLI command、config schema 或測試，該 scope 必須由 source issue 明確授權。
 
-Internal machine-readable workflow contract 的 design-only validation vocabulary 見 [internal-workflow-contract.md](internal-workflow-contract.md)。Issue / PR label taxonomy 與 #110 label / milestone audit checker dependency 見 [label-taxonomy.md](label-taxonomy.md)。這些文件可供未來 #108 / #109 / #110 checker 消費，但本文件與這些 design docs 都不代表 checker 已實作。
+Internal machine-readable workflow contract 的 design-only validation vocabulary 見 [internal-workflow-contract.md](internal-workflow-contract.md)。Issue / PR label taxonomy 與 #110 label / milestone audit checker rules 見 [label-taxonomy.md](label-taxonomy.md)。`spec label-audit` 現在已用 human-readable、read-only 形式消費 accepted taxonomy；但這些 docs 仍是 canonical workflow 規範，不授權 metadata mutation，也不把 checker 變成 remediation bot。
 
 ## General Rules
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -10,7 +10,9 @@ Internal machine-readable workflow contract 的 design-only vocabulary 見 [inte
 
 Dogfood finding、review blocker、CI failure、evidence freshness gap 與 repeated workflow failure 如何轉成 bounded follow-up issue，見 [harness-gap-loop.md](harness-gap-loop.md)。該 loop 是 repo-local workflow discipline，不是 hosted harness platform 或 remediation automation。
 
-Issue / PR label taxonomy、visual hierarchy、combination rules、migration staging 與 #110 label / milestone audit checker dependency 見 [label-taxonomy.md](label-taxonomy.md)。
+Issue / PR label taxonomy、visual hierarchy、combination rules、migration staging 與 #110 label / milestone audit checker rules 見 [label-taxonomy.md](label-taxonomy.md)。
+
+`spec label-audit` 是 repo-local、human-readable 的 read-only guardrail。它讀取 accepted taxonomy 與 `gh issue list` / `gh pr list` metadata，輸出 `PASS` / `WARNING` / `NEEDS-HUMAN-REVIEW`；它只 report，不建立 labels、不修改 labels、不修改 milestones、不修改 issue / PR metadata。`needs human review` 代表 stop-and-report，不代表 checker 自動替 human 做 metadata 決策。
 
 相鄰工具與 roadmap 邊界請見 [docs/positioning.md](positioning.md)。多 agent / Codex / Claude Code / ChatGPT / other agents 的分工與 handoff patterns 請見 [docs/agent-handoff.md](agent-handoff.md)。
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -174,6 +174,31 @@ Safety:
     await evidenceCheck(opts);
   });
 
+// label-audit subcommand
+program
+  .command('label-audit')
+  .description('Run a read-only label and milestone metadata audit for issues and PRs')
+  .requiredOption('--repo <owner/name>', 'GitHub repository owner/name to audit')
+  .option('--limit <number>', 'Maximum number of issues / PRs to fetch per list (default: 200)')
+  .addHelpText('after', `
+Checks:
+  - open issue area / type / status coverage
+  - conflicting status labels and needs-design vs active review PRs
+  - unknown labels outside the accepted taxonomy snapshot
+  - primary layer / roadmap milestone consistency
+
+Safety:
+  Reports only. Does not create, rename, delete, or mutate labels, issues, milestones, or PR metadata.
+  Needs human review means stop-and-report; the checker does not auto-decide remediation.
+`)
+  .action(async (opts: {
+    repo: string;
+    limit?: string;
+  }) => {
+    const { labelAudit } = await import('./label-audit.js');
+    await labelAudit(opts);
+  });
+
 program.parseAsync(process.argv).catch((err: unknown) => {
   console.error(`✗ ${(err as Error).message}`);
   process.exit(1);

--- a/src/cli/label-audit.ts
+++ b/src/cli/label-audit.ts
@@ -1,0 +1,577 @@
+import fs from 'fs';
+import path from 'path';
+import { run } from '../utils/shell.js';
+
+type Severity = 'pass' | 'warning' | 'needs-human-review';
+
+type LabelAuditCheck = {
+  severity: Severity;
+  summary: string;
+  detail: string;
+};
+
+type LabelAuditOptions = {
+  repo: string;
+  limit?: string;
+};
+
+type IssuePayload = {
+  number?: number;
+  title?: string;
+  url?: string;
+  state?: string;
+  stateReason?: string;
+  labels?: Array<{ name?: string }>;
+  milestone?: { title?: string } | null;
+};
+
+type PullRequestPayload = {
+  number?: number;
+  title?: string;
+  url?: string;
+  labels?: Array<{ name?: string }>;
+  milestone?: { title?: string } | null;
+  closingIssuesReferences?: Array<{ number?: number }>;
+  isDraft?: boolean;
+};
+
+type NormalizedIssue = {
+  number: number;
+  title: string;
+  url: string;
+  state: 'OPEN' | 'CLOSED';
+  stateReason: string | null;
+  labels: string[];
+  milestone: string | null;
+};
+
+type NormalizedPullRequest = {
+  number: number;
+  title: string;
+  url: string;
+  labels: string[];
+  milestone: string | null;
+  closingIssues: number[];
+  isDraft: boolean;
+};
+
+type Taxonomy = {
+  acceptedLabels: Set<string>;
+  typeOrEquivalentLabels: Set<string>;
+  areaLabels: Set<string>;
+  statusLabels: Set<string>;
+  layerLabels: Set<string>;
+  layerToMilestone: Map<string, string>;
+};
+
+const STATUS_IN_REVIEW = 'status:in-review';
+const STATUS_IMPLEMENTED = 'status:implemented';
+const STATUS_NEEDS_DESIGN = 'status:needs-design';
+
+export async function labelAudit(opts: LabelAuditOptions): Promise<void> {
+  try {
+    const report = buildLabelAuditReport(opts, process.cwd());
+    printReport(report);
+
+    if (report.overall === 'needs-human-review') {
+      process.exit(1);
+    }
+  } catch (err) {
+    console.error(`✗ Label audit failed: ${(err as Error).message}`);
+    process.exit(1);
+  }
+}
+
+function buildLabelAuditReport(
+  opts: LabelAuditOptions,
+  repoRoot: string
+): { overall: Severity; checks: LabelAuditCheck[] } {
+  const taxonomy = loadAcceptedTaxonomy(repoRoot);
+  const limit = parseLimit(opts.limit);
+  const checks: LabelAuditCheck[] = [];
+
+  const issuesRead = readJsonResult<IssuePayload[]>(
+    [
+      'gh',
+      'issue',
+      'list',
+      '--repo',
+      opts.repo,
+      '--state',
+      'all',
+      '--limit',
+      String(limit),
+      '--json',
+      'number,title,url,state,stateReason,labels,milestone',
+    ],
+    'could not read gh issue list output',
+    'could not parse gh issue list output'
+  );
+  if (issuesRead.error) {
+    return singleNeedsHumanReviewReport(issuesRead.error);
+  }
+
+  const prsRead = readJsonResult<PullRequestPayload[]>(
+    [
+      'gh',
+      'pr',
+      'list',
+      '--repo',
+      opts.repo,
+      '--state',
+      'open',
+      '--limit',
+      String(limit),
+      '--json',
+      'number,title,url,labels,milestone,closingIssuesReferences,isDraft',
+    ],
+    'could not read gh pr list output',
+    'could not parse gh pr list output'
+  );
+  if (prsRead.error) {
+    return singleNeedsHumanReviewReport(prsRead.error);
+  }
+
+  const normalizedIssues = normalizeIssues(issuesRead.value ?? []);
+  if (normalizedIssues.error) {
+    return singleNeedsHumanReviewReport(normalizedIssues.error);
+  }
+
+  const normalizedPrs = normalizePullRequests(prsRead.value ?? []);
+  if (normalizedPrs.error) {
+    return singleNeedsHumanReviewReport(normalizedPrs.error);
+  }
+
+  const openReviewPrsByIssue = buildOpenReviewPrsByIssue(normalizedPrs.value);
+
+  for (const issue of normalizedIssues.value) {
+    checks.push(...auditIssue(issue, taxonomy, openReviewPrsByIssue));
+  }
+
+  for (const pr of normalizedPrs.value) {
+    checks.push(...auditPullRequest(pr, taxonomy));
+  }
+
+  return {
+    overall: summarizeOverall(checks),
+    checks,
+  };
+}
+
+function auditIssue(
+  issue: NormalizedIssue,
+  taxonomy: Taxonomy,
+  openReviewPrsByIssue: Map<number, NormalizedPullRequest[]>
+): LabelAuditCheck[] {
+  const checks: LabelAuditCheck[] = [];
+  const labelSet = new Set(issue.labels);
+  const typeLabels = issue.labels.filter((label) => taxonomy.typeOrEquivalentLabels.has(label));
+  const areaLabels = issue.labels.filter((label) => taxonomy.areaLabels.has(label));
+  const statusLabels = issue.labels.filter((label) => taxonomy.statusLabels.has(label));
+  const layerLabels = issue.labels.filter((label) => taxonomy.layerLabels.has(label));
+  const unknownLabels = issue.labels.filter((label) => !taxonomy.acceptedLabels.has(label));
+  const linkedReviewPrs = openReviewPrsByIssue.get(issue.number) ?? [];
+
+  if (issue.state === 'OPEN') {
+    if (typeLabels.length > 0) {
+      checks.push(pass(
+        `issue #${issue.number} has type metadata`,
+        typeLabels.join(', ')
+      ));
+    } else {
+      checks.push(warning(
+        `issue #${issue.number} is missing a type or GitHub default equivalent label`,
+        'Open issues should keep one type/equivalent label for deterministic audit output.'
+      ));
+    }
+
+    if (areaLabels.length > 0) {
+      checks.push(pass(
+        `issue #${issue.number} has area metadata`,
+        areaLabels.join(', ')
+      ));
+    } else {
+      checks.push(warning(
+        `issue #${issue.number} is missing a primary area label`,
+        'Open issues should keep at least one area label.'
+      ));
+    }
+
+    checks.push(...checkStatusShape(issue.number, statusLabels));
+
+    if (statusLabels.length === 0) {
+      checks.push(warning(
+        `issue #${issue.number} is missing a status label`,
+        'Open issues should keep one active status label.'
+      ));
+    } else if (statusLabels.length === 1) {
+      checks.push(pass(
+        `issue #${issue.number} has status metadata`,
+        statusLabels[0]
+      ));
+    }
+
+    if (labelSet.has(STATUS_IMPLEMENTED)) {
+      checks.push(warning(
+        `issue #${issue.number} is open but already uses status:implemented`,
+        'Completed status usually belongs on merged/closed work with closeout evidence.'
+      ));
+    }
+  } else {
+    checks.push(...checkStatusShape(issue.number, statusLabels));
+
+    if (issue.stateReason === 'COMPLETED') {
+      if (labelSet.has(STATUS_IMPLEMENTED)) {
+        checks.push(pass(
+          `issue #${issue.number} closed completed state aligns with status:implemented`,
+          'Completed closeout metadata is aligned.'
+        ));
+      } else {
+        checks.push(warning(
+          `issue #${issue.number} is closed as completed without status:implemented`,
+          'Closed completed issues should align with status:implemented when closeout evidence exists.'
+        ));
+      }
+    } else if (issue.stateReason === 'NOT_PLANNED') {
+      if (labelSet.has(STATUS_IMPLEMENTED)) {
+        checks.push(warning(
+          `issue #${issue.number} is closed as not planned but still uses status:implemented`,
+          'Closed not planned issues should not carry implemented status.'
+        ));
+      } else {
+        checks.push(pass(
+          `issue #${issue.number} is closed as not planned and does not require status:implemented`,
+          'No completed-status backfill is needed.'
+        ));
+      }
+    }
+  }
+
+  if (layerLabels.length === 0) {
+    checks.push(warning(
+      `issue #${issue.number} is missing a primary layer label`,
+      'Issues should usually keep one primary layer label when classification is clear.'
+    ));
+  } else if (layerLabels.length === 1) {
+    const expectedMilestone = taxonomy.layerToMilestone.get(layerLabels[0]);
+    if (!issue.milestone) {
+      checks.push(warning(
+        `issue #${issue.number} is missing a roadmap milestone`,
+        `Layer label ${layerLabels[0]} has no matching milestone assigned.`
+      ));
+    } else if (expectedMilestone && issue.milestone !== expectedMilestone) {
+      checks.push(warning(
+        `issue #${issue.number} milestone does not match layer label`,
+        `Layer ${layerLabels[0]} normally maps to milestone ${expectedMilestone}, found ${issue.milestone}.`
+      ));
+    } else if (issue.milestone) {
+      checks.push(pass(
+        `issue #${issue.number} milestone matches layer label`,
+        `${issue.milestone} / ${layerLabels[0]}`
+      ));
+    }
+  } else {
+    checks.push(needsHumanReview(
+      `issue #${issue.number} has multiple layer labels`,
+      layerLabels.join(', ')
+    ));
+  }
+
+  if (unknownLabels.length > 0) {
+    checks.push(warning(
+      `issue #${issue.number} uses unknown labels`,
+      `${unknownLabels.join(', ')} (report only; keep human review in the loop before any metadata cleanup).`
+    ));
+  }
+
+  if (linkedReviewPrs.length > 0) {
+    const prSummary = linkedReviewPrs.map((pr) => `#${pr.number}`).join(', ');
+    if (labelSet.has(STATUS_NEEDS_DESIGN)) {
+      checks.push(needsHumanReview(
+        `issue #${issue.number} still uses status:needs-design while open PRs target implementation`,
+        `Open non-draft PRs: ${prSummary}`
+      ));
+    } else if (labelSet.has(STATUS_IN_REVIEW)) {
+      checks.push(pass(
+        `issue #${issue.number} uses status:in-review while PR review is active`,
+        `Open non-draft PRs: ${prSummary}`
+      ));
+    } else {
+      checks.push(warning(
+        `issue #${issue.number} may need status:in-review because open PR ${prSummary} is not draft`,
+        'Review-state labeling should stay conservative but visible on the source issue.'
+      ));
+    }
+  }
+
+  return checks;
+}
+
+function auditPullRequest(pr: NormalizedPullRequest, taxonomy: Taxonomy): LabelAuditCheck[] {
+  const checks: LabelAuditCheck[] = [];
+  const layerLabels = pr.labels.filter((label) => taxonomy.layerLabels.has(label));
+  const statusLabels = pr.labels.filter((label) => taxonomy.statusLabels.has(label));
+  const unknownLabels = pr.labels.filter((label) => !taxonomy.acceptedLabels.has(label));
+
+  if (statusLabels.length > 1) {
+    checks.push(needsHumanReview(
+      `PR #${pr.number} has conflicting status labels`,
+      statusLabels.join(', ')
+    ));
+  }
+
+  if (layerLabels.length > 1) {
+    checks.push(needsHumanReview(
+      `PR #${pr.number} has multiple layer labels`,
+      layerLabels.join(', ')
+    ));
+  } else if (layerLabels.length === 1 && pr.milestone) {
+    const expectedMilestone = taxonomy.layerToMilestone.get(layerLabels[0]);
+    if (expectedMilestone && pr.milestone !== expectedMilestone) {
+      checks.push(warning(
+        `PR #${pr.number} milestone does not match layer label`,
+        `Layer ${layerLabels[0]} normally maps to milestone ${expectedMilestone}, found ${pr.milestone}.`
+      ));
+    }
+  }
+
+  if (unknownLabels.length > 0) {
+    checks.push(warning(
+      `PR #${pr.number} uses unknown labels`,
+      `${unknownLabels.join(', ')} (report only; keep human review in the loop before any metadata cleanup).`
+    ));
+  }
+
+  if (checks.length === 0) {
+    checks.push(pass(
+      `PR #${pr.number} metadata stays within read-only audit scope`,
+      pr.title
+    ));
+  }
+
+  return checks;
+}
+
+function checkStatusShape(issueNumber: number, statusLabels: string[]): LabelAuditCheck[] {
+  if (statusLabels.length <= 1) {
+    return [];
+  }
+
+  return [needsHumanReview(
+    `issue #${issueNumber} has conflicting active status labels`,
+    statusLabels.join(', ')
+  )];
+}
+
+function buildOpenReviewPrsByIssue(prs: NormalizedPullRequest[]): Map<number, NormalizedPullRequest[]> {
+  const result = new Map<number, NormalizedPullRequest[]>();
+
+  for (const pr of prs) {
+    if (pr.isDraft) continue;
+
+    for (const issueNumber of pr.closingIssues) {
+      const current = result.get(issueNumber) ?? [];
+      current.push(pr);
+      result.set(issueNumber, current);
+    }
+  }
+
+  return result;
+}
+
+function normalizeIssues(payload: IssuePayload[]): { value: NormalizedIssue[]; error?: string } {
+  const issues: NormalizedIssue[] = [];
+
+  for (const issue of payload) {
+    const issueNumber = issue.number;
+    if (typeof issueNumber !== 'number' || !Number.isFinite(issueNumber)) {
+      return { value: [], error: 'gh issue list output is missing required fields for an issue: number' };
+    }
+    if (typeof issue.title !== 'string' || typeof issue.url !== 'string' || typeof issue.state !== 'string' || !Array.isArray(issue.labels)) {
+      return { value: [], error: `gh issue list output is missing required fields for issue #${issueNumber}` };
+    }
+
+    const state = issue.state.toUpperCase();
+    if (state !== 'OPEN' && state !== 'CLOSED') {
+      return { value: [], error: `gh issue list output has an unsupported state for issue #${issueNumber}: ${issue.state}` };
+    }
+
+    issues.push({
+      number: issueNumber,
+      title: issue.title,
+      url: issue.url,
+      state,
+      stateReason: typeof issue.stateReason === 'string' ? issue.stateReason.toUpperCase() : null,
+      labels: normalizeLabelNames(issue.labels),
+      milestone: issue.milestone?.title ?? null,
+    });
+  }
+
+  return { value: issues };
+}
+
+function normalizePullRequests(payload: PullRequestPayload[]): { value: NormalizedPullRequest[]; error?: string } {
+  const prs: NormalizedPullRequest[] = [];
+
+  for (const pr of payload) {
+    const prNumber = pr.number;
+    if (typeof prNumber !== 'number' || !Number.isFinite(prNumber)) {
+      return { value: [], error: 'gh pr list output is missing required fields for a pull request: number' };
+    }
+    if (typeof pr.title !== 'string' || typeof pr.url !== 'string' || !Array.isArray(pr.labels)) {
+      return { value: [], error: `gh pr list output is missing required fields for PR #${prNumber}` };
+    }
+
+    const closingIssues = Array.isArray(pr.closingIssuesReferences)
+      ? pr.closingIssuesReferences
+        .map((item) => item.number)
+        .filter((value): value is number => Number.isFinite(value))
+      : [];
+
+    prs.push({
+      number: prNumber,
+      title: pr.title,
+      url: pr.url,
+      labels: normalizeLabelNames(pr.labels),
+      milestone: pr.milestone?.title ?? null,
+      closingIssues,
+      isDraft: Boolean(pr.isDraft),
+    });
+  }
+
+  return { value: prs };
+}
+
+function normalizeLabelNames(labels: Array<{ name?: string }>): string[] {
+  return [...new Set(labels
+    .map((label) => label.name?.trim())
+    .filter((label): label is string => Boolean(label)))];
+}
+
+function loadAcceptedTaxonomy(repoRoot: string): Taxonomy {
+  const labelTaxonomyPath = path.join(repoRoot, 'docs', 'label-taxonomy.md');
+  const workflowPath = path.join(repoRoot, 'docs', 'workflow.md');
+  const labelTaxonomy = fs.readFileSync(labelTaxonomyPath, 'utf8');
+  const workflow = fs.readFileSync(workflowPath, 'utf8');
+
+  const typeLabels = new Set(extractBacktickedLabels(labelTaxonomy, /^- Type labels:/m));
+  const areaLabels = new Set(extractBacktickedLabels(labelTaxonomy, /^- Area labels:/m));
+  const statusLabels = new Set(extractBacktickedLabels(labelTaxonomy, /^- Status labels:/m));
+  const layerLabels = new Set(extractBacktickedLabels(labelTaxonomy, /^- Layer labels:/m));
+  const defaultEquivalentLabels = new Set(extractBacktickedLabels(labelTaxonomy, /^- GitHub default \/ equivalent labels:/m));
+  const layerToMilestone = extractLayerMilestoneMap(workflow);
+
+  return {
+    acceptedLabels: new Set([
+      ...typeLabels,
+      ...areaLabels,
+      ...statusLabels,
+      ...layerLabels,
+      ...defaultEquivalentLabels,
+    ]),
+    typeOrEquivalentLabels: new Set([
+      ...typeLabels,
+      ...defaultEquivalentLabels,
+    ]),
+    areaLabels,
+    statusLabels,
+    layerLabels,
+    layerToMilestone,
+  };
+}
+
+function extractBacktickedLabels(value: string, marker: RegExp): string[] {
+  const line = value.split('\n').find((candidate) => marker.test(candidate));
+  if (!line) return [];
+  return [...line.matchAll(/`([^`]+)`/g)].map((match) => match[1]);
+}
+
+function extractLayerMilestoneMap(workflow: string): Map<string, string> {
+  const result = new Map<string, string>();
+  for (const match of workflow.matchAll(/- `([^`]+)` \/ `([^`]+)`: /g)) {
+    result.set(match[2], match[1]);
+  }
+  return result;
+}
+
+function parseLimit(limitOption: string | undefined): number {
+  if (!limitOption) return 200;
+  const parsed = Number.parseInt(limitOption, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error('--limit must be a positive integer.');
+  }
+  return parsed;
+}
+
+function readJsonResult<T>(
+  argv: string[],
+  readErrorMessage: string,
+  parseErrorMessage: string
+): { value?: T; error?: string } {
+  const result = run(argv);
+  if (result.exitCode !== 0) {
+    return { error: `${readErrorMessage}: ${firstMeaningfulMessage(result.stderr, result.stdout)}` };
+  }
+
+  try {
+    return { value: JSON.parse(result.stdout) as T };
+  } catch {
+    return { error: parseErrorMessage };
+  }
+}
+
+function firstMeaningfulMessage(...values: string[]): string {
+  for (const value of values) {
+    const trimmed = value.trim();
+    if (trimmed.length > 0) {
+      return trimmed.split('\n')[0];
+    }
+  }
+  return 'no details returned';
+}
+
+function singleNeedsHumanReviewReport(detail: string): { overall: Severity; checks: LabelAuditCheck[] } {
+  return {
+    overall: 'needs-human-review',
+    checks: [needsHumanReview('could not complete label audit with high confidence', detail)],
+  };
+}
+
+function summarizeOverall(checks: LabelAuditCheck[]): Severity {
+  if (checks.some((check) => check.severity === 'needs-human-review')) {
+    return 'needs-human-review';
+  }
+  if (checks.some((check) => check.severity === 'warning')) {
+    return 'warning';
+  }
+  return 'pass';
+}
+
+function printReport(report: { overall: Severity; checks: LabelAuditCheck[] }): void {
+  const counts = {
+    pass: report.checks.filter((check) => check.severity === 'pass').length,
+    warning: report.checks.filter((check) => check.severity === 'warning').length,
+    needsHumanReview: report.checks.filter((check) => check.severity === 'needs-human-review').length,
+  };
+
+  console.log(
+    `Label audit summary: ${report.overall.toUpperCase()} ` +
+    `(${counts.pass} pass, ${counts.warning} warning, ${counts.needsHumanReview} needs-human-review)`
+  );
+
+  for (const check of report.checks) {
+    console.log(`[${check.severity.toUpperCase()}] ${check.summary} — ${check.detail}`);
+  }
+}
+
+function pass(summary: string, detail: string): LabelAuditCheck {
+  return { severity: 'pass', summary, detail };
+}
+
+function warning(summary: string, detail: string): LabelAuditCheck {
+  return { severity: 'warning', summary, detail };
+}
+
+function needsHumanReview(summary: string, detail: string): LabelAuditCheck {
+  return { severity: 'needs-human-review', summary, detail };
+}

--- a/src/cli/label-audit.ts
+++ b/src/cli/label-audit.ts
@@ -86,7 +86,11 @@ function buildLabelAuditReport(
   opts: LabelAuditOptions,
   repoRoot: string
 ): { overall: Severity; checks: LabelAuditCheck[] } {
-  const taxonomy = loadAcceptedTaxonomy(repoRoot);
+  const taxonomyRead = loadAcceptedTaxonomy(repoRoot);
+  if ('error' in taxonomyRead) {
+    return singleNeedsHumanReviewReport(taxonomyRead.error);
+  }
+  const taxonomy = taxonomyRead.value;
   const limit = parseLimit(opts.limit);
   const checks: LabelAuditCheck[] = [];
 
@@ -172,20 +176,34 @@ function auditIssue(
   const unknownLabels = issue.labels.filter((label) => !taxonomy.acceptedLabels.has(label));
   const linkedReviewPrs = openReviewPrsByIssue.get(issue.number) ?? [];
 
+  if (typeLabels.length > 1) {
+    checks.push(needsHumanReview(
+      `issue #${issue.number} has multiple type labels`,
+      typeLabels.join(', ')
+    ));
+  }
+
+  if (areaLabels.length > 3) {
+    checks.push(needsHumanReview(
+      `issue #${issue.number} has too many area labels`,
+      areaLabels.join(', ')
+    ));
+  }
+
   if (issue.state === 'OPEN') {
-    if (typeLabels.length > 0) {
+    if (typeLabels.length === 1) {
       checks.push(pass(
         `issue #${issue.number} has type metadata`,
         typeLabels.join(', ')
       ));
-    } else {
+    } else if (typeLabels.length === 0) {
       checks.push(warning(
         `issue #${issue.number} is missing a type or GitHub default equivalent label`,
         'Open issues should keep one type/equivalent label for deterministic audit output.'
       ));
     }
 
-    if (areaLabels.length > 0) {
+    if (areaLabels.length > 0 && areaLabels.length <= 3) {
       checks.push(pass(
         `issue #${issue.number} has area metadata`,
         areaLabels.join(', ')
@@ -259,12 +277,17 @@ function auditIssue(
         `issue #${issue.number} is missing a roadmap milestone`,
         `Layer label ${layerLabels[0]} has no matching milestone assigned.`
       ));
+    } else if (!expectedMilestone) {
+      checks.push(warning(
+        `issue #${issue.number} layer label has no configured roadmap milestone mapping`,
+        `${layerLabels[0]} is missing from workflow milestone mapping.`
+      ));
     } else if (expectedMilestone && issue.milestone !== expectedMilestone) {
       checks.push(warning(
         `issue #${issue.number} milestone does not match layer label`,
         `Layer ${layerLabels[0]} normally maps to milestone ${expectedMilestone}, found ${issue.milestone}.`
       ));
-    } else if (issue.milestone) {
+    } else if (issue.milestone === expectedMilestone) {
       checks.push(pass(
         `issue #${issue.number} milestone matches layer label`,
         `${issue.milestone} / ${layerLabels[0]}`
@@ -325,12 +348,27 @@ function auditPullRequest(pr: NormalizedPullRequest, taxonomy: Taxonomy): LabelA
       `PR #${pr.number} has multiple layer labels`,
       layerLabels.join(', ')
     ));
-  } else if (layerLabels.length === 1 && pr.milestone) {
+  } else if (layerLabels.length === 1) {
     const expectedMilestone = taxonomy.layerToMilestone.get(layerLabels[0]);
-    if (expectedMilestone && pr.milestone !== expectedMilestone) {
+    if (!pr.milestone) {
+      checks.push(warning(
+        `PR #${pr.number} is missing a roadmap milestone`,
+        `Layer label ${layerLabels[0]} has no matching milestone assigned.`
+      ));
+    } else if (!expectedMilestone) {
+      checks.push(warning(
+        `PR #${pr.number} layer label has no configured roadmap milestone mapping`,
+        `${layerLabels[0]} is missing from workflow milestone mapping.`
+      ));
+    } else if (pr.milestone !== expectedMilestone) {
       checks.push(warning(
         `PR #${pr.number} milestone does not match layer label`,
         `Layer ${layerLabels[0]} normally maps to milestone ${expectedMilestone}, found ${pr.milestone}.`
+      ));
+    } else {
+      checks.push(pass(
+        `PR #${pr.number} milestone matches layer label`,
+        `${pr.milestone} / ${layerLabels[0]}`
       ));
     }
   }
@@ -448,42 +486,74 @@ function normalizeLabelNames(labels: Array<{ name?: string }>): string[] {
     .filter((label): label is string => Boolean(label)))];
 }
 
-function loadAcceptedTaxonomy(repoRoot: string): Taxonomy {
+function loadAcceptedTaxonomy(repoRoot: string): { value: Taxonomy } | { error: string } {
   const labelTaxonomyPath = path.join(repoRoot, 'docs', 'label-taxonomy.md');
   const workflowPath = path.join(repoRoot, 'docs', 'workflow.md');
   const labelTaxonomy = fs.readFileSync(labelTaxonomyPath, 'utf8');
   const workflow = fs.readFileSync(workflowPath, 'utf8');
 
-  const typeLabels = new Set(extractBacktickedLabels(labelTaxonomy, /^- Type labels:/m));
-  const areaLabels = new Set(extractBacktickedLabels(labelTaxonomy, /^- Area labels:/m));
-  const statusLabels = new Set(extractBacktickedLabels(labelTaxonomy, /^- Status labels:/m));
-  const layerLabels = new Set(extractBacktickedLabels(labelTaxonomy, /^- Layer labels:/m));
-  const defaultEquivalentLabels = new Set(extractBacktickedLabels(labelTaxonomy, /^- GitHub default \/ equivalent labels:/m));
+  const typeLabels = extractBacktickedLabels(labelTaxonomy, /^- Type labels:/m, 'Type labels');
+  const areaLabels = extractBacktickedLabels(labelTaxonomy, /^- Area labels:/m, 'Area labels');
+  const statusLabels = extractBacktickedLabels(labelTaxonomy, /^- Status labels:/m, 'Status labels');
+  const layerLabels = extractBacktickedLabels(labelTaxonomy, /^- Layer labels:/m, 'Layer labels');
+  const defaultEquivalentLabels = extractBacktickedLabels(
+    labelTaxonomy,
+    /^- GitHub default \/ equivalent labels:/m,
+    'GitHub default / equivalent labels'
+  );
+  if ('error' in typeLabels) {
+    return { error: `could not parse accepted taxonomy markers: ${typeLabels.error}` };
+  }
+  if ('error' in areaLabels) {
+    return { error: `could not parse accepted taxonomy markers: ${areaLabels.error}` };
+  }
+  if ('error' in statusLabels) {
+    return { error: `could not parse accepted taxonomy markers: ${statusLabels.error}` };
+  }
+  if ('error' in layerLabels) {
+    return { error: `could not parse accepted taxonomy markers: ${layerLabels.error}` };
+  }
+  if ('error' in defaultEquivalentLabels) {
+    return { error: `could not parse accepted taxonomy markers: ${defaultEquivalentLabels.error}` };
+  }
   const layerToMilestone = extractLayerMilestoneMap(workflow);
+  if (layerToMilestone.size === 0) {
+    return { error: 'could not parse workflow layer-to-milestone mapping' };
+  }
 
-  return {
+  return { value: {
     acceptedLabels: new Set([
-      ...typeLabels,
-      ...areaLabels,
-      ...statusLabels,
-      ...layerLabels,
-      ...defaultEquivalentLabels,
+      ...typeLabels.value,
+      ...areaLabels.value,
+      ...statusLabels.value,
+      ...layerLabels.value,
+      ...defaultEquivalentLabels.value,
     ]),
     typeOrEquivalentLabels: new Set([
-      ...typeLabels,
-      ...defaultEquivalentLabels,
+      ...typeLabels.value,
+      ...defaultEquivalentLabels.value,
     ]),
-    areaLabels,
-    statusLabels,
-    layerLabels,
+    areaLabels: new Set(areaLabels.value),
+    statusLabels: new Set(statusLabels.value),
+    layerLabels: new Set(layerLabels.value),
     layerToMilestone,
-  };
+  } };
 }
 
-function extractBacktickedLabels(value: string, marker: RegExp): string[] {
+function extractBacktickedLabels(
+  value: string,
+  marker: RegExp,
+  markerName: string
+): { value: string[] } | { error: string } {
   const line = value.split('\n').find((candidate) => marker.test(candidate));
-  if (!line) return [];
-  return [...line.matchAll(/`([^`]+)`/g)].map((match) => match[1]);
+  if (!line) {
+    return { error: `missing marker line for ${markerName}` };
+  }
+  const labels = [...line.matchAll(/`([^`]+)`/g)].map((match) => match[1]);
+  if (labels.length === 0) {
+    return { error: `marker line for ${markerName} does not contain any backticked labels` };
+  }
+  return { value: labels };
 }
 
 function extractLayerMilestoneMap(workflow: string): Map<string, string> {

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -700,6 +700,25 @@ test('spec plan/config/clean help describe AI-facing usage and safety constraint
   assert.match(labelAuditHelp.stdout, /does not create, rename, delete, or mutate/i);
 });
 
+test('spec label-audit forwards --limit to gh issue and pr list', async (t) => {
+  const fixture = await createLabelAuditFixture(t, {
+    issues: [],
+    prs: [],
+  });
+
+  const result = await runSpec([
+    'label-audit',
+    '--repo', fixture.repo,
+    '--limit', '25',
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assert.match(ghLog, /issue list[\s\S]*--limit 25/);
+  assert.match(ghLog, /pr list[\s\S]*--limit 25/);
+  assertNoGhMutationCommands(ghLog);
+});
+
 test('spec label-audit passes for open issues with accepted type, area, status, layer, and milestone metadata', async (t) => {
   const fixture = await createLabelAuditFixture(t, {
     issues: [{
@@ -729,6 +748,70 @@ test('spec label-audit passes for open issues with accepted type, area, status, 
   assert.match(result.stdout, /issue #110 has status metadata/i);
   assert.match(result.stdout, /issue #110 milestone matches layer label/i);
   assert.equal(result.stderr, '');
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec label-audit reports multiple type labels as needs human review', async (t) => {
+  const fixture = await createLabelAuditFixture(t, {
+    issues: [{
+      number: 213,
+      title: 'conflicting type labels',
+      url: 'https://github.com/Erick52106/spec-injector/issues/213',
+      state: 'OPEN',
+      labels: [
+        { name: 'bug' },
+        { name: 'enhancement' },
+        { name: 'area:workflow' },
+        { name: 'status:ready' },
+        { name: 'layer2 : Workflow Guardrails' },
+      ],
+      milestone: { title: 'Layer 2 — Workflow Guardrails' },
+    }],
+  });
+
+  const result = await runSpec([
+    'label-audit',
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stdout, /Label audit summary:\s+NEEDS-HUMAN-REVIEW/i);
+  assert.match(result.stdout, /issue #213 has multiple type labels/i);
+  assertNoRawStackTrace(result);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec label-audit reports more than three area labels as needs human review', async (t) => {
+  const fixture = await createLabelAuditFixture(t, {
+    issues: [{
+      number: 214,
+      title: 'too many area labels',
+      url: 'https://github.com/Erick52106/spec-injector/issues/214',
+      state: 'OPEN',
+      labels: [
+        { name: 'enhancement' },
+        { name: 'area:workflow' },
+        { name: 'area:docs' },
+        { name: 'area:cli' },
+        { name: 'area:tooling' },
+        { name: 'status:ready' },
+        { name: 'layer2 : Workflow Guardrails' },
+      ],
+      milestone: { title: 'Layer 2 — Workflow Guardrails' },
+    }],
+  });
+
+  const result = await runSpec([
+    'label-audit',
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stdout, /Label audit summary:\s+NEEDS-HUMAN-REVIEW/i);
+  assert.match(result.stdout, /issue #214 has too many area labels/i);
+  assertNoRawStackTrace(result);
   const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
   assertNoGhMutationCommands(ghLog);
 });
@@ -1006,6 +1089,77 @@ test('spec label-audit warns when an open ready issue has a non-draft PR but is 
   assertNoGhMutationCommands(ghLog);
 });
 
+test('spec label-audit warns when a PR has a layer label but no milestone', async (t) => {
+  const fixture = await createLabelAuditFixture(t, {
+    prs: [{
+      number: 312,
+      title: 'workflow PR without milestone',
+      url: 'https://github.com/Erick52106/spec-injector/pull/312',
+      labels: [{ name: 'layer2 : Workflow Guardrails' }],
+      milestone: null,
+      closingIssuesReferences: [],
+      isDraft: false,
+    }],
+  });
+
+  const result = await runSpec([
+    'label-audit',
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Label audit summary:\s+WARNING/i);
+  assert.match(result.stdout, /PR #312 is missing a roadmap milestone/i);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec label-audit warns when a layer label has no configured milestone mapping', async (t) => {
+  const fixture = await createLabelAuditFixture(t, {
+    issues: [{
+      number: 215,
+      title: 'unmapped layer milestone issue',
+      url: 'https://github.com/Erick52106/spec-injector/issues/215',
+      state: 'OPEN',
+      labels: [
+        { name: 'enhancement' },
+        { name: 'area:workflow' },
+        { name: 'status:ready' },
+        { name: 'layer2 : Workflow Guardrails' },
+      ],
+      milestone: { title: 'Layer 2 — Workflow Guardrails' },
+    }],
+  });
+  const repoDir = await createTempRepo(t, 'spec-injector-label-audit-taxonomy-');
+  await writeRepoFiles(repoDir, {
+    'docs/label-taxonomy.md': [
+      '# Minimal taxonomy',
+      '',
+      '- Type labels: `type:chore`, `type:ci`, `type:design`, `type:refactor`, `type:test`.',
+      '- Area labels: `area:workflow`, `area:docs`, `area:cli`, `area:tooling`.',
+      '- Status labels: `status:blocked`, `status:implemented`, `status:in-review`, `status:needs-design`, `status:ready`.',
+      '- Layer labels: `layer1 : Core Compiler`, `layer2 : Workflow Guardrails`.',
+      '- GitHub default / equivalent labels: `bug`, `documentation`, `enhancement`.',
+    ].join('\n'),
+    'docs/workflow.md': [
+      '# Workflow',
+      '',
+      '- `Layer 1 — Core Compiler` / `layer1 : Core Compiler`: core compiler.',
+    ].join('\n'),
+  });
+
+  const result = await runSpec([
+    'label-audit',
+    '--repo', fixture.repo,
+  ], { env: fixture.env, cwd: repoDir });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Label audit summary:\s+WARNING/i);
+  assert.match(result.stdout, /issue #215 layer label has no configured roadmap milestone mapping/i);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
 test('spec label-audit reports malformed gh output as needs human review without a raw stack trace', async (t) => {
   const fixture = await createLabelAuditFixture(t, {
     issueListCommand: {
@@ -1048,6 +1202,41 @@ test('spec label-audit reports missing gh fields as needs human review without a
   assert.notEqual(result.code, 0);
   assert.match(result.stdout, /Label audit summary:\s+NEEDS-HUMAN-REVIEW/i);
   assert.match(result.stdout, /gh issue list output is missing required fields for issue #212/i);
+  assertNoRawStackTrace(result);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec label-audit reports missing taxonomy markers as needs human review without a raw stack trace', async (t) => {
+  const fixture = await createLabelAuditFixture(t, {
+    issues: [],
+    prs: [],
+  });
+  const repoDir = await createTempRepo(t, 'spec-injector-label-audit-malformed-taxonomy-');
+  await writeRepoFiles(repoDir, {
+    'docs/label-taxonomy.md': [
+      '# Broken taxonomy',
+      '',
+      '- Area labels: `area:workflow`.',
+      '- Status labels: `status:ready`.',
+      '- Layer labels: `layer2 : Workflow Guardrails`.',
+      '- GitHub default / equivalent labels: `enhancement`.',
+    ].join('\n'),
+    'docs/workflow.md': [
+      '# Workflow',
+      '',
+      '- `Layer 2 — Workflow Guardrails` / `layer2 : Workflow Guardrails`: workflow guardrails.',
+    ].join('\n'),
+  });
+
+  const result = await runSpec([
+    'label-audit',
+    '--repo', fixture.repo,
+  ], { env: fixture.env, cwd: repoDir });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stdout, /Label audit summary:\s+NEEDS-HUMAN-REVIEW/i);
+  assert.match(result.stdout, /could not parse accepted taxonomy markers/i);
   assertNoRawStackTrace(result);
   const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
   assertNoGhMutationCommands(ghLog);

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -11,6 +11,7 @@ import {
   createEvidenceCheckFixture,
   createExternalConfigPlanFixture,
   createFailingGitEnv,
+  createLabelAuditFixture,
   createMissingPath,
   createPreflightFixture,
   createSpecPlanFixture,
@@ -625,6 +626,7 @@ test('spec --help lists deterministic CLI purpose and available commands', async
   assert.match(result.stdout, /\bconfig\b/);
   assert.match(result.stdout, /\bclean\b/);
   assert.match(result.stdout, /\bevidence-check\b/);
+  assert.match(result.stdout, /\blabel-audit\b/);
   assert.match(result.stdout, /help \[command\]/i);
 });
 
@@ -689,6 +691,366 @@ test('spec plan/config/clean help describe AI-facing usage and safety constraint
   assert.match(evidenceCheckHelp.stdout, /--pr <number-or-url>/);
   assert.match(evidenceCheckHelp.stdout, /--expected-head <sha>/);
   assert.match(evidenceCheckHelp.stdout, /read-only guardrail/i);
+
+  const labelAuditHelp = await runSpec(['label-audit', '--help']);
+  assert.equal(labelAuditHelp.code, 0, labelAuditHelp.stderr);
+  assert.match(labelAuditHelp.stdout, /label and milestone metadata audit/i);
+  assert.match(labelAuditHelp.stdout, /--repo <owner\/name>/);
+  assert.match(labelAuditHelp.stdout, /reports only/i);
+  assert.match(labelAuditHelp.stdout, /does not create, rename, delete, or mutate/i);
+});
+
+test('spec label-audit passes for open issues with accepted type, area, status, layer, and milestone metadata', async (t) => {
+  const fixture = await createLabelAuditFixture(t, {
+    issues: [{
+      number: 110,
+      title: 'feat(workflow): add issue label audit for area/type/status taxonomy',
+      url: `https://github.com/${'Erick52106/spec-injector'}/issues/110`,
+      state: 'OPEN',
+      labels: [
+        { name: 'enhancement' },
+        { name: 'area:workflow' },
+        { name: 'status:ready' },
+        { name: 'layer2 : Workflow Guardrails' },
+      ],
+      milestone: { title: 'Layer 2 — Workflow Guardrails' },
+    }],
+  });
+
+  const result = await runSpec([
+    'label-audit',
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Label audit summary:\s+PASS/i);
+  assert.match(result.stdout, /issue #110 has type metadata/i);
+  assert.match(result.stdout, /issue #110 has area metadata/i);
+  assert.match(result.stdout, /issue #110 has status metadata/i);
+  assert.match(result.stdout, /issue #110 milestone matches layer label/i);
+  assert.equal(result.stderr, '');
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec label-audit warns when open issues are missing area, status, or type metadata', async (t) => {
+  const fixture = await createLabelAuditFixture(t, {
+    issues: [
+      {
+        number: 201,
+        title: 'missing area metadata',
+        url: 'https://github.com/Erick52106/spec-injector/issues/201',
+        state: 'OPEN',
+        labels: [
+          { name: 'enhancement' },
+          { name: 'status:ready' },
+          { name: 'layer2 : Workflow Guardrails' },
+        ],
+        milestone: { title: 'Layer 2 — Workflow Guardrails' },
+      },
+      {
+        number: 202,
+        title: 'missing status metadata',
+        url: 'https://github.com/Erick52106/spec-injector/issues/202',
+        state: 'OPEN',
+        labels: [
+          { name: 'enhancement' },
+          { name: 'area:workflow' },
+          { name: 'layer2 : Workflow Guardrails' },
+        ],
+        milestone: { title: 'Layer 2 — Workflow Guardrails' },
+      },
+      {
+        number: 203,
+        title: 'missing type metadata',
+        url: 'https://github.com/Erick52106/spec-injector/issues/203',
+        state: 'OPEN',
+        labels: [
+          { name: 'area:workflow' },
+          { name: 'status:ready' },
+          { name: 'layer2 : Workflow Guardrails' },
+        ],
+        milestone: { title: 'Layer 2 — Workflow Guardrails' },
+      },
+    ],
+  });
+
+  const result = await runSpec([
+    'label-audit',
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Label audit summary:\s+WARNING/i);
+  assert.match(result.stdout, /issue #201 is missing a primary area label/i);
+  assert.match(result.stdout, /issue #202 is missing a status label/i);
+  assert.match(result.stdout, /issue #203 is missing a type or GitHub default equivalent label/i);
+  assert.equal(result.stderr, '');
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec label-audit reports conflicting active status labels as needs human review', async (t) => {
+  const fixture = await createLabelAuditFixture(t, {
+    issues: [{
+      number: 204,
+      title: 'conflicting status labels',
+      url: 'https://github.com/Erick52106/spec-injector/issues/204',
+      state: 'OPEN',
+      labels: [
+        { name: 'enhancement' },
+        { name: 'area:workflow' },
+        { name: 'status:ready' },
+        { name: 'status:needs-design' },
+        { name: 'layer2 : Workflow Guardrails' },
+      ],
+      milestone: { title: 'Layer 2 — Workflow Guardrails' },
+    }],
+  });
+
+  const result = await runSpec([
+    'label-audit',
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stdout, /Label audit summary:\s+NEEDS-HUMAN-REVIEW/i);
+  assert.match(result.stdout, /issue #204 has conflicting active status labels/i);
+  assertNoRawStackTrace(result);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec label-audit warns when a closed completed issue lacks status:implemented', async (t) => {
+  const fixture = await createLabelAuditFixture(t, {
+    issues: [{
+      number: 205,
+      title: 'closed completed without implemented status',
+      url: 'https://github.com/Erick52106/spec-injector/issues/205',
+      state: 'CLOSED',
+      stateReason: 'COMPLETED',
+      labels: [
+        { name: 'enhancement' },
+        { name: 'area:workflow' },
+        { name: 'layer2 : Workflow Guardrails' },
+      ],
+      milestone: { title: 'Layer 2 — Workflow Guardrails' },
+    }],
+  });
+
+  const result = await runSpec([
+    'label-audit',
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Label audit summary:\s+WARNING/i);
+  assert.match(result.stdout, /issue #205 is closed as completed without status:implemented/i);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec label-audit does not require status:implemented for issues closed as not planned', async (t) => {
+  const fixture = await createLabelAuditFixture(t, {
+    issues: [{
+      number: 206,
+      title: 'closed not planned without implemented status',
+      url: 'https://github.com/Erick52106/spec-injector/issues/206',
+      state: 'CLOSED',
+      stateReason: 'NOT_PLANNED',
+      labels: [
+        { name: 'enhancement' },
+        { name: 'area:workflow' },
+        { name: 'layer2 : Workflow Guardrails' },
+      ],
+      milestone: { title: 'Layer 2 — Workflow Guardrails' },
+    }],
+  });
+
+  const result = await runSpec([
+    'label-audit',
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Label audit summary:\s+PASS/i);
+  assert.match(result.stdout, /issue #206 is closed as not planned and does not require status:implemented/i);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec label-audit keeps accepted keep-as-is labels out of unknown-label warnings', async (t) => {
+  const fixture = await createLabelAuditFixture(t, {
+    issues: [
+      {
+        number: 207,
+        title: 'keep-as-is chore issue',
+        url: 'https://github.com/Erick52106/spec-injector/issues/207',
+        state: 'OPEN',
+        labels: [
+          { name: 'type:chore' },
+          { name: 'area:tooling' },
+          { name: 'status:ready' },
+          { name: 'layer2 : Workflow Guardrails' },
+        ],
+        milestone: { title: 'Layer 2 — Workflow Guardrails' },
+      },
+      {
+        number: 208,
+        title: 'keep-as-is ci issue',
+        url: 'https://github.com/Erick52106/spec-injector/issues/208',
+        state: 'OPEN',
+        labels: [
+          { name: 'type:ci' },
+          { name: 'area:ci' },
+          { name: 'status:ready' },
+          { name: 'layer2 : Workflow Guardrails' },
+        ],
+        milestone: { title: 'Layer 2 — Workflow Guardrails' },
+      },
+      {
+        number: 209,
+        title: 'keep-as-is refactor issue',
+        url: 'https://github.com/Erick52106/spec-injector/issues/209',
+        state: 'OPEN',
+        labels: [
+          { name: 'type:refactor' },
+          { name: 'area:cli' },
+          { name: 'status:ready' },
+          { name: 'layer1 : Core Compiler' },
+        ],
+        milestone: { title: 'Layer 1 — Core Compiler' },
+      },
+    ],
+  });
+
+  const result = await runSpec([
+    'label-audit',
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Label audit summary:\s+PASS/i);
+  assert.doesNotMatch(result.stdout, /unknown label/i);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec label-audit warns on unknown labels without suggesting automatic deletion', async (t) => {
+  const fixture = await createLabelAuditFixture(t, {
+    issues: [{
+      number: 210,
+      title: 'unknown label issue',
+      url: 'https://github.com/Erick52106/spec-injector/issues/210',
+      state: 'OPEN',
+      labels: [
+        { name: 'enhancement' },
+        { name: 'area:workflow' },
+        { name: 'status:ready' },
+        { name: 'layer2 : Workflow Guardrails' },
+        { name: 'surprise:custom' },
+      ],
+      milestone: { title: 'Layer 2 — Workflow Guardrails' },
+    }],
+  });
+
+  const result = await runSpec([
+    'label-audit',
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Label audit summary:\s+WARNING/i);
+  assert.match(result.stdout, /issue #210 uses unknown labels/i);
+  assert.match(result.stdout, /surprise:custom/);
+  assert.doesNotMatch(result.stdout, /\bdelete\b/i);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec label-audit warns when an open ready issue has a non-draft PR but is not marked status:in-review', async (t) => {
+  const fixture = await createLabelAuditFixture(t, {
+    issues: [{
+      number: 211,
+      title: 'ready issue with active review PR',
+      url: 'https://github.com/Erick52106/spec-injector/issues/211',
+      state: 'OPEN',
+      labels: [
+        { name: 'enhancement' },
+        { name: 'area:workflow' },
+        { name: 'status:ready' },
+        { name: 'layer2 : Workflow Guardrails' },
+      ],
+      milestone: { title: 'Layer 2 — Workflow Guardrails' },
+    }],
+    prs: [{
+      number: 311,
+      title: 'feat(workflow): active review PR',
+      url: 'https://github.com/Erick52106/spec-injector/pull/311',
+      labels: [{ name: 'area:workflow' }],
+      milestone: { title: 'Layer 2 — Workflow Guardrails' },
+      closingIssuesReferences: [{ number: 211 }],
+      isDraft: false,
+    }],
+  });
+
+  const result = await runSpec([
+    'label-audit',
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Label audit summary:\s+WARNING/i);
+  assert.match(result.stdout, /issue #211 may need status:in-review because open PR #311 is not draft/i);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec label-audit reports malformed gh output as needs human review without a raw stack trace', async (t) => {
+  const fixture = await createLabelAuditFixture(t, {
+    issueListCommand: {
+      exitCode: 0,
+      stdout: '{"not":"valid json"',
+    },
+  });
+
+  const result = await runSpec([
+    'label-audit',
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stdout, /Label audit summary:\s+NEEDS-HUMAN-REVIEW/i);
+  assert.match(result.stdout, /could not parse gh issue list output/i);
+  assertNoRawStackTrace(result);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec label-audit reports missing gh fields as needs human review without a raw stack trace', async (t) => {
+  const fixture = await createLabelAuditFixture(t, {
+    issueListCommand: {
+      exitCode: 0,
+      stdout: JSON.stringify([{
+        number: 212,
+        title: 'missing labels payload',
+        url: 'https://github.com/Erick52106/spec-injector/issues/212',
+        state: 'OPEN',
+      }]),
+    },
+  });
+
+  const result = await runSpec([
+    'label-audit',
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stdout, /Label audit summary:\s+NEEDS-HUMAN-REVIEW/i);
+  assert.match(result.stdout, /gh issue list output is missing required fields for issue #212/i);
+  assertNoRawStackTrace(result);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
 });
 
 test('spec preflight passes for a clean dedicated worktree and avoids mutating git state', async (t) => {

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -52,6 +52,39 @@ type EvidenceCheckFixtureOptions = {
   reviews?: Array<{ author?: { login?: string }; body?: string; state?: string; submittedAt?: string }>;
 };
 
+type LabelAuditFixture = {
+  env: NodeJS.ProcessEnv;
+  ghLogPath: string;
+  repo: string;
+};
+
+type LabelAuditIssuePayload = {
+  number: number;
+  title: string;
+  url: string;
+  state: string;
+  stateReason?: string;
+  labels?: Array<{ name: string }>;
+  milestone?: { title: string } | null;
+};
+
+type LabelAuditPrPayload = {
+  number: number;
+  title: string;
+  url: string;
+  labels?: Array<{ name: string }>;
+  milestone?: { title: string } | null;
+  closingIssuesReferences?: Array<{ number: number }>;
+  isDraft?: boolean;
+};
+
+type LabelAuditFixtureOptions = {
+  issues?: LabelAuditIssuePayload[];
+  prs?: LabelAuditPrPayload[];
+  issueListCommand?: { exitCode?: number; stdout?: string; stderr?: string };
+  prListCommand?: { exitCode?: number; stdout?: string; stderr?: string };
+};
+
 type ExplicitPathPlanFixtureOptions = {
   issueNumber?: number;
   title: string;
@@ -289,6 +322,28 @@ export async function createEvidenceCheckFixture(
     issueNumber,
     headSha,
     evidenceUrl,
+  };
+}
+
+export async function createLabelAuditFixture(
+  t: TestLifecycle,
+  options: LabelAuditFixtureOptions = {}
+): Promise<LabelAuditFixture> {
+  const repo = 'Erick52106/spec-injector';
+  const issues = options.issues ?? [];
+  const prs = options.prs ?? [];
+  const fakeGh = await createFakeLabelAuditGh(t, {
+    repo,
+    issues,
+    prs,
+    issueListCommand: options.issueListCommand,
+    prListCommand: options.prListCommand,
+  });
+
+  return {
+    env: fakeGh.env,
+    ghLogPath: fakeGh.logPath,
+    repo,
   };
 }
 
@@ -535,6 +590,91 @@ if (args[0] === 'pr' && args[1] === 'checks') {
     process.exit(payload.checksCommand.exitCode ?? 0);
   }
   process.stdout.write(JSON.stringify(payload.checks));
+  process.exit(0);
+}
+
+console.error('Unsupported gh invocation: ' + args.join(' '));
+process.exit(1);
+`, 'utf8');
+  await fs.chmod(ghPath, 0o755);
+
+  return {
+    env: {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+      FAKE_GH_PAYLOAD_FILE: payloadPath,
+      FAKE_GH_LOG: logPath,
+    },
+    logPath,
+  };
+}
+
+async function createFakeLabelAuditGh(
+  t: TestLifecycle,
+  payload: {
+    repo: string;
+    issues: LabelAuditIssuePayload[];
+    prs: LabelAuditPrPayload[];
+    issueListCommand?: { exitCode?: number; stdout?: string; stderr?: string };
+    prListCommand?: { exitCode?: number; stdout?: string; stderr?: string };
+  }
+): Promise<{
+  env: NodeJS.ProcessEnv;
+  logPath: string;
+}> {
+  const binDir = await fs.mkdtemp(path.join(os.tmpdir(), 'spec-injector-label-audit-gh-'));
+  t.after(async () => {
+    await fs.rm(binDir, { recursive: true, force: true });
+  });
+
+  const payloadPath = path.join(binDir, 'label-audit.json');
+  const logPath = path.join(binDir, 'gh.log');
+  const ghPath = path.join(binDir, 'gh');
+
+  await fs.writeFile(payloadPath, JSON.stringify(payload), 'utf8');
+  await fs.writeFile(logPath, '', 'utf8');
+  await fs.writeFile(ghPath, `#!/usr/bin/env node
+import fs from 'node:fs';
+
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.FAKE_GH_LOG, args.join(' ') + '\\n', 'utf8');
+const payload = JSON.parse(fs.readFileSync(process.env.FAKE_GH_PAYLOAD_FILE, 'utf8'));
+
+function requireRepo() {
+  const repoFlagIndex = args.indexOf('--repo');
+  if (repoFlagIndex === -1 || args[repoFlagIndex + 1] !== payload.repo) {
+    console.error('Unexpected repo flag: ' + args.join(' '));
+    process.exit(1);
+  }
+}
+
+if (args[0] === 'issue' && args[1] === 'list') {
+  requireRepo();
+  if (payload.issueListCommand) {
+    if (payload.issueListCommand.stdout !== undefined) {
+      process.stdout.write(payload.issueListCommand.stdout);
+    }
+    if (payload.issueListCommand.stderr !== undefined) {
+      process.stderr.write(payload.issueListCommand.stderr);
+    }
+    process.exit(payload.issueListCommand.exitCode ?? 0);
+  }
+  process.stdout.write(JSON.stringify(payload.issues));
+  process.exit(0);
+}
+
+if (args[0] === 'pr' && args[1] === 'list') {
+  requireRepo();
+  if (payload.prListCommand) {
+    if (payload.prListCommand.stdout !== undefined) {
+      process.stdout.write(payload.prListCommand.stdout);
+    }
+    if (payload.prListCommand.stderr !== undefined) {
+      process.stderr.write(payload.prListCommand.stderr);
+    }
+    process.exit(payload.prListCommand.exitCode ?? 0);
+  }
+  process.stdout.write(JSON.stringify(payload.prs));
   process.exit(0);
 }
 

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -648,8 +648,24 @@ function requireRepo() {
   }
 }
 
+function requireJsonFields(expectedFields, commandLabel) {
+  const jsonFlagIndex = args.indexOf('--json');
+  if (jsonFlagIndex === -1) {
+    console.error('Missing --json for ' + commandLabel + ': ' + args.join(' '));
+    process.exit(1);
+  }
+  const actualFields = new Set(String(args[jsonFlagIndex + 1] ?? '').split(',').map((value) => value.trim()).filter(Boolean));
+  for (const field of expectedFields) {
+    if (!actualFields.has(field)) {
+      console.error('Missing ' + commandLabel + ' json field "' + field + '": ' + args.join(' '));
+      process.exit(1);
+    }
+  }
+}
+
 if (args[0] === 'issue' && args[1] === 'list') {
   requireRepo();
+  requireJsonFields(['number', 'title', 'url', 'state', 'stateReason', 'labels', 'milestone'], 'issue list');
   if (payload.issueListCommand) {
     if (payload.issueListCommand.stdout !== undefined) {
       process.stdout.write(payload.issueListCommand.stdout);
@@ -665,6 +681,7 @@ if (args[0] === 'issue' && args[1] === 'list') {
 
 if (args[0] === 'pr' && args[1] === 'list') {
   requireRepo();
+  requireJsonFields(['number', 'title', 'url', 'labels', 'milestone', 'closingIssuesReferences', 'isDraft'], 'pr list');
   if (payload.prListCommand) {
     if (payload.prListCommand.stdout !== undefined) {
       process.stdout.write(payload.prListCommand.stdout);


### PR DESCRIPTION
Closes #110

## Summary
- 新增 `spec label-audit`，以 repo-local accepted taxonomy 與 `gh` metadata 做 read-only label / milestone audit。
- 新增 mocked `gh` integration tests，覆蓋 pass / warning / needs human review、keep-as-is labels、unknown labels、malformed / missing output。
- 依 review findings 補上 type / area ambiguity、taxonomy parse failure、PR milestone warning 與 fixture contract coverage。

## Scope
- 實作 `spec label-audit --repo <owner/name>` CLI command
- 讀取 `docs/label-taxonomy.md` 與 `docs/workflow.md` 的 accepted taxonomy / layer mapping 作為 audit input
- 只處理 #174 review findings 範圍內的 CLI / tests follow-up

## Non-goals
- 不建立、修改、rename、delete labels
- 不修改 milestones、issues、PR metadata
- 不實作 autofix、remediation bot、dashboard、daemon、hosted control plane
- 不引入 network-dependent tests 或 hidden LLM inference
- 不處理 #61 optional gh integration smoke test

## Validation
- `pnpm install --frozen-lockfile` ✅
- `pnpm build` ✅
- `pnpm test` ✅ (`172/172`)
- `git diff --check` ✅
- lint / typecheck skipped reason: repo 沒有獨立 `lint` 或 `typecheck` script；`pnpm build` 已執行 `tsc`

## Issue evidence
- Source issue: #110
- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/110#issuecomment-4371965915
- Branch: `feat/label-audit-checker-110`
- Commit hash / HEAD: `dc529330f9530e13e68b0b4efe2d345b76cdad11`

## Implementation Evidence
- 新增 command: `spec label-audit --repo <owner/name>`
- Audit output categories: `PASS` / `WARNING` / `NEEDS-HUMAN-REVIEW`
- Read-only boundary: checker 只 report，不 mutate GitHub metadata
- Tests 使用 mocked `gh` output；沒有 target repo mutation

## Review finding assessment
- `Codex` finding 1 (`multiple type labels`)：`adopted`；多個 type/default-equivalent labels 現在回報 `NEEDS-HUMAN-REVIEW`，並補 regression test。
- `Codex` finding 2 (`4+ area labels`)：`adopted`；超過三個 area labels 現在回報 `NEEDS-HUMAN-REVIEW`，並補 regression test。
- `Codex` finding 3 (`taxonomy marker parse failure`)：`adopted`；缺 marker / 失敗 parsing 現在回報清楚的 `NEEDS-HUMAN-REVIEW` diagnostic，並補 regression test。
- `CodeRabbit` finding 4 (`fake gh --json contract`)：`adopted`；fixture 現在驗證 `issue list` / `pr list` 的 `--json` fields。
- `CodeRabbit` finding 5 (`--limit passthrough`)：`adopted`；補 integration test 驗證 `--limit` 會傳到兩個 `gh list` commands。
- `CodeRabbit` finding 6 (`PR layer label without milestone`)：`adopted`；PR 單一 layer label 且缺 milestone 現在回報 `WARNING`，並補 regression test。
- `CodeRabbit` finding 7 (`unmapped layer-to-milestone`)：`adopted`；issue / PR layer label 缺 mapping 時現在回報 `WARNING`，並補 regression test。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only label-audit CLI command to audit repository labels and milestones against the accepted taxonomy, producing PASS/WARNING/NEEDS-HUMAN-REVIEW reports without mutating metadata.

* **Documentation**
  * Clarified workflow contract and label taxonomy relationships, explicitly documenting that the audit consumes the accepted taxonomy in a human-readable, read-only manner and will not perform automated remediation.

* **Tests**
  * Added integration tests and fixtures covering audit outcomes, error handling, and safety/non-mutating behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->