### PR TITLE
docs(readme): add current capabilities section

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -89,6 +89,15 @@ The current implemented / documented capabilities can be understood in four stag
 | Output | Produces a bounded Markdown task package or compact planning prompt for an AI coding agent to read before implementation. | Output is handoff context, not an autonomous execution plan. |
 | Verify | Repo workflow docs define validation, implementation evidence comments, PR body evidence URLs, HEAD/readback checks, and review closeout. | Workflow guardrails are read-only / human-reviewed discipline, not a merge bot or remediation automation. |
 
+## Current capabilities
+
+- Compiles GitHub issues into bounded, agent-ready task context; see [issue-to-context pipeline](docs/issue-to-context-pipeline.md).
+- Surfaces references and diagnostics so missing or unreadable context remains visible; see [workflow](docs/workflow.md) and [validation](docs/validation.md).
+- Uses source trust and context-budget design to keep task packages bounded; see [source trust](docs/source-trust.md).
+- Supports human-reviewed validation, evidence, readback, and finding-assessment workflows; see [workflow](docs/workflow.md) and [validation](docs/validation.md).
+- Includes read-only workflow guardrails like label/milestone audit; see [label taxonomy](docs/label-taxonomy.md).
+- Keeps companion, status, and remediation ideas documented as design-only, not shipped runtime behavior; see [current capability showcase planning doc](docs/readme-current-capability-showcase.md) and [readme showcase readiness](docs/readme-showcase-readiness.md).
+
 ## Quickstart
 
 Requirements:

--- a/README.md
+++ b/README.md
@@ -89,6 +89,15 @@ GitHub Issue
 | Output | 產生 bounded Markdown task package 或 compact planning prompt，供 AI coding agent 開工前閱讀。 | Output 是 handoff context，不是 autonomous execution plan。 |
 | Verify | Repo workflow docs 規範 validation、implementation evidence comment、PR body evidence URL、HEAD/readback check 與 review closeout。 | Workflow guardrails 是 read-only / human-reviewed discipline，不是 merge bot 或 remediation automation。 |
 
+## 目前能力
+
+- 將 GitHub issue 編譯為 bounded、agent-ready 的 task context；可參考 [issue-to-context pipeline](docs/issue-to-context-pipeline.md)。
+- 顯示 source references 與診斷資訊，讓缺漏或不可讀 context 保持可見；可參考 [workflow](docs/workflow.md) 與 [validation](docs/validation.md)。
+- 以 source trust 與 context-budget 設計約束 task package 邊界；可參考 [source trust](docs/source-trust.md)。
+- 支援 human-reviewed 的 validation / evidence / readback 與 review finding 分類流程；可參考 [workflow](docs/workflow.md) 與 [validation](docs/validation.md)。
+- 提供 read-only 的 workflow guardrail，例如 label / milestone audit；可參考 [label taxonomy](docs/label-taxonomy.md)。
+- 將 companion / status / remediation 相關方向保留為 design-only，不視為已實作功能；可參考 [current capability showcase planning doc](docs/readme-current-capability-showcase.md) 與 [readme showcase readiness](docs/readme-showcase-readiness.md)。
+
 ## Quickstart
 
 Requirements:


### PR DESCRIPTION
## Summary
- 新增 `README.md` / `README.en.md` 的短版 current capabilities section。
- 這是 `#120 split PR B`。
- 不完成 `#120`，也不 close `#120`。

## Scope
- 只修改 `README.md` / `README.en.md`。
- 使用 `#192` current capability showcase planning 的 safe current capability 邊界。
- `README.md` / `README.en.md` claims 保持語意對齊。

## Non-goals
- 不重寫 README narrative。
- 不新增 hero。
- 不新增 diagram / visual assets。
- 不修改 `docs/`。
- 不實作 runtime / automation。
- 不處理 `#149` remediation loop。
- 不完成或關閉 `#120`。
- 不修改 target repo。

## Validation
- `git diff --check`: pass
- `pnpm build`: pass
- `pnpm test`: pass
- `pnpm test:gh`: not run / not required

## Implementation Evidence
- Branch: `docs/readme-current-capabilities-120`
- Commit: c97269fc533a1f89ca8610a84e2a34a5761266ce
- Files changed:
  - `README.md`
  - `README.en.md`
- `#120` state: OPEN
- No README full rewrite / no generated assets / no runtime changes / no target repo mutation

## Review finding assessment
- No automated review findings yet.
- Future findings must be classified as adopted / not adopted / optional polish / noise / needs human review before changes.

Related to #120


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Current Capabilities" section to README documentation with structured listings of implemented features and corresponding documentation references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->