### PR TITLE
test(cli): add optional gh integration smoke test

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,22 @@ Notes:
 - `spec plan ... --dry-run --format prompt --verbose` is the recommended pre-implementation command for AI planning.
 - For a full generated task package file, omit `--dry-run`; output is written under `.spec-injector/out/`.
 
+## Optional live gh smoke test
+
+`spec plan` 本身會透過真實的 `gh` CLI 讀取 GitHub issue，因此保留一個可選擇性的 live smoke test：
+
+```bash
+pnpm test:gh
+```
+
+此測試刻意是 `opt-in`，不會在 `pnpm test` / CI 中自動執行。它會驗證：
+
+- `gh --version`
+- `gh auth status`
+- `spec plan https://github.com/Erick52106/spec-injector/issues/61 --dry-run --format prompt`
+
+執行結果會要求至少包含基本 prompt sections，確認 issue URL 解析與 `spec plan` 最小 live 讀取鏈路。若環境未安裝 `gh` 或未登入，測試不會作為預設 regressions 阻擋；請先補齊環境後再執行。
+
 Current local install and release details are documented in [docs/release.md](docs/release.md).
 
 ## Example workflow with Codex / Claude Code

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ pnpm test:gh
 此測試刻意是 `opt-in`，不會在 `pnpm test` / CI 中自動執行。它會驗證：
 
 - `gh --version`
-- `gh auth status`
+- `gh auth status --active --hostname github.com`
 - `spec plan https://github.com/Erick52106/spec-injector/issues/61 --dry-run --format prompt`
 
 執行結果會要求至少包含基本 prompt sections，確認 issue URL 解析與 `spec plan` 最小 live 讀取鏈路。若環境未安裝 `gh` 或未登入，測試不會作為預設 regressions 阻擋；請先補齊環境後再執行。

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "tsc",
     "test": "pnpm build && node --test \"tests/**/*.test.ts\"",
+    "test:gh": "SPEC_INJECTOR_RUN_GH_TESTS=1 node --test tests/optional-gh.smoke.test.ts",
     "dev": "tsc --watch",
     "start": "node dist/cli/index.js"
   },

--- a/tests/optional-gh.smoke.test.ts
+++ b/tests/optional-gh.smoke.test.ts
@@ -1,0 +1,94 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { runCommand, runSpec, repoRoot } from './helpers/cli.ts';
+import { assertNoRawStackTrace } from './helpers/assertions.ts';
+
+const ISSUE_URL = 'https://github.com/Erick52106/spec-injector/issues/61';
+const ISSUE_NUMBER = '#61';
+
+function formatSpecPlanFailure(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  const lower = message.toLowerCase();
+
+  if (lower.includes('rate limit')) {
+    return `Optional gh smoke test failed due rate limit or GitHub quota: ${message}`;
+  }
+
+  if (lower.includes('connection') || lower.includes('timed out') || lower.includes('network')) {
+    return `Optional gh smoke test failed due network issue: ${message}`;
+  }
+
+  if (lower.includes('authentication') || lower.includes('must authenticate')) {
+    return `Optional gh smoke test failed because GitHub authentication is required: ${message}`;
+  }
+
+  return `Optional gh smoke test failed for live spec plan execution. This is optional and may be environment-dependent. ${message}`;
+}
+
+test(
+  'optional gh smoke test: `spec plan` against public issue 61',
+  { skip: process.env.SPEC_INJECTOR_RUN_GH_TESTS !== '1' },
+  async () => {
+    try {
+      await runCommand('gh', ['--version'], repoRoot);
+    } catch (error) {
+      assert.fail(
+        'Optional gh smoke test precondition failed: gh CLI is not available or not callable. ' +
+          'Please install `gh` and ensure it is on PATH, then run `pnpm test:gh` again.\n' +
+          `Error: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+
+    try {
+      await runCommand('gh', ['auth', 'status'], repoRoot);
+    } catch (error) {
+      assert.fail(
+        'Optional gh smoke test precondition failed: gh auth status is not usable.\n' +
+          'Please run `gh auth login` before `pnpm test:gh` to authenticate against GitHub.\n' +
+          `Error: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+
+    const tempConfigDir = await fs.mkdtemp(path.join(os.tmpdir(), 'spec-injector-smoke-config-'));
+    const configPath = path.join(tempConfigDir, 'config.json');
+    try {
+      await fs.writeFile(configPath, `${JSON.stringify({ version: 2 }, null, 2)}\n`, 'utf8');
+    } catch (error) {
+      await fs.rm(tempConfigDir, { force: true, recursive: true });
+      assert.fail(
+        `Optional gh smoke test precondition failed: unable to prepare temporary config at ${configPath}.\n` +
+          `Error: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+
+    let result;
+    try {
+      result = await runSpec([
+        'plan',
+        ISSUE_URL,
+        '--dry-run',
+        '--format',
+        'prompt',
+        '--config',
+        configPath,
+      ]).catch((error: unknown) => {
+        throw new Error(formatSpecPlanFailure(error));
+      });
+    } finally {
+      await fs.rm(tempConfigDir, { force: true, recursive: true });
+    }
+
+    assert.strictEqual(result.code, 0, 'spec plan should exit with code 0 for the smoke test target issue');
+    assert.ok(result.stdout.includes('# Implementation Plan Prompt:'), 'prompt output should include prompt title');
+    assert.ok(result.stdout.includes('## 1. Issue Summary'), 'prompt output should include issue summary section');
+    assert.ok(result.stdout.includes(`- Issue: ${ISSUE_NUMBER}`), 'prompt output should include parsed issue number');
+    assert.ok(result.stdout.includes('Suggested verification checklist:'), 'prompt output should include the suggestion section');
+    assert.ok(result.stdout.includes('Read the referenced files as needed'), 'prompt output should include output contract tail text');
+    assert.ok(result.stdout.length > 0, 'prompt output should not be empty');
+    assertNoRawStackTrace(result);
+  }
+);

--- a/tests/optional-gh.smoke.test.ts
+++ b/tests/optional-gh.smoke.test.ts
@@ -44,11 +44,11 @@ test(
     }
 
     try {
-      await runCommand('gh', ['auth', 'status'], repoRoot);
+      await runCommand('gh', ['auth', 'status', '--active', '--hostname', 'github.com'], repoRoot);
     } catch (error) {
       assert.fail(
-        'Optional gh smoke test precondition failed: gh auth status is not usable.\n' +
-          'Please run `gh auth login` before `pnpm test:gh` to authenticate against GitHub.\n' +
+        'Optional gh smoke test precondition failed: gh auth status --active --hostname github.com is not usable.\n' +
+          'Please run `gh auth login --hostname github.com` before `pnpm test:gh`, or run `gh auth status --active --hostname github.com` to verify active GitHub auth.\n' +
           `Error: ${error instanceof Error ? error.message : String(error)}`
       );
     }


### PR DESCRIPTION
Closes #61

## Summary
- 將 optional `pnpm test:gh` 的 auth 預檢 scope 到 `github.com` active account，降低與無關 host 認證問題造成的 false failure。
- 透過 `gh auth status --active --hostname github.com` 來驗證本 smoke test 實際目標。
- 保持 `pnpm test` 與 CI 的既有邊界不變，僅調整 optional smoke path。

## Scope
- 僅修正 `tests/optional-gh.smoke.test.ts` 的 auth precheck command shape。
- 對 README 文案做最小同步：明確 `gh auth status --active --hostname github.com`。
- 不修改 CI 與預設 `pnpm test`。

## Non-goals
- 不新增 dependency。
- 不加入 GitHub App 或 token secret 管理。
- 不做 target repo / tachigo / storefront / tachiya mutation。

## Validation
- `pnpm install --frozen-lockfile` ✅
- `pnpm build` ✅
- `pnpm test` ✅
- `git diff --check` ✅
- `pnpm test:gh` ✅

## Issue evidence
- https://github.com/Erick52106/spec-injector/issues/61#issuecomment-4372620834

## Implementation Evidence
- 最新 Commit / HEAD: 5293de2e2aa8c4440fbfb37610813e8f1c2f084a
- Branch: test/optional-gh-smoke-61
- Files changed: `tests/optional-gh.smoke.test.ts`, `README.md`
- Scope / non-goals: 只範圍調整 auth precheck host（不改預設 test/CI）。

## Review finding assessment
- CodeRabbit finding: Scope auth precheck to the target GitHub host
- classification: adopted
- action: 已將 `gh auth status` 改為 `gh auth status --active --hostname github.com`
- rationale: 避免其他 host/account 的問題造成 `pnpm test:gh` 對 `github.com` public issue 的 false failure；符合 optional smoke scope。
- validation: `pnpm build` / `pnpm test` / `git diff --check` / `pnpm test:gh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an "Optional live gh smoke test" section to Quickstart explaining how to opt into a live GitHub CLI smoke test and what it verifies.

* **Tests**
  * Added an opt-in smoke test that validates GitHub CLI availability, authentication, and basic live issue-reading behavior.

* **Chores**
  * Added an npm script to run the optional live GitHub smoke test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
