### PR TITLE
docs(workflow): require readback verification after evidence writes

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -327,7 +327,7 @@ Passing tests alone is not enough if evidence, PR body, scope guard, or CI repor
 Before merge, review closeout must also confirm:
 
 - PR body includes evidence URL and commit hash.
- - Issue evidence comment exists.
+- Issue evidence comment exists.
 - Issue evidence comment readback verified（URL/內容可取得）。
 - Review rationale / closeout comment readback verified when used as evidence.
 - CI / required checks pass.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -47,10 +47,18 @@ Required:
 
 - `git diff --check`
 - Markdown sanity check, including code fence parity and heading sanity.
+- `gh pr view` / `gh issue view` readback for any GitHub evidence write actions involved in the workflow change.
 
 Recommended:
 
 - `pnpm test` when cheap, or when docs include commands, output examples, workflow examples, or user-visible behavior claims.
+
+Required review checks for evidence writes:
+
+- PR body / evidence comment 寫入後，立即 readback verify，不得只看 write command exit code。
+- 驗證 `PR body` 包含 `Closes #<issue-number>`、evidence URL、commit hash、validation 結果。
+- 驗證 issue evidence comment URL 與 comment 內容可在 issue readback 中找到。
+- 有使用 review rationale / closeout comment 作為 evidence 時，需有可讀的 URL 或 final report readback 註記。
 
 Review checks:
 
@@ -262,7 +270,9 @@ PR body must include:
 
 PR body 應以繁體中文為主。若 PR body 主要使用英文，reviewer 應確認該英文限於 commands、raw output、technical terms、file paths、external API names 或短而精準的英文片段，而不是整份 PR body 的預設語言。
 
-After backfill, use `gh pr view` or equivalent to confirm the PR body is non-empty and contains the evidence URL and commit hash.
+After backfill, use `gh pr view <pr-number> --json body,headRefOid` or equivalent to confirm the PR body is non-empty and contains the evidence URL and commit hash. `headRefOid` must match the PR head being reported.
+
+Readback mismatch（如 write 後 artifact 未更新、內容不符、URL 缺失、HEAD 過期）為 stop-and-report 條件，必須先修正後才能進入 merge-time closeout。
 
 Repo-local PR / evidence consistency check 可在 source issue implementation evidence comment 已存在、且 PR body 已 backfill 後執行 `spec evidence-check`。此 checker deterministic 且 read-only：missing linked issue、missing evidence URL、evidence URL 指到錯 issue、stale PR body HEAD、expected HEAD mismatch、vague validation evidence、draft state、failing / pending checks、或 missing review finding assessment 都可能回報 warning / fail / needs-human-review。它不得 auto-edit PR、issue comments、labels、review threads、merge state 或 issue state。
 
@@ -284,6 +294,8 @@ Issue evidence 應以繁體中文為主；commands、file paths、raw output、r
 
 Issue evidence should be posted after the PR exists, then its permanent comment URL should be backfilled into the PR body.
 
+Issue evidence write 後必須 readback verify，確認 comment URL、comment 內容與 evidence URL 一致。若 readback 失敗，需先修正後重試或在 final report 停止並標明原因。
+
 ## Merge-readiness Quality Gates
 
 A PR is ready for human review only when:
@@ -298,11 +310,13 @@ A PR is ready for human review only when:
 - Source issue evidence comment 以繁體中文為主，技術內容可保留英文。
 - PR body is backfilled with issue evidence URL.
 - PR body includes commit hash.
+- PR head hash readback verified.
 - Linked issue and PR have a roadmap milestone and one primary layer label when high-confidence classification is possible.
 - PR 在 high-confidence classification 可行時，有合理 area / type labels。
 - PR metadata 與 linked issue 一致；若不一致，PR body 或 final report 說明 scoped exception。
 - If milestone / layer label is missing and the current PR does not scope metadata updates, PR body, final report, or review notes mark a follow-up.
 - `gh pr view` confirms PR body is non-empty and contains evidence URL and commit hash.
+- `gh pr view <pr-number> --json headRefOid` 需驗證 head hash 與 PR body / issue evidence 記錄一致。
 - CI checks are reported.
 - Scope guard confirms non-goals.
 - Skipped validation, if any, has an explicit reason.
@@ -313,7 +327,9 @@ Passing tests alone is not enough if evidence, PR body, scope guard, or CI repor
 Before merge, review closeout must also confirm:
 
 - PR body includes evidence URL and commit hash.
-- Issue evidence comment exists.
+ - Issue evidence comment exists.
+- Issue evidence comment readback verified（URL/內容可取得）。
+- Review rationale / closeout comment readback verified when used as evidence.
 - CI / required checks pass.
 - CodeRabbit / Codex auto review findings were inspected.
 - Automated review findings have been inspected.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -172,7 +172,9 @@ PR body 必須包含：
 
 PR 建立後要在 source issue 留 implementation evidence comment，再把 issue evidence comment URL 回填 PR body。
 
-回填後必須用 `gh pr view` 或等價方式反查 PR body，確認：
+write action 後不得只看 exit code。PR body、issue evidence comment、review rationale comment / closeout comment 等 GitHub mutation 都必須立即 readback verify。
+
+PR body 寫入後，必須立即用 `gh pr view <pr-number> --json body,headRefOid`（或等價方式）反查，確認：
 
 - PR body 非空
 - 包含 `Closes #<issue-number>`
@@ -180,6 +182,25 @@ PR 建立後要在 source issue 留 implementation evidence comment，再把 iss
 - 包含 commit hash
 - 包含 validation 結果
 - 包含 scope guard / non-goals confirmation
+
+Issue evidence comment 新增或更新後，必須用 `gh issue view` / `gh api` 等 readback 方式確認 comment URL 與內容存在；若無法讀回，視為 mismatch 並 stop-and-report 或修正後重試。
+
+Review rationale comment / closeout comment 若作為 merge evidence，也必須能 readback，或在 final report 中提供明確的 URL 與 readback 狀態；若使用 comment 作 evidence，final report 不得只寫「已補齊」。
+
+若 readback 發現以下情況，需 stop-and-report 或先修正後重新 verify 再繼續：
+
+- PR body 未更新
+- issue comment 不存在
+- evidence URL 缺失
+- HEAD hash 過期（與 `gh pr view <pr-number> --json headRefOid` 不一致）
+- comment / body 內容不符
+- write command exit code 成功但 artifact 實際未變更
+
+Final report 中，驗證結果須明確寫出：
+
+- 已 readback verified
+- 無法 readback 的原因
+- 或 readback mismatch 的處理結果
 
 CI 通過後，若 PR checklist 有 CI item，應勾選。AI agent 不自行 merge PR。
 
@@ -237,9 +258,12 @@ Merge 前必須檢查：
 - Codex auto review findings。
 - Human review verdict。
 - CI / required checks。
-- PR body 的 issue evidence URL。
+- PR body 的 issue evidence URL（readback verified）。
 - Source issue implementation evidence comment。
 - Latest commit hash。
+- Source issue implementation evidence comment readback verified（URL 存在且內容可讀）。
+- Review rationale / closeout comment（若有作為 evidence）readback verified 或 final report 註明無法 readback 的原因。
+- PR head hash 已比對 `gh pr view <pr-number> --json headRefOid`。
 
 每個 actionable finding 必須分類：
 


### PR DESCRIPTION
## Summary
- 補強 `docs/workflow.md` 與 `docs/validation.md`，明確規範 GitHub write action 後的 readback verification。
- 本次 follow-up 專注修正 `docs/validation.md` 第 330 行 list indentation。

## Scope
- 僅針對 `docs/validation.md` markdown list indentation 做最小修正。
- 不修改 runtime code、tests、CI、package scripts，亦不接觌 #61。

## Non-goals
- 不新增 checker / automation。
- 不做 GitHub API integration。
- 不修改 target repo。

## Validation
- `git diff --check`
- `pnpm build`
- `pnpm test`

## Issue evidence
- https://github.com/Erick52106/spec-injector/issues/175#issuecomment-4372404905

## Implementation Evidence
- Files changed: `docs/validation.md`
- PR head ref: `docs/readback-verify-workflow-175`
- Latest commit / HEAD: `5590c66`
- No runtime / tests / CI mutation

## Review finding assessment
- 來源: CodeRabbit on `docs/validation.md` line 330
- Finding: list item indentation drift (` - Issue evidence comment exists.`)
- classification: adopted
- action: fixed indentation；line 已改為 `- Issue evidence comment exists.`
- validation: `git diff --check` / `pnpm build` / `pnpm test` all pass

Closes #175

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Strengthened validation and workflow docs with mandatory readback/verification steps for GitHub evidence writes (PR body, issue comments, commit/head consistency).
  * Expanded merge-readiness quality gates to require verified PR body/evidence presence, evidence comment existence/content verification, and head-hash consistency checks.
  * Added explicit stop-and-report and retry guidance for readback mismatches and updated final reporting requirements to record verification outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->