### PR TITLE
docs(readme): refresh product narrative with current workflow evidence

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -2,15 +2,17 @@ Language: [繁體中文](README.md) | English
 
 # spec-injector
 
-`spec-injector` is a deterministic request-to-context compiler for AI coding agents.
+`spec-injector` is currently a deterministic GitHub issue-to-context compiler for AI coding agents.
 
-It compiles GitHub issues, repo docs, source references, source trust direction, guardrails, validation hints, and the target repo's `.spec-injector/config.json` into a bounded task package / prompt that an AI coding agent can use directly before starting work. GitHub issue input is the currently implemented entry point; future fuzzy request / markdown brief adapters remain a deterministic design direction, not a hidden LLM planner.
+It compiles GitHub issues, repo docs, source references, source trust direction, guardrails, validation hints, and the target repo's `.spec-injector/config.json` into a bounded task package / prompt that an AI coding agent can use directly before starting work.
+
+Broader deterministic request-to-context adapters for fuzzy requests, markdown briefs, or PR review notes are a future design direction; the implemented and repo-governed path today remains GitHub issue-to-context, not a hidden LLM planner.
 
 Its goal is not to replace humans or AI writing code, but to let Codex, Claude Code, or other implementers obtain checkable, repeatable work context constrained by repo configuration before modifying any files.
 
 Core positioning:
 
-- request / issue scoped: currently uses a single GitHub issue as the scope source of truth, while keeping future request adapters behind deterministic design boundaries
+- issue-scoped today: currently uses a single GitHub issue as the scope source of truth, while keeping future request adapters behind deterministic design boundaries
 - brownfield-friendly: designed around existing GitHub issues, repo docs, source references, and repo-specific workflow rules
 - repo-safe: reads target repo context, but does not automatically modify target repo code
 - deterministic: the same issue, repo files, and config should produce stable output
@@ -284,10 +286,12 @@ These directions should get separate issues, tests, and corresponding docs updat
 ## Documentation links
 
 - Agent instructions: [AGENTS.md](AGENTS.md)
+- Agent handoff patterns: [docs/agent-handoff.md](docs/agent-handoff.md)
 - Architecture: [docs/architecture.md](docs/architecture.md)
 - Core concepts: [docs/concepts.md](docs/concepts.md)
 - Catalog / protocol model: [docs/catalog-protocol.md](docs/catalog-protocol.md)
 - Product moat thesis: [docs/product-moat.md](docs/product-moat.md)
+- Positioning and adjacent workflows: [docs/positioning.md](docs/positioning.md)
 - Classifier: [docs/classifier.md](docs/classifier.md)
 - References: [docs/references.md](docs/references.md)
 - Guardrails: [docs/guardrails.md](docs/guardrails.md)

--- a/README.en.md
+++ b/README.en.md
@@ -2,27 +2,34 @@ Language: [繁體中文](README.md) | English
 
 # spec-injector
 
-`spec-injector` is a deterministic issue-to-context compiler.
+`spec-injector` is a deterministic request-to-context compiler for AI coding agents.
 
-It compiles a GitHub issue, the target repo's `.spec-injector/config.json`, repo docs, source references, and guardrails into a task package / prompt that an AI coding agent can use directly before starting work. Its goal is not to replace humans or AI writing code, but to let Codex, Claude Code, or other implementers obtain checkable, repeatable work context constrained by repo configuration before modifying any files.
+It compiles GitHub issues, repo docs, source references, source trust direction, guardrails, validation hints, and the target repo's `.spec-injector/config.json` into a bounded task package / prompt that an AI coding agent can use directly before starting work. GitHub issue input is the currently implemented entry point; future fuzzy request / markdown brief adapters remain a deterministic design direction, not a hidden LLM planner.
+
+Its goal is not to replace humans or AI writing code, but to let Codex, Claude Code, or other implementers obtain checkable, repeatable work context constrained by repo configuration before modifying any files.
 
 Core positioning:
 
-- issue-scoped: uses a single GitHub issue as the scope source of truth
+- request / issue scoped: currently uses a single GitHub issue as the scope source of truth, while keeping future request adapters behind deterministic design boundaries
+- brownfield-friendly: designed around existing GitHub issues, repo docs, source references, and repo-specific workflow rules
 - repo-safe: reads target repo context, but does not automatically modify target repo code
 - deterministic: the same issue, repo files, and config should produce stable output
-- config-driven: uses repo-local config, always-read references, discovery, and guardrails
+- source-trust aware: distinguishes repo instructions, always-read docs, issue-mentioned paths, auto-discovered references, and diagnostics
+- context-budget aware: emits bounded context instead of stuffing the whole repo into a prompt
 - guardrails-aware: maps detected domains to repo-defined constraints / reminders
+- evidence-oriented: treats validation hints, issue evidence, PR body backfill, and review closeout as part of the handoff workflow
+- agent-agnostic: emits Markdown task packages / prompts for Codex, Claude Code, or other AI coding agents
 - no hidden LLM: does not call a hidden LLM, external AI API, or local model
 
 ## Why this exists
 
 Common AI coding agent failures are usually not about being unable to write code, but about starting work without clear enough boundaries:
 
-- issue body, repo instructions, architecture docs, and validation rules are scattered across different places
+- issue body, repo instructions, architecture docs, source references, and validation rules are scattered across different places
 - AI may start changing files first and fill in context later, causing scope creep
 - reviewers have a hard time tracing whether an implementation really followed the source issue
 - repo-specific guardrails are easy to forget, such as database, auth, CI, or docs-only work
+- stale paths, renamed files, missing docs, or unreadable source in brownfield repos can become hidden assumptions
 
 `spec-injector` organizes the information that should be read before implementation into one structured Markdown output. It lets an implementer read the task package first, then produce an implementation plan, and start modifying files only after human approval.
 
@@ -36,6 +43,8 @@ The Layer 1 CLI of `spec-injector` guarantees these boundaries:
 - guardrails come from target repo config and are constraints / reminders, not approval
 - `spec plan --dry-run` only outputs to stdout and does not write a task package
 - non-dry-run output from `spec plan` only writes to `.spec-injector/out/issue-<number>-task-package.md`
+- task packages can surface missing files, unreadable files, path alias hints, and validation checklists so context gaps are visible
+- read-only workflow guardrails can check label / milestone taxonomy, PR evidence readback, and the optional live `gh` smoke path, but do not auto-fix metadata or merge
 - mutating commands must be explicit command behavior, such as `spec init`, `spec config add/remove always-read`, or `spec clean`
 - CLI core does not automatically create branches, commits, PRs, issue comments, or modify target repo source code
 
@@ -50,7 +59,8 @@ For more architecture boundaries, see [docs/architecture.md](docs/architecture.m
 3. **Domain Classifier**: detects relevant domains with deterministic keyword scoring.
 4. **Guardrail Matcher**: matches detected domains against guardrails in `.spec-injector/config.json`.
 5. **Reference Collector**: collects built-in presets, repo `always_read`, configured docs, issue-mentioned files, and auto-discovered docs / source references.
-6. **Task Package Renderer**: outputs either the full task package or the compact AI planning prompt for `--format prompt`.
+6. **Diagnostics / Validation Direction**: preserves missing / unreadable / alias hints and the suggested verification checklist.
+7. **Task Package Renderer**: outputs either the full task package or the compact AI planning prompt for `--format prompt`.
 
 ## Pipeline diagram
 
@@ -61,9 +71,21 @@ GitHub Issue
   -> Domain Classifier
   -> Guardrail Matcher
   -> Reference Collector
+  -> Diagnostics / Validation Direction
   -> Task Package Renderer
   -> Markdown task package / prompt for Codex or Claude Code
 ```
+
+## Current capability map
+
+The current implemented / documented capabilities can be understood in four stages:
+
+| Stage | What happens | Boundary |
+| --- | --- | --- |
+| Input | Reads GitHub issues, repo config, repo docs, issue-mentioned paths, and configured discovery sources. | GitHub issue input is implemented today; future fuzzy request input remains a design direction. |
+| Compile | Uses deterministic parser / classifier / reference collector behavior to combine guardrails, source references, diagnostics, and validation hints. | No hidden LLM, semantic RAG, or vector DB. |
+| Output | Produces a bounded Markdown task package or compact planning prompt for an AI coding agent to read before implementation. | Output is handoff context, not an autonomous execution plan. |
+| Verify | Repo workflow docs define validation, implementation evidence comments, PR body evidence URLs, HEAD/readback checks, and review closeout. | Workflow guardrails are read-only / human-reviewed discipline, not a merge bot or remediation automation. |
 
 ## Quickstart
 
@@ -103,6 +125,22 @@ Notes:
 - `spec config suggest always-read --repo .` prints deterministic suggestions only; it does not modify config.
 - `spec plan ... --dry-run --format prompt --verbose` is the recommended pre-implementation command for AI planning.
 - For a full generated task package file, omit `--dry-run`; output is written under `.spec-injector/out/`.
+
+## Optional live gh smoke test
+
+`spec plan` reads GitHub issues through the real `gh` CLI, so the repo keeps an optional live smoke test:
+
+```bash
+pnpm test:gh
+```
+
+This test is intentionally `opt-in`; it does not run automatically in `pnpm test` or CI. It verifies:
+
+- `gh --version`
+- `gh auth status --active --hostname github.com`
+- `spec plan https://github.com/Erick52106/spec-injector/issues/61 --dry-run --format prompt`
+
+The result must include the basic prompt sections, confirming issue URL parsing and the minimal live `spec plan` read path. If the environment does not have `gh` installed or authenticated, this test is not a default regression blocker; set up the environment first, then run it explicitly.
 
 Current local install and release details are documented in [docs/release.md](docs/release.md).
 
@@ -144,10 +182,12 @@ Full task package output is Markdown intended for human and AI review. It can in
 - always-read references
 - auto-discovered documentation
 - auto-discovered source files
+- source reference direction and trust context
 - matched guardrails
 - rule-matched documentation
 - missing files
-- suggested verification checklist
+- unreadable / alias diagnostics where applicable
+- suggested verification checklist and implementation evidence direction
 
 Prompt output with `--format prompt` is shorter and designed for AI planning. It lists relevant references without inlining the full always-read docs, README content, discovered docs, or source snippets.
 
@@ -162,6 +202,9 @@ Key terms used across this project:
 - **Domain classifier**: uses deterministic signals in title, labels, and body to select relevant domains.
 - **Guardrail**: repo-defined constraint / reminder; it highlights risk, but does not authorize scope expansion.
 - **Reference**: docs, source files, built-in presets, or issue-mentioned files listed in a task package.
+- **Source trust**: labels where context came from and how it should be trusted, so auto-discovered references are not mistaken for human-approved scope.
+- **Context budget**: constrains task package / prompt size and include mode so output stays bounded.
+- **Read diagnostics**: context health signals such as missing files, unreadable files, or alias hints.
 - **Task package**: structured context used before AI starts work; it is not an autonomous execution plan.
 - **Implementation evidence**: the structured comment written back to the source issue after PR creation.
 
@@ -211,11 +254,19 @@ Important fields:
 - autonomous agent
 - daemon
 - hidden LLM wrapper
+- hosted control-plane platform
+- agent orchestration platform
 - GitHub automation bot
+- GitHub Projects / roadmap dashboard
 - custom domain runtime
+- full SDD lifecycle platform
 - general-purpose RAG system
+- semantic RAG / vector search product
+- hidden LLM planner
 - target repo auto-editing system
 - multi-agent runtime
+- companion runtime in CLI core
+- remediation bot
 - PR / merge automation service
 - stable npm release promise
 

--- a/README.md
+++ b/README.md
@@ -2,15 +2,17 @@ Language: 繁體中文 | [English](README.en.md)
 
 # spec-injector
 
-`spec-injector` 是一個 deterministic request-to-context compiler for AI coding agents。
+`spec-injector` 目前是一個 deterministic GitHub issue-to-context compiler for AI coding agents。
 
-它把 GitHub issue、repo docs、source references、source trust direction、guardrails、validation hints 與 target repo 的 `.spec-injector/config.json` 編譯成 AI coding agent 開工前可直接使用的 bounded task package / prompt。GitHub issue 是目前已實作入口；future fuzzy request / markdown brief adapter 仍屬設計方向，不是 hidden LLM planner。
+它把 GitHub issue、repo docs、source references、source trust direction、guardrails、validation hints 與 target repo 的 `.spec-injector/config.json` 編譯成 AI coding agent 開工前可直接使用的 bounded task package / prompt。
+
+Broader deterministic request-to-context adapters for fuzzy requests、markdown briefs 或 PR review notes 是 future design direction；目前已實作且 repo 規範要求守住的 path 仍是 GitHub issue-to-context，不是 hidden LLM planner。
 
 它的目標不是代替人或 AI 寫程式，而是讓 Codex、Claude Code 或其他 implementer 在修改任何檔案前，先取得可檢查、可重複、受 repo 設定約束的工作脈絡。
 
 核心定位：
 
-- request / issue scoped：目前以單一 GitHub issue 作為 scope source of truth，並保留 future request adapter 的 deterministic design boundary
+- issue-scoped today：目前以單一 GitHub issue 作為 scope source of truth，並保留 future request adapter 的 deterministic design boundary
 - brownfield-friendly：面向 existing GitHub issues、既有 repo docs、source references 與 repo-specific workflow rules
 - repo-safe：讀取 target repo context，但不自動修改 target repo code
 - deterministic：相同 issue、repo files 與 config 應產生穩定 output

--- a/README.md
+++ b/README.md
@@ -2,27 +2,34 @@ Language: 繁體中文 | [English](README.en.md)
 
 # spec-injector
 
-`spec-injector` 是一個 deterministic issue-to-context compiler。
+`spec-injector` 是一個 deterministic request-to-context compiler for AI coding agents。
 
-它把 GitHub issue、target repo 的 `.spec-injector/config.json`、repo docs、source references 與 guardrails 編譯成 AI coding agent 開工前可直接使用的 task package / prompt。它的目標不是代替人或 AI 寫程式，而是讓 Codex、Claude Code 或其他 implementer 在修改任何檔案前，先取得可檢查、可重複、受 repo 設定約束的工作脈絡。
+它把 GitHub issue、repo docs、source references、source trust direction、guardrails、validation hints 與 target repo 的 `.spec-injector/config.json` 編譯成 AI coding agent 開工前可直接使用的 bounded task package / prompt。GitHub issue 是目前已實作入口；future fuzzy request / markdown brief adapter 仍屬設計方向，不是 hidden LLM planner。
+
+它的目標不是代替人或 AI 寫程式，而是讓 Codex、Claude Code 或其他 implementer 在修改任何檔案前，先取得可檢查、可重複、受 repo 設定約束的工作脈絡。
 
 核心定位：
 
-- issue-scoped：以單一 GitHub issue 作為 scope source of truth
+- request / issue scoped：目前以單一 GitHub issue 作為 scope source of truth，並保留 future request adapter 的 deterministic design boundary
+- brownfield-friendly：面向 existing GitHub issues、既有 repo docs、source references 與 repo-specific workflow rules
 - repo-safe：讀取 target repo context，但不自動修改 target repo code
 - deterministic：相同 issue、repo files 與 config 應產生穩定 output
-- config-driven：使用 repo-local config、always-read references、discovery 與 guardrails
+- source-trust aware：區分 repo instructions、always-read docs、issue-mentioned paths、auto-discovered references 與 diagnostics 的信任來源
+- context-budget aware：輸出 bounded context，而不是把 repo 全部塞進 prompt
 - guardrails-aware：把 detected domains 對應到 repo-defined constraints / reminders
+- evidence-oriented：把 validation hints、issue evidence、PR body backfill 與 review closeout 視為 handoff workflow 的一部分
+- agent-agnostic：輸出 Markdown task package / prompt，供 Codex、Claude Code 或其他 AI coding agent 消費
 - no hidden LLM：不呼叫 hidden LLM、external AI API 或 local model
 
 ## Why this exists
 
 AI coding agent 常見的失誤不是「不會寫程式」，而是開工前沒有足夠清楚的邊界：
 
-- issue body、repo instructions、architecture docs 與 validation rules 分散在不同地方
+- issue body、repo instructions、architecture docs、source references 與 validation rules 分散在不同地方
 - AI 可能先動手再補脈絡，導致 scope creep
 - reviewer 難以追蹤某次實作是否真的遵守 source issue
 - repo-specific guardrails 容易被忘記，例如 database、auth、CI、docs-only work
+- brownfield repo 的 stale path、renamed file、missing doc 或 unreadable source 容易變成隱性假設
 
 `spec-injector` 把這些開工前需要看的資訊整理成一份 structured Markdown output。它讓 implementer 先讀 task package，再產生 implementation plan，經 human approval 後才開始修改檔案。
 
@@ -36,6 +43,8 @@ AI coding agent 常見的失誤不是「不會寫程式」，而是開工前沒�
 - guardrails 來自 target repo config，是 constraints / reminders，不是 approval
 - `spec plan --dry-run` 只輸出到 stdout，不寫入 task package
 - `spec plan` 的 non-dry-run output 只寫入 `.spec-injector/out/issue-<number>-task-package.md`
+- task package 可以揭露 missing files、unreadable files、path alias hints 與 validation checklist，讓 context gaps 可被看見
+- read-only workflow guardrails 可以檢查 label / milestone taxonomy、PR evidence readback 與 optional live `gh` smoke path，但不自動修 metadata 或 merge
 - mutating commands 必須是明確 command 行為，例如 `spec init`、`spec config add/remove always-read`、`spec clean`
 - CLI core 不會自動建立 branch、commit、PR、issue comment 或修改 target repo source code
 
@@ -50,7 +59,8 @@ AI coding agent 常見的失誤不是「不會寫程式」，而是開工前沒�
 3. **Domain Classifier**：用 deterministic keyword scoring 偵測 relevant domains。
 4. **Guardrail Matcher**：用 detected domains 比對 `.spec-injector/config.json` 中的 guardrails。
 5. **Reference Collector**：收集 built-in preset、repo `always_read`、configured docs、issue-mentioned files、auto-discovered docs / source references。
-6. **Task Package Renderer**：輸出 full task package 或 `--format prompt` 的 compact AI planning prompt。
+6. **Diagnostics / Validation Direction**：保留 missing / unreadable / alias hints 與 suggested verification checklist。
+7. **Task Package Renderer**：輸出 full task package 或 `--format prompt` 的 compact AI planning prompt。
 
 ## Pipeline diagram
 
@@ -61,9 +71,21 @@ GitHub Issue
   -> Domain Classifier
   -> Guardrail Matcher
   -> Reference Collector
+  -> Diagnostics / Validation Direction
   -> Task Package Renderer
   -> Markdown task package / prompt for Codex or Claude Code
 ```
+
+## Current capability map
+
+目前 `spec-injector` 的已實作 / 已文件化能力可以用四段理解：
+
+| Stage | What happens | Boundary |
+| --- | --- | --- |
+| Input | 讀取 GitHub issue、repo config、repo docs、issue-mentioned paths 與 configured discovery sources。 | GitHub issue 是目前實作入口；future fuzzy request 仍是 design direction。 |
+| Compile | 用 deterministic parser / classifier / reference collector 組合 guardrails、source references、diagnostics 與 validation hints。 | 不呼叫 hidden LLM，不使用 semantic RAG / vector DB。 |
+| Output | 產生 bounded Markdown task package 或 compact planning prompt，供 AI coding agent 開工前閱讀。 | Output 是 handoff context，不是 autonomous execution plan。 |
+| Verify | Repo workflow docs 規範 validation、implementation evidence comment、PR body evidence URL、HEAD/readback check 與 review closeout。 | Workflow guardrails 是 read-only / human-reviewed discipline，不是 merge bot 或 remediation automation。 |
 
 ## Quickstart
 
@@ -160,10 +182,12 @@ Full task package output is Markdown intended for human and AI review. It can in
 - always-read references
 - auto-discovered documentation
 - auto-discovered source files
+- source reference direction and trust context
 - matched guardrails
 - rule-matched documentation
 - missing files
-- suggested verification checklist
+- unreadable / alias diagnostics where applicable
+- suggested verification checklist and implementation evidence direction
 
 Prompt output with `--format prompt` is shorter and designed for AI planning. It lists relevant references without inlining the full always-read docs, README content, discovered docs, or source snippets.
 
@@ -178,6 +202,9 @@ Key terms used across this project:
 - **Domain classifier**：用 title、labels、body 中的 deterministic signals 選出 relevant domains。
 - **Guardrail**：repo-defined constraint / reminder；提醒風險，但不授權擴 scope。
 - **Reference**：task package 中列出的 docs、source files、built-in preset 或 issue-mentioned files。
+- **Source trust**：標示 context 來源與信任方向，避免 auto-discovered reference 被誤讀成 human-approved scope。
+- **Context budget**：限制 task package / prompt 的內容量與 include mode，讓 output 保持 bounded。
+- **Read diagnostics**：missing、unreadable 或 alias hints 等 context health 訊號。
 - **Task package**：AI 開工前使用的 structured context，不是 autonomous execution plan。
 - **Implementation evidence**：PR 建立後寫回 source issue 的 structured comment。
 
@@ -227,11 +254,19 @@ Important fields:
 - autonomous agent
 - daemon
 - hidden LLM wrapper
+- hosted control-plane platform
+- agent orchestration platform
 - GitHub automation bot
+- GitHub Projects / roadmap dashboard
 - custom domain runtime
+- full SDD lifecycle platform
 - general-purpose RAG system
+- semantic RAG / vector search product
+- hidden LLM planner
 - target repo auto-editing system
 - multi-agent runtime
+- companion runtime in CLI core
+- remediation bot
 - PR / merge automation service
 - stable npm release promise
 


### PR DESCRIPTION
## Summary

- 保守刷新 README product narrative，將 current implemented path 明確收斂為 GitHub issue-to-context compilation。
- 將 broader `request-to-context` adapters 保留為 future deterministic design direction，避免把 fuzzy request / markdown brief / PR review note adapters 說成已實作。
- 補上 current capability map，說明 input / compile / output / verify 四段 workflow。
- 同步繁中與英文 README 的 source trust、context budget、read diagnostics、validation / evidence workflow、agent-agnostic handoff、non-goals 與 documentation links 語義。

## Scope

- Docs-only README narrative refresh 與 review findings follow-up。
- 修改 `README.md` 與 `README.en.md`。
- 保持 GitHub issue 為目前已實作入口；future fuzzy request / markdown brief / PR review note adapters 只描述為 deterministic design direction。

## Non-goals

- 未修改 runtime code、tests、CI、package scripts 或 config schema。
- 未新增 CLI command / flag。
- 未新增 images、diagrams、generated assets、visual showcase 或 companion UI。
- 未宣稱 hidden LLM、semantic RAG / vector DB、hosted control plane、merge bot、target repo auto-editing、full SDD lifecycle platform 或 companion runtime 已完成。
- 未處理 #132 / #133 / #120 / #149 / #100 / #111 / #112。
- 未修改 target repo / tachigo / storefront / tachiya，也未建立或複製 `.spec-injector/` 到任何 target repo。

## Validation

- `git diff --check`: pass
- `pnpm build`: pass; `pnpm build` runs `tsc`
- `pnpm test`: pass, 173 tests, 172 pass, 1 skipped optional gh smoke test
- `pnpm test:gh`: not run; optional live `gh` smoke test, not required for this README-only follow-up and not part of default `pnpm test` / CI
- `pnpm lint`: not run; no `lint` script exists in `package.json`
- `pnpm typecheck`: not run as a separate command; no `typecheck` script exists in `package.json`, and `pnpm build` already runs `tsc`

## Issue evidence

- Original issue evidence comment: https://github.com/Erick52106/spec-injector/issues/119#issuecomment-4377822789
- Follow-up issue evidence comment: https://github.com/Erick52106/spec-injector/issues/119#issuecomment-4377887008

## Implementation Evidence

- Branch: `docs/readme-product-narrative-119`
- Latest HEAD: `d6e1c892217d9e4074e1d37d4fe6c9380f78dedd`
- Commits:
  - `1d1fe5e62b60d8ff22e39568e471854db8d83cb1` docs(readme): refresh product narrative with current workflow evidence
  - `d6e1c892217d9e4074e1d37d4fe6c9380f78dedd` docs(readme): align positioning and bilingual links
- Files changed: `README.md`, `README.en.md`
- Scope guard: docs-only README narrative refresh and review follow-up; no runtime / tests / CI / package script changes.

## Review finding assessment

- CodeRabbit README.en documentation links: adopted. `README.en.md` now includes `docs/agent-handoff.md` and `docs/positioning.md` in the Documentation links section, aligned with `README.md` ordering and formatting.
- Codex positioning boundary: adopted. `README.md` and `README.en.md` now state the current implemented path as deterministic GitHub issue-to-context compilation, while broader deterministic request-to-context adapters remain future design direction.
- Rationale: both findings are within #119 docs-only scope, reduce bilingual / positioning drift, and avoid overclaiming unimplemented request adapters.
- Human merge decision remains required; this PR must not be self-merged by the AI agent.

Closes #119


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined positioning and boundaries for spec-injector as a deterministic GitHub issue-to-context compiler with source-trust and context-budget awareness.
  * Expanded core guarantees with read-only workflow guardrails, task-package diagnostics, and validation checklist.
  * Added Diagnostics / Validation pipeline stage and updated pipeline diagram.
  * Added optional live gh smoke-test guidance and verification expectations.
  * Expanded task-package overview, glossary entries, non-goals, and reordered reference links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->