### PR TITLE
feat(evidence-check): flag multiple closing issues and print auxiliary footer

### DIFF
--- a/src/cli/evidence-check.ts
+++ b/src/cli/evidence-check.ts
@@ -220,28 +220,28 @@ function buildReport(input: {
       }
     } else if (input.linkedIssues.length > 1) {
       const urlIssue = parseIssueNumberFromEvidenceUrl(input.evidenceUrl);
-      if (urlIssue && !input.linkedIssues.includes(urlIssue)) {
+      if (urlIssue === null) {
         checks.push(needsHumanReview(
           'Issue evidence URL',
           input.evidenceUrl,
-          'evidence URL does not match any linked issue',
-          'Resolve source issue ambiguity before readback reuse.'
+          'could not parse linked issue from evidence URL under ambiguity',
+          'Keep source issue selection to a human before using this evidence URL as authoritative.'
         ));
-      } else {
-        checks.push(pass(
+      } else if (input.linkedIssues.includes(urlIssue)) {
+        checks.push(needsHumanReview(
           'Issue evidence URL',
           input.evidenceUrl,
-          'evidence URL found for one linked issue',
-          'Evidence is parseable, but source issue selection remains ambiguous.'
+          'evidence URL matches one candidate, but source issue remains ambiguous',
+          'Do not reuse this evidence URL as authoritative until a human selects exactly one source issue.'
+        ));
+      } else {
+        checks.push(fail(
+          'Issue evidence URL',
+          input.evidenceUrl,
+          'evidence URL does not match any linked issue',
+          'Stop and backfill an evidence URL that points to one of the linked issues.'
         ));
       }
-    } else {
-      checks.push(pass(
-        'Issue evidence URL',
-        input.evidenceUrl,
-        'evidence URL found',
-        'Use this URL for PR body evidence readback.'
-      ));
     }
   }
 

--- a/src/cli/evidence-check.ts
+++ b/src/cli/evidence-check.ts
@@ -65,14 +65,14 @@ export async function evidenceCheck(opts: EvidenceCheckOptions): Promise<void> {
       'number,url,body,headRefName,headRefOid,isDraft,reviews',
     ], 'Could not read PR metadata.');
     const body = pr.body ?? '';
-    const linkedIssue = parseLinkedIssue(body);
+    const linkedIssues = parseLinkedIssues(body);
     const evidenceUrl = findEvidenceUrl(body);
-    const issue = linkedIssue
+    const issue = linkedIssues.length === 1
       ? readJson<IssuePayload>([
         'gh',
         'issue',
         'view',
-        String(linkedIssue),
+        String(linkedIssues[0]),
         '--repo',
         context.repo,
         '--json',
@@ -94,7 +94,7 @@ export async function evidenceCheck(opts: EvidenceCheckOptions): Promise<void> {
       pr,
       issue,
       body,
-      linkedIssue,
+      linkedIssues,
       expectedIssue: parseIssueOption(opts.issue),
       evidenceUrl,
       expectedEvidenceUrl: opts.evidenceUrl,
@@ -134,7 +134,7 @@ function buildReport(input: {
   pr: PullRequestPayload;
   issue: IssuePayload | null;
   body: string;
-  linkedIssue: number | null;
+  linkedIssues: number[];
   expectedIssue: number | null;
   evidenceUrl: string | null;
   expectedEvidenceUrl?: string;
@@ -149,28 +149,37 @@ function buildReport(input: {
     : undefined;
   const combinedEvidence = [input.body, evidenceComment?.body ?? ''].join('\n');
 
-  if (input.linkedIssue) {
-    checks.push(pass(
-      'PR body linked issue',
-      `#${input.linkedIssue}`,
-      'linked issue reference found',
-      'Continue using this source issue as the evidence anchor.'
-    ));
-  } else {
+  if (input.linkedIssues.length === 0) {
     checks.push(fail(
       'PR body linked issue',
       'none',
       'source issue reference is missing',
       'Stop and add a human-reviewed linked issue reference such as Closes #<issue>.'
     ));
+  } else if (input.linkedIssues.length > 1) {
+    checks.push(needsHumanReview(
+      'PR body linked issues',
+      `#${input.linkedIssues.join(', #')}`,
+      `detected ${input.linkedIssues.length} distinct closing issues`,
+      'Do not auto-select a source issue; choose exactly one source issue with human review before proceeding.'
+    ));
+  } else {
+    const [linkedIssue] = input.linkedIssues;
+    checks.push(pass(
+      'PR body linked issue',
+      `#${linkedIssue}`,
+      'linked issue reference found',
+      'Continue using this source issue as the evidence anchor.'
+    ));
   }
 
-  if (input.expectedIssue && input.linkedIssue && input.expectedIssue !== input.linkedIssue) {
-    checks.push(fail(
+  if (input.expectedIssue && input.linkedIssues.length > 0 && input.expectedIssue !== input.linkedIssues[0]) {
+    const expectedIssueEvidence = `expected #${input.expectedIssue}, found ${input.linkedIssues.length === 1 ? `#${input.linkedIssues[0]}` : `${input.linkedIssues.length} candidates`}`;
+    checks.push(needsHumanReview(
       'Expected issue',
-      `expected #${input.expectedIssue}, found #${input.linkedIssue}`,
-      'linked issue does not match --issue',
-      'Stop and confirm the correct source issue before editing PR metadata.'
+      expectedIssueEvidence,
+      `expected issue does not uniquely match PR linked issue(s)`,
+      'Stop and confirm the correct source issue with human review.'
     ));
   }
 
@@ -192,36 +201,70 @@ function buildReport(input: {
         'evidence URL does not match --evidence-url',
         'Stop and confirm which implementation evidence comment is authoritative.'
       ));
-    } else if (input.linkedIssue && urlIssue !== input.linkedIssue) {
-      checks.push(fail(
-        'Issue evidence URL',
-        input.evidenceUrl,
-        'evidence URL points to a different issue',
-        'Stop and backfill the source issue evidence comment URL; do not auto-edit the PR body.'
-      ));
+    } else if (input.linkedIssues.length === 1) {
+      const linkedIssue = input.linkedIssues[0];
+      if (urlIssue !== linkedIssue) {
+        checks.push(fail(
+          'Issue evidence URL',
+          input.evidenceUrl,
+          'evidence URL points to a different issue',
+          'Stop and backfill the source issue evidence comment URL; do not auto-edit the PR body.'
+        ));
+      } else {
+        checks.push(pass(
+          'Issue evidence URL',
+          input.evidenceUrl,
+          'evidence URL points to linked issue',
+          'Use this URL for PR body evidence readback.'
+        ));
+      }
+    } else if (input.linkedIssues.length > 1) {
+      const urlIssue = parseIssueNumberFromEvidenceUrl(input.evidenceUrl);
+      if (urlIssue && !input.linkedIssues.includes(urlIssue)) {
+        checks.push(needsHumanReview(
+          'Issue evidence URL',
+          input.evidenceUrl,
+          'evidence URL does not match any linked issue',
+          'Resolve source issue ambiguity before readback reuse.'
+        ));
+      } else {
+        checks.push(pass(
+          'Issue evidence URL',
+          input.evidenceUrl,
+          'evidence URL found for one linked issue',
+          'Evidence is parseable, but source issue selection remains ambiguous.'
+        ));
+      }
     } else {
       checks.push(pass(
         'Issue evidence URL',
         input.evidenceUrl,
-        'evidence URL points to linked issue',
+        'evidence URL found',
         'Use this URL for PR body evidence readback.'
       ));
     }
   }
 
-  if (input.evidenceUrl && evidenceComment) {
+  if (input.linkedIssues.length === 1 && input.evidenceUrl && evidenceComment) {
     checks.push(pass(
       'Issue evidence comment',
       input.evidenceUrl,
       'issue evidence comment exists',
       'Keep this comment aligned with latest HEAD before merge readiness.'
     ));
-  } else if (input.evidenceUrl) {
+  } else if (input.linkedIssues.length === 1 && input.evidenceUrl) {
     checks.push(fail(
       'Issue evidence comment',
       input.evidenceUrl,
       'issue evidence comment was not found on the linked issue',
       'Stop and verify the source issue comment URL before merge readiness.'
+    ));
+  } else if (input.linkedIssues.length > 1) {
+    checks.push(needsHumanReview(
+      'Issue evidence comment',
+      input.evidenceUrl ?? 'provided',
+      'source issue ambiguity prevents authoritative comment verification',
+      'Resolve source issue first, then verify issue evidence comment against that issue.'
     ));
   }
 
@@ -399,11 +442,12 @@ function checkCi(checks: CheckPayload[], checksReadError?: string): EvidenceChec
   return result;
 }
 
-function parseLinkedIssue(body: string): number | null {
-  const match = [...body.matchAll(LINKED_ISSUE_PATTERN)]
+function parseLinkedIssues(body: string): number[] {
+  const issueNumbers = [...body.matchAll(LINKED_ISSUE_PATTERN)]
     .map((item) => item[1])
-    .find(Boolean);
-  return match ? Number.parseInt(match, 10) : null;
+    .map((value) => Number.parseInt(value, 10))
+    .filter((issue) => Number.isFinite(issue));
+  return [...new Set(issueNumbers)];
 }
 
 function parseIssueOption(issueOption: string | undefined): number | null {
@@ -516,6 +560,14 @@ function printReport(report: { overall: Severity; checks: EvidenceCheck[] }): vo
       `evidence: ${check.evidence}; reason: ${check.reason}; suggested human action: ${check.action}`
     );
   }
+
+  console.log('');
+  console.log('Auxiliary notice:');
+  console.log('- spec evidence-check is a read-only checker.');
+  console.log('- PASS means evidence shape looks OK, but PASS is not approval.');
+  console.log('- Human merge decision remains authoritative.');
+  console.log('- This checker does not edit PRs, post issue comments, resolve review threads, merge, close issues, or mutate GitHub metadata.');
+  console.log('- It does not fully enforce thread-level review conversation closeout.');
 }
 
 function pass(item: string, evidence: string, reason: string, action: string): EvidenceCheck {

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -1721,7 +1721,7 @@ test('spec evidence-check reports multiple distinct closing issues as needs huma
   assertNoGhMutationCommands(ghLog);
 });
 
-test('spec evidence-check flags --issue mismatch and ambiguity as needs-human-review', async (t) => {
+test('spec evidence-check flags --issue ambiguity as needs-human-review', async (t) => {
   const fixture = await createEvidenceCheckFixture(t, {
     issueNumber: 120,
     prBody: [
@@ -1754,6 +1754,45 @@ test('spec evidence-check flags --issue mismatch and ambiguity as needs-human-re
   assert.match(result.stdout, /Evidence check summary:\s+NEEDS-HUMAN-REVIEW/i);
   assert.match(result.stdout, /detected 2 distinct closing issues/i);
   assert.match(result.stdout, /evidence URL matches one candidate, but source issue remains ambiguous/i);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec evidence-check flags --issue disagreement under multiple linked issues as needs-human-review', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t, {
+    issueNumber: 120,
+    prBody: [
+      'Closes #120',
+      'Closes #149',
+      '## Summary',
+      'ok',
+      '## Scope',
+      'ok',
+      '## Non-goals',
+      'ok',
+      '## Validation',
+      '- `git diff --check` ✅',
+      '- `pnpm build` ✅',
+      '- `pnpm test` ✅',
+      '## Implementation Evidence',
+      '- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/120#issuecomment-1090001',
+      '- Latest HEAD: 1234567890abcdef1234567890abcdef12345678',
+    ].join('\n'),
+  });
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', String(fixture.prNumber),
+    '--repo', fixture.repo,
+    '--issue', '777',
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stdout, /Evidence check summary:\s+NEEDS-HUMAN-REVIEW/i);
+  assert.match(result.stdout, /expected issue does not uniquely match PR linked issue\(s\)/i);
+  assert.match(result.stdout, /Expected issue/i);
+  assert.match(result.stdout, /expected #777, found 2 candidates/i);
+  assert.match(result.stdout, /detected 2 distinct closing issues/i);
   const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
   assertNoGhMutationCommands(ghLog);
 });
@@ -1852,11 +1891,18 @@ test('spec evidence-check prints auxiliary read-only non-merge authority footer'
     '--repo', passFixture.repo,
     '--issue', '120',
   ], { env: passFixture.env });
+  assert.equal(passResult.code, 0, passResult.stderr);
   assert.match(passResult.stdout, /Auxiliary notice:/i);
   assert.match(passResult.stdout, /read-only checker/i);
   assert.match(passResult.stdout, /PASS means evidence shape looks OK/i);
   assert.match(passResult.stdout, /PASS is not approval/i);
   assert.match(passResult.stdout, /Human merge decision remains authoritative/i);
+  assert.match(passResult.stdout, /does not edit PRs/i);
+  assert.match(passResult.stdout, /post issue comments/i);
+  assert.match(passResult.stdout, /resolve review threads/i);
+  assert.match(passResult.stdout, /merge/i);
+  assert.match(passResult.stdout, /close issues/i);
+  assert.match(passResult.stdout, /mutate GitHub metadata/i);
 
   const issueFixture = await createEvidenceCheckFixture(t, {
     issueNumber: 120,
@@ -1884,8 +1930,14 @@ test('spec evidence-check prints auxiliary read-only non-merge authority footer'
     '--repo', issueFixture.repo,
     '--issue', '120',
   ], { env: issueFixture.env });
+  assert.notEqual(needsResult.code, 0);
   assert.match(needsResult.stdout, /Auxiliary notice:/i);
-  assert.match(needsResult.stdout, /does not edit PRs|does not edit pr/i);
+  assert.match(needsResult.stdout, /does not edit PRs/i);
+  assert.match(needsResult.stdout, /post issue comments/i);
+  assert.match(needsResult.stdout, /resolve review threads/i);
+  assert.match(needsResult.stdout, /merge/i);
+  assert.match(needsResult.stdout, /close issues/i);
+  assert.match(needsResult.stdout, /mutate GitHub metadata/i);
   assert.match(needsResult.stdout, /does not fully enforce thread-level review conversation closeout/i);
   assert.match(needsResult.stdout, /Evidence check summary:\s+NEEDS-HUMAN-REVIEW/i);
   const passLog = (await readGhLog(passFixture.ghLogPath)).join('\n');

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -1723,8 +1723,9 @@ test('spec evidence-check reports multiple distinct closing issues as needs huma
 
 test('spec evidence-check flags --issue mismatch and ambiguity as needs-human-review', async (t) => {
   const fixture = await createEvidenceCheckFixture(t, {
-    issueNumber: 149,
+    issueNumber: 120,
     prBody: [
+      'Closes #120',
       'Closes #149',
       '## Summary',
       'ok',
@@ -1737,7 +1738,7 @@ test('spec evidence-check flags --issue mismatch and ambiguity as needs-human-re
       '- `pnpm build` ✅',
       '- `pnpm test` ✅',
       '## Implementation Evidence',
-      '- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/149#issuecomment-1090001',
+      '- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/120#issuecomment-1090001',
       '- Latest HEAD: 1234567890abcdef1234567890abcdef12345678',
     ].join('\n'),
   });
@@ -1751,8 +1752,56 @@ test('spec evidence-check flags --issue mismatch and ambiguity as needs-human-re
 
   assert.notEqual(result.code, 0);
   assert.match(result.stdout, /Evidence check summary:\s+NEEDS-HUMAN-REVIEW/i);
-  assert.match(result.stdout, /Expected issue/);
-  assert.match(result.stdout, /expected #120, found #149/i);
+  assert.match(result.stdout, /detected 2 distinct closing issues/i);
+  assert.match(result.stdout, /evidence URL matches one candidate, but source issue remains ambiguous/i);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec evidence-check fails when multi-linked issue evidence URL is not among candidates', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t, {
+    issueNumber: 120,
+    prBody: [
+      'Closes #120',
+      'Closes #149',
+      '## Summary',
+      'ok',
+      '## Scope',
+      'ok',
+      '## Non-goals',
+      'ok',
+      '## Validation',
+      '- `git diff --check` ✅',
+      '- `pnpm build` ✅',
+      '- `pnpm test` ✅',
+      '## Implementation Evidence',
+      '- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/777#issuecomment-1090001',
+      '- Latest HEAD: 1234567890abcdef1234567890abcdef12345678',
+    ].join('\n'),
+    issueComments: [{
+      url: 'https://github.com/Erick52106/spec-injector/issues/777#issuecomment-1090001',
+      body: [
+        '## Implementation evidence',
+        '- PR URL: https://github.com/Erick52106/spec-injector/pull/1091',
+        '- Branch: feat/pr-evidence-consistency-checker-109',
+        '- Commit hash / HEAD: 1234567890abcdef1234567890abcdef12345678',
+        '- Tests / validation:',
+        '- `git diff --check` ✅',
+        '- `pnpm build` ✅',
+        '- `pnpm test` ✅',
+      ].join('\n'),
+    }],
+  });
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', String(fixture.prNumber),
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stdout, /Evidence check summary:\s+FAIL/i);
+  assert.match(result.stdout, /evidence URL does not match any linked issue/i);
   const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
   assertNoGhMutationCommands(ghLog);
 });

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -1665,6 +1665,186 @@ test('spec evidence-check does not let --issue satisfy a missing PR body closing
   assertNoGhMutationCommands(ghLog);
 });
 
+test('spec evidence-check accepts a single closing issue matching --issue', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t);
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', String(fixture.prNumber),
+    '--repo', fixture.repo,
+    '--issue', '109',
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Evidence check summary:\s+PASS/i);
+  assert.match(result.stdout, /PR body linked issue.*#109/i);
+  assert.doesNotMatch(result.stdout, /PR body linked issues/i);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec evidence-check reports multiple distinct closing issues as needs human review', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t, {
+    issueNumber: 120,
+    prBody: [
+      'Closes #120',
+      'Closes #149',
+      '## Summary',
+      'ok',
+      '## Scope',
+      'ok',
+      '## Non-goals',
+      'ok',
+      '## Validation',
+      '- `git diff --check` ✅',
+      '- `pnpm build` ✅',
+      '- `pnpm test` ✅',
+      '## Implementation Evidence',
+      '- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/120#issuecomment-1090001',
+      '- Latest HEAD: 1234567890abcdef1234567890abcdef12345678',
+    ].join('\n'),
+  });
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', String(fixture.prNumber),
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stdout, /Evidence check summary:\s+NEEDS-HUMAN-REVIEW/i);
+  assert.match(result.stdout, /#120/);
+  assert.match(result.stdout, /#149/);
+  assert.match(result.stdout, /detected 2 distinct closing issues/i);
+  assert.doesNotMatch(result.stdout, /linked issue reference found/i);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec evidence-check flags --issue mismatch and ambiguity as needs-human-review', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t, {
+    issueNumber: 149,
+    prBody: [
+      'Closes #149',
+      '## Summary',
+      'ok',
+      '## Scope',
+      'ok',
+      '## Non-goals',
+      'ok',
+      '## Validation',
+      '- `git diff --check` ✅',
+      '- `pnpm build` ✅',
+      '- `pnpm test` ✅',
+      '## Implementation Evidence',
+      '- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/149#issuecomment-1090001',
+      '- Latest HEAD: 1234567890abcdef1234567890abcdef12345678',
+    ].join('\n'),
+  });
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', String(fixture.prNumber),
+    '--repo', fixture.repo,
+    '--issue', '120',
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stdout, /Evidence check summary:\s+NEEDS-HUMAN-REVIEW/i);
+  assert.match(result.stdout, /Expected issue/);
+  assert.match(result.stdout, /expected #120, found #149/i);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec evidence-check treats duplicate same closing issue references as one', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t, {
+    issueNumber: 120,
+    prBody: [
+      'Closes #120',
+      'Fixes #120',
+      '## Summary',
+      'ok',
+      '## Scope',
+      'ok',
+      '## Non-goals',
+      'ok',
+      '## Validation',
+      '- `git diff --check` ✅',
+      '- `pnpm build` ✅',
+      '- `pnpm test` ✅',
+      '## Implementation Evidence',
+      '- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/120#issuecomment-1090001',
+      '- Latest HEAD: 1234567890abcdef1234567890abcdef12345678',
+    ].join('\n'),
+  });
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', String(fixture.prNumber),
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Evidence check summary:\s+PASS/i);
+  assert.match(result.stdout, /PR body linked issue.*#120/i);
+  assert.doesNotMatch(result.stdout, /detected 2 distinct closing issues/i);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec evidence-check prints auxiliary read-only non-merge authority footer', async (t) => {
+  const passFixture = await createEvidenceCheckFixture(t, {
+    issueNumber: 120,
+  });
+  const passResult = await runSpec([
+    'evidence-check',
+    '--pr', String(passFixture.prNumber),
+    '--repo', passFixture.repo,
+    '--issue', '120',
+  ], { env: passFixture.env });
+  assert.match(passResult.stdout, /Auxiliary notice:/i);
+  assert.match(passResult.stdout, /read-only checker/i);
+  assert.match(passResult.stdout, /PASS means evidence shape looks OK/i);
+  assert.match(passResult.stdout, /PASS is not approval/i);
+  assert.match(passResult.stdout, /Human merge decision remains authoritative/i);
+
+  const issueFixture = await createEvidenceCheckFixture(t, {
+    issueNumber: 120,
+    prBody: [
+      'Closes #120',
+      'Closes #149',
+      '## Summary',
+      'ok',
+      '## Scope',
+      'ok',
+      '## Non-goals',
+      'ok',
+      '## Validation',
+      '- `git diff --check` ✅',
+      '- `pnpm build` ✅',
+      '- `pnpm test` ✅',
+      '## Implementation Evidence',
+      '- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/120#issuecomment-1090001',
+      '- Latest HEAD: 1234567890abcdef1234567890abcdef12345678',
+    ].join('\n'),
+  });
+  const needsResult = await runSpec([
+    'evidence-check',
+    '--pr', String(issueFixture.prNumber),
+    '--repo', issueFixture.repo,
+    '--issue', '120',
+  ], { env: issueFixture.env });
+  assert.match(needsResult.stdout, /Auxiliary notice:/i);
+  assert.match(needsResult.stdout, /does not edit PRs|does not edit pr/i);
+  assert.match(needsResult.stdout, /does not fully enforce thread-level review conversation closeout/i);
+  assert.match(needsResult.stdout, /Evidence check summary:\s+NEEDS-HUMAN-REVIEW/i);
+  const passLog = (await readGhLog(passFixture.ghLogPath)).join('\n');
+  const issueLog = (await readGhLog(issueFixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(passLog);
+  assertNoGhMutationCommands(issueLog);
+});
+
 test('spec evidence-check prefers closing keyword issue over earlier bare issue mentions', async (t) => {
   const fixture = await createEvidenceCheckFixture(t, {
     prBody: [

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -42,6 +42,9 @@ type EvidenceCheckFixture = {
 };
 
 type EvidenceCheckFixtureOptions = {
+  issueNumber?: number;
+  evidenceCommentId?: string;
+  branch?: string;
   prBody?: string;
   issueComments?: Array<{ url: string; body: string }>;
   headSha?: string;
@@ -242,11 +245,12 @@ export async function createEvidenceCheckFixture(
 ): Promise<EvidenceCheckFixture> {
   const repo = 'Erick52106/spec-injector';
   const prNumber = 1091;
-  const issueNumber = 109;
+  const issueNumber = options.issueNumber ?? 109;
+  const evidenceCommentId = options.evidenceCommentId ?? '1090001';
   const headSha = options.headSha ?? '1234567890abcdef1234567890abcdef12345678';
-  const evidenceUrl = `https://github.com/${repo}/issues/${issueNumber}#issuecomment-1090001`;
+  const evidenceUrl = `https://github.com/${repo}/issues/${issueNumber}#issuecomment-${evidenceCommentId}`;
   const prUrl = `https://github.com/${repo}/pull/${prNumber}`;
-  const branch = 'feat/pr-evidence-consistency-checker-109';
+  const branch = options.branch ?? 'feat/pr-evidence-consistency-checker-109';
   const defaultValidation = [
     '- `git diff --check` ✅',
     '- `pnpm build` ✅',


### PR DESCRIPTION
## Summary
- 加上純測試層面的補強，將 `spec evidence-check` 的 `--issue` 雙重驗證分成兩條路徑：
  - ambiguous（`--issue` 在 linked issues 集合中）
  - true disagreement（`--issue` 不在 detected linked issues 中）
- 為 footer 契約加入 exit-code 斷言（PASS path = 0，NEEDS-HUMAN-REVIEW path != 0），並加強 read-only / no-auto 合約的文字覆蓋。
- 不修改 runtime。
- Closes #200

## Scope
- tests/cli.integration.test.ts

## Non-goals
- 不新增/修改 runtime 行為。
- 不修改 PR body。
- 不寫 GitHub issue comments。
- 不 resolve review threads。
- 不 merge。
- 不 close issues。
- 不實作 GraphQL thread reader。
- 不處理 #149 remediation loop。
- 不修改 target repo。

## Validation
- git diff --check
- pnpm build
- pnpm test
- pnpm test:gh not run / not required

## Implementation Evidence
- Branch: feat/evidence-check-multi-closing-footer-200
- Commit hash / HEAD: e1ac626498db1521c84b02801c05c8e7441fe764
- Files changed: tests/cli.integration.test.ts
- #120 state: OPEN
- #149 state: OPEN

## Review finding assessment
- Finding 1: adopted (file: tests/cli.integration.test.ts)
  - Action: 保留 ambiguity 測試為 `flags --issue ambiguity as needs-human-review`，並新增 `--issue` 真不一致（outside linked issues）測試。
  - Outcome: 對 `--issue 777`（非候選）在 `Closes #120` + `Closes #149` 下輸出 NEEDS-HUMAN-REVIEW 並顯示 mismatch/reason。
- Finding 2: adopted (file: tests/cli.integration.test.ts)
  - Action: 在 footer 測試加入 PASS/NEEDS-HUMAN-REVIEW exit-code 斷言，並加上 read-only / 無 auto-mutation 合約文字檢查。
  - Outcome: 驗證 PASS 與 HUMAN-REVIEW 路徑皆保留所需 footer 行為。
- validation summary: `git diff --check` pass, `pnpm build` pass, `pnpm test` pass, `pnpm test:gh` not run / not required

- Issue evidence comment URLs:
  - https://github.com/Erick52106/spec-injector/issues/200#issuecomment-4408530459
  - https://github.com/Erick52106/spec-injector/issues/200#issuecomment-4408612407
  - https://github.com/Erick52106/spec-injector/issues/200#issuecomment-4408702369

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Handles PRs with multiple linked issues (deduplicated) and added read-only "Auxiliary notice" clarifying PASS is not merge approval.

* **Improvements**
  * Checks now vary by number of linked issues: skip linked-issue comment lookup unless exactly one; evidence URL/comment validation and `--issue` expectations produce PASS/FAIL/NEEDS-HUMAN-REVIEW according to ambiguity.

* **Tests**
  * Added integration tests for multiple-linked-issue scenarios, ambiguity, mismatches, duplicates, read-only footer; test fixtures extended to support configurable issue/evidence/branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
