### PR TITLE
docs(layers+readme): align layer wording and source trust caveats

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -328,3 +328,16 @@ Documented future-facing layers:
 - **Layer 3 future agent interface**: possible structured outputs or richer agent-facing integrations, while preserving deterministic and reviewable boundaries.
 
 Future docs and design candidates include custom domains, richer classifier evidence visibility, JSON output, and optional user repo CI scaffolding. They are not part of the current runtime unless a later issue implements them explicitly.
+
+## Current canonical layer model
+
+The current canonical model is the 4-layer roadmap:
+
+- Layer 1 — Core Compiler
+- Layer 2 — Workflow Guardrails
+- Layer 3 — Protocolization
+- Layer 4 — Companion UX
+
+If the repository still contains older 3-layer references, keep them as terminology history / previous framing only, not as current canonical positioning.
+
+Issue #149 remains parked / design-only and is not a current capability. It requires separate design gates before implementation and should not be represented as auto-fix, auto-resolve, auto-merge, auto-close, or target-repo mutation behavior.

--- a/README.en.md
+++ b/README.en.md
@@ -325,7 +325,8 @@ Current implemented layer:
 Documented future-facing layers:
 
 - **Layer 2 AI workflow**: AI tool uses task package to draft an implementation plan, then waits for human approval before implementation.
-- **Layer 3 future agent interface**: possible structured outputs or richer agent-facing integrations, while preserving deterministic and reviewable boundaries.
+- **Layer 3 Protocolization**: richer evidence and protocol alignment for deterministic context handoff, while preserving deterministic and reviewable boundaries.
+- **Layer 4 Companion UX**: consistent human-facing guidance, boundary statements, and support for handoff quality, still design-oriented.
 
 Future docs and design candidates include custom domains, richer classifier evidence visibility, JSON output, and optional user repo CI scaffolding. They are not part of the current runtime unless a later issue implements them explicitly.
 

--- a/README.md
+++ b/README.md
@@ -329,8 +329,9 @@ Current implemented layer:
 
 Documented future-facing layers:
 
-- **Layer 2 AI workflow**：AI tool uses task package to draft an implementation plan, then waits for human approval before implementation.
-- **Layer 3 future agent interface**：possible structured outputs or richer agent-facing integrations, while preserving deterministic and reviewable boundaries.
+- **Layer 2 Workflow Guardrails**：AI tool uses task package to draft an implementation plan, then waits for human approval before implementation.
+- **Layer 3 Protocolization**：possible richer protocolized context handoff, while preserving deterministic and reviewable boundaries.
+- **Layer 4 Companion UX**：human-facing summary quality, boundary statements, and handoff alignment, still design-oriented.
 
 Future docs and design candidates include custom domains, richer classifier evidence visibility, JSON output, and optional user repo CI scaffolding. They are not part of the current runtime unless a later issue implements them explicitly.
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ Broader deterministic request-to-context adapters for fuzzy requests、markdown 
 - agent-agnostic：輸出 Markdown task package / prompt，供 Codex、Claude Code 或其他 AI coding agent 消費
 - no hidden LLM：不呼叫 hidden LLM、external AI API 或 local model
 
+補充（目前實作邊界）：
+- source-trust aware / context-budget aware 是 current direction + partial runtime behavior。
+- 現況 runtime 已輸出 source labels / source categories、bounded snippets / item-count limits、可視化 diagnostics。
+- 現況 runtime 尚未實作完整 trust-level policy engine，也尚未實作 token / byte budget 演算法。
+
 ## Why this exists
 
 AI coding agent 常見的失誤不是「不會寫程式」，而是開工前沒有足夠清楚的邊界：
@@ -328,3 +333,16 @@ Documented future-facing layers:
 - **Layer 3 future agent interface**：possible structured outputs or richer agent-facing integrations, while preserving deterministic and reviewable boundaries.
 
 Future docs and design candidates include custom domains, richer classifier evidence visibility, JSON output, and optional user repo CI scaffolding. They are not part of the current runtime unless a later issue implements them explicitly.
+
+## Current canonical layer model
+
+`spec-injector` 的目前 canonical model 為 4-layer roadmap：
+
+- Layer 1 — Core Compiler
+- Layer 2 — Workflow Guardrails
+- Layer 3 — Protocolization
+- Layer 4 — Companion UX
+
+若文件中仍存在舊版 3-layer 或其他歷史敘事，僅保留作為 terminology history / previous framing；不表示目前實作定位。
+
+`#149 supervised remediation loop` 目前仍為 parked / design-only，不會被表示為 current capability，不作為 current implementation boundary；它在實作前仍需額外設計核可，且不得自動 auto-fix、auto-resolve、auto-merge、auto-close 或 mutate target repo。

--- a/docs/design/layers.md
+++ b/docs/design/layers.md
@@ -165,3 +165,14 @@ Layer 3 principles:
 - Do not modify CLI runtime.
 - Do not modify the config schema.
 - Do not call an LLM, API, or local model.
+
+## Current canonical layer model
+
+Canonical model is now 4 layers:
+
+- Layer 1 — Core Compiler
+- Layer 2 — Workflow Guardrails
+- Layer 3 — Protocolization
+- Layer 4 — Companion UX
+
+Legacy wording that describes only 3 layers should be kept only as terminology history / previous framing and is no longer the current canonical model.

--- a/docs/design/layers.md
+++ b/docs/design/layers.md
@@ -15,9 +15,10 @@ The goals are to:
 
 | Layer | Name | Role |
 | --- | --- | --- |
-| Layer 1 | Deterministic CLI | Current core: stable, scriptable, debuggable commands with repeatable outputs. It does not call an LLM, API, or local model unless that behavior is explicitly part of a command design. |
-| Layer 2 | AI workflow / slash-command-like usage | AI-friendly workflow instructions built on top of Layer 1. For example, `/spec-plan <issue>` or an AI running `spec plan --dry-run --format prompt`. The AI may install, initialize, run commands, and draft implementation plans, but must stop for human approval before modifying a target repo when the workflow requires it. |
-| Layer 3 | Agent / subagent / multi-agent interface | A structured interface for planner, implementer, reviewer, and verifier agents. Future candidates include `--format json` or `--format agent`. `spec-injector` acts as a deterministic context compiler so agents consume normalized context instead of independently guessing repo context. |
+| Layer 1 | Core Compiler | Current core: stable, scriptable, debuggable commands with repeatable outputs. It does not call an LLM, API, or local model unless that behavior is explicitly part of a command design. |
+| Layer 2 | Workflow Guardrails | AI-friendly workflow instructions built on top of Layer 1. For example, `/spec-plan <issue>` or an AI running `spec plan --dry-run --format prompt`. The AI may install, initialize, run commands, and draft implementation plans, but must stop for human approval before modifying a target repo when the workflow requires it. |
+| Layer 3 | Protocolization | A structured interface for planner, implementer, reviewer, and verifier agents. Future candidates include `--format json` or `--format agent`. `spec-injector` acts as a deterministic context compiler so agents consume normalized context instead of independently guessing repo context. |
+| Layer 4 | Companion UX | Human-facing guidance and companion experience patterns built on top of Layers 1-3, including progress surfacing, explicit boundary statements, and review handoff framing. |
 
 ## Layer 1: Deterministic CLI
 
@@ -126,6 +127,17 @@ Layer 3 principles:
 - Do not require an LLM inside the `spec-injector` core.
 
 `--format json`, MCP, and subagent orchestration are future candidates. They are not implemented by this issue.
+
+## Layer 4: Companion UX
+
+Layer 4 is the companion-facing product and communication layer for humans.
+
+Layer 4 principles:
+
+- Keep narrative alignment across docs and READMEs.
+- Make current-scope and design-boundary statements explicit.
+- Surface deterministic evidence handoff and review checkpoints.
+- Keep companion guidance consistent with Layers 1–3 and avoid scope overreach.
 
 ## Boundary rules
 

--- a/docs/source-trust.md
+++ b/docs/source-trust.md
@@ -254,3 +254,12 @@ These criteria are for future implementation issues, not this PR's runtime behav
 - Canonical include distinction: full-include / reference-only / diagnostics-only / hint-only / excluded.
 - Deferred: runtime implementation, context budget algorithm, structured output, input adapters, catalog protocol, workflow contract consumers.
 - Must not be built: hidden LLM, RAG, vector DB, source trust by model confidence, target repo auto-editing, or hint-to-reference promotion.
+## Implemented today vs design future
+
+| Scope | Status | Notes |
+| --- | --- | --- |
+| Implemented today | Implemented | source labels / source categories；bounded snippets / item-count limits；visible missing / unreadable / read failed / alias diagnostics |
+| Partial / design direction | Design | trust levels as design vocabulary；include modes as design vocabulary；context budget policy beyond item-count caps |
+| Not implemented | Not implemented | full trust-level runtime policy engine；token / byte budget algorithm；hidden scoring；semantic RAG / vector search；hidden summarization；LLM confidence |
+
+#149 remains parked / design-only. It is not current behavior and must not be implemented as auto-fix / auto-resolve / auto-merge / auto-close or target-repo mutation.

--- a/docs/source-trust.md
+++ b/docs/source-trust.md
@@ -262,4 +262,4 @@ These criteria are for future implementation issues, not this PR's runtime behav
 | Partial / design direction | Design | trust levels as design vocabulary；include modes as design vocabulary；context budget policy beyond item-count caps |
 | Not implemented | Not implemented | full trust-level runtime policy engine；token / byte budget algorithm；hidden scoring；semantic RAG / vector search；hidden summarization；LLM confidence |
 
-#149 remains parked / design-only. It is not current behavior and must not be implemented as auto-fix / auto-resolve / auto-merge / auto-close or target-repo mutation.
+Issue `#149` remains parked / design-only. It is not current behavior and must not be implemented as auto-fix / auto-resolve / auto-merge / auto-close or target-repo mutation.


### PR DESCRIPTION
## Summary
- 對齊 canonical 4-layer model（Layer 1 — Core Compiler, Layer 2 — Workflow Guardrails, Layer 3 — Protocolization, Layer 4 — Companion UX），並修正文檔敘事一致性。
- 將 `docs/design/layers.md`、`README.md`、`README.en.md`、`docs/source-trust.md` 的 3-layer / 4-layer 混用訊息統一。
- 修正 `#149 remains parked / design-only...` 的 malformed ATX heading。
- Closes #199

## Scope
- README.md
- README.en.md
- docs/design/layers.md
- docs/source-trust.md

## Non-goals
- 不改 runtime / tests / CI / package scripts
- 不處理 #120 / #149
- 不改 target repo

## Validation
- git diff --check
- pnpm build
- pnpm test
- pnpm test:gh not run / not required

## Implementation Evidence
- Branch: docs/layers-readme-source-trust-199
- Commit: 8713398071d13f82decc5486a143d5471c24be2e
- Files changed: README.md, README.en.md, docs/design/layers.md, docs/source-trust.md
- Issue evidence comment: https://github.com/Erick52106/spec-injector/issues/199#issuecomment-4408592704

## Review finding follow-up assessment
- latest HEAD: 8713398071d13f82decc5486a143d5471c24be2e
- findings count: 4

| Finding | Source | Location | Classification | Action |
|---|---|---|---|---|
| 1 | CodeRabbit | docs/design/layers.md | adopted | 將 summary table 與層級章節更新為 4-layer，並新增 `Layer 4: Companion UX` canonical 對齊敘事 |
| 2 | CodeRabbit | docs/source-trust.md | adopted | 將 `#149 remains parked / ...` 改為 `Issue \`#149\` remains parked ...`，修正 malformed heading |
| 3 | CodeRabbit | README.en.md | adopted | 將 roadmap / next layer 說明改為 4-layer canonical 版，保留 #149 parked / design-only |
| 4 | CodeRabbit | README.md | adopted | 將 roadmap / next layer 說明改為 4-layer canonical 版，與英文版同步 |

Validation summary: git diff --check / pnpm build / pnpm test 均通過。
