### PR TITLE
docs(dogfood/workflow): add dogfood template and workflow cheatsheet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,8 @@ PR body 必須包含：
 
 Source issue 必須有 implementation evidence comment。PR body 回填後必須用 `gh pr view` 或等價方式反查，確認不是空的，且包含 evidence URL 與 commit hash。
 
+Workflow 快速進場建議可先看 `docs/cheatsheet.md`，但 `docs/workflow.md` 與 `docs/validation.md` 為 canonical policy。
+
 ## Labels / roadmap metadata
 
 - Issue 應有合理的 area / type / status labels。

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -59,11 +59,17 @@
    - 交由 human 作 merge
 
 ## Quick validation matrix
-- Docs-only:
+- ordinary docs-only (copy/link or wording adjustments):
   - required: `git diff --check`
-  - recommended: `pnpm test`（若文件含實際命令或行為說明）
-- implementation:
-  - required: `git diff --check`, `pnpm build`, `pnpm test`
+  - when doc includes markdown links: manual sanity check for broken/bare URLs, obvious path typo, and section consistency
+  - quick test command: optional `pnpm test`（僅當文件明示行為驗證）
+- workflow-rule / AGENTS / validation / guardrail docs:
+  - required: `git diff --check`
+  - markdown/link sanity check（含 `docs/**` 參考鏈）
+  - consistency readback vs `docs/workflow.md` and `docs/validation.md`（`git diff` 變更核對）
+  - `pnpm build`
+  - `pnpm test`
+  - if PR touches closeout expectations（issue evidence / PR body readback rules）：extra evidence/readback pass
 - tests:
   - required when issue scope includes behavior, command output, or runtime
 - metadata-only:
@@ -93,3 +99,4 @@
 - 正規規則入口：`docs/workflow.md`
 - 驗證規則入口：`docs/validation.md`
 - 這份文件僅作為快速執行時使用的 cheatsheet
+- workflow-rule 類別的實際驗證邏輯以 `docs/validation.md` 為準，cheatsheet 只保留快速執行提示

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -49,6 +49,7 @@
 13. run evidence-check
    - `spec evidence-check --pr <num> --repo <owner/name> --expected-head <sha>`
    - PASS 僅為輔助結果
+   - 不保證所有 CodeRabbit / Codex / human review threads 已關閉，thread closeout 仍需人工逐條確認
 14. run label-audit when relevant
    - 對照 issue / PR metadata 與 label 規範
 15. wait for human merge decision

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -1,0 +1,95 @@
+# Spec-injector workflow cheatsheet（happy path）
+
+## Purpose
+這是一份供執行時快速對照的 happy-path 指南，不取代 `docs/workflow.md` / `docs/validation.md`，也不擴大到新 policy。
+
+## When to use this cheatsheet
+- 開始一張 issue/PR 流程前的快速記憶提詞
+- review 前確認步驟順序
+- 需要提醒 review thread / evidence / PR body readback 的 checkpoint
+- merge-time 前最後一次 human-readable 自檢
+
+## Happy path
+1. sync main
+   - `git checkout main`
+   - `git pull --ff-only`
+   - `git status --short`（確認 clean）
+2. create dedicated worktree
+   - `git worktree add -b <branch> <path> main`
+   - 進入 worktree 確認 `git status --short` clean
+3. run preflight
+   - 任務 issue / PR file-scope 檢查
+   - target repo 是否清楚、是否仍為 read-only
+4. run spec plan
+   - 使用 external config（如有需要）
+   - 使用只讀方式收斂目標參考
+5. implement scoped changes
+   - 只改允許的檔案
+   - 文件更新以 `docs/**` / `AGENTS.md` / workflow docs 為主
+6. run validation
+   - `git diff --check`
+   - `pnpm build`
+   - `pnpm test`（按 issue 要求）
+7. commit / push / create PR
+   - Commit message 依實際規則
+   - Push 目標 branch
+   - 建立 ready-for-review PR
+8. add issue evidence comment
+   - 在 source issue 留 implementation evidence comment（繁中）
+9. backfill PR body
+   - 填入 `issue evidence URL`、`commit hash`、`validation 結果`
+10. readback verify PR body / issue evidence
+   - `gh pr view <pr> --json body,headRefOid`
+   - `gh issue view <issue> --json comments`
+11. check CodeRabbit / Codex / human review findings
+   - 不當成 approval
+   - 僅做狀態盤點
+12. classify findings before changes
+   - `adopted` / `not adopted` / `optional polish` / `noise / not applicable` / `needs human review`
+13. run evidence-check
+   - `spec evidence-check --pr <num> --repo <owner/name> --expected-head <sha>`
+   - PASS 僅為輔助結果
+14. run label-audit when relevant
+   - 對照 issue / PR metadata 與 label 規範
+15. wait for human merge decision
+   - 不代替 human 做 final decision
+16. merge-time closeout
+   - readback 所有 evidence
+   - 確認 no unresolved human-required block
+   - 交由 human 作 merge
+
+## Quick validation matrix
+- Docs-only:
+  - required: `git diff --check`
+  - recommended: `pnpm test`（若文件含實際命令或行為說明）
+- implementation:
+  - required: `git diff --check`, `pnpm build`, `pnpm test`
+- tests:
+  - required when issue scope includes behavior, command output, or runtime
+- metadata-only:
+  - required: `gh pr view` / `gh issue view` readback（無 repo file change）
+
+## Do not do
+- no stash / clean / reset（除非 human 明確授權）
+- no target repo mutation（含 commit / push / branch / file edit / `.spec-injector/` / `spec init`）
+- no auto-merge / auto-close
+- no auto-resolve without written rationale
+- no review finding fix without necessity assessment
+
+## Readback checklist
+- PR body contains:
+  - `Closes #<issue-number>`
+  - validation 命令與結果
+  - issue evidence comment URL
+  - commit hash
+  - scope guard / non-goals
+- Issue evidence comment 可讀：
+  - PR URL
+  - branch / commit / files
+  - no target repo mutation
+- #120 / #149 preserved state（如需求要求）
+
+## Canonical policy links
+- 正規規則入口：`docs/workflow.md`
+- 驗證規則入口：`docs/validation.md`
+- 這份文件僅作為快速執行時使用的 cheatsheet

--- a/docs/dogfood/TEMPLATE.md
+++ b/docs/dogfood/TEMPLATE.md
@@ -1,0 +1,125 @@
+# Dogfood Report Template (Read-Only)
+
+> 只做第二階段 Brownfield dogfood 的 read-only report，`spec-injector` 仍維持 deterministic issue-to-context compiler 的定位，不承諾自動修復或 remediation。
+
+## Goal
+- 明確記錄指定 issue / request 在目標 repo 的 read-only 驗證結果
+- 識別 `spec plan` 與人工作業交界處的真實資訊缺口
+- 釐清 true positives、false positives、false negatives，並給出 follow-up 建議
+
+## Target repository
+- Name:
+- URL:
+- Branch / ref tested:
+- Commit / HEAD under test:
+- Target repo status (clean/dirty):
+
+## Safety checklist
+- ☐ target repo remains read-only
+- ☐ do not run `spec init` in target repo
+- ☐ do not create `.spec-injector/` in target repo
+- ☐ do not commit / push / branch in target repo
+- ☐ do not modify target repo files
+- ☐ do not paste sensitive source content or large private snippets
+- ☐ stop if target repo is dirty or uncertain
+- ☐ use external config path if repo-specific config is needed
+- ☐ record commands run
+- ☐ record no target repo mutation
+
+## Inputs
+- Source issue / request under test:
+- Target repo context snapshot (docs / files opened / constraints):
+- Dogfood run arguments or command intent:
+- Local constraints (monorepo / permissions / access):
+
+## Commands run
+### Preconditions
+- `git status` (target repo)
+- `pwd` and workspace path
+
+### Commands
+- List each command exactly once, preserving redaction for tokens or private paths.
+
+## Environment / tool versions, if known
+- Node:
+- pnpm:
+- OS / shell:
+- Runtime env vars:
+- External config path (if used):
+
+## Issue / request under test
+- Request title:
+- Request owner / link:
+- Expected evidence scope:
+- Linked issue / PR context:
+
+## Expected behavior
+- Expected `spec plan` behavior:
+- Expected confidence / determinism expectations:
+- Expected review thread / findings state assumptions:
+
+## Observed output summary
+- Command outputs (sanitized):
+- Exit code summary:
+- Major observations:
+- Confidence flags (if any):
+
+## Source reference precision
+- 目標參考是否被成功收斂：
+  - 主要參考是否被識別
+  - 來源鏈是否有落空
+  - 參考順序是否穩定
+- 參考 precision / recall 問題摘要：
+
+## Diagnostics quality
+- Reported diagnostics 是否具體可操作：
+- 失真或過度含糊處：
+- 輸出中缺少的關鍵欄位：
+
+## True positives
+- 可被實際採納的發現：
+- 為何可採納（含證據）：
+
+## False positives
+- 可能為誤報的發現：
+- 為何判斷為 FP：
+
+## False negatives
+- 可能漏掉但重要的現象：
+- 漏掉原因（權限、截斷、噪音、流程限制）：
+
+## Scope gaps
+- 本次 dogfood 未覆蓋但屬於流程或實作界外的項目：
+- 建議拆 issue 的 follow-up：
+
+## Monorepo / brownfield friction
+- Monorepo 導覽成本與障礙：
+- Brownfield 文件/設定噪音：
+- 權限與讀取邊界限制：
+
+## zh-TW / language friction, if any
+- 用詞/命名歧義：
+- 需求與 CLI output 的語言對齊問題：
+- 需要補齊的中英對照：
+
+## Context boundary / truncation / omission observations
+- 觀測到截斷 / 省略：
+- 忽略區段可能影響判斷的原因：
+- 輸出省略的可補充方式：
+
+## AI usability notes
+- 對 AI 實作者最有價值的資訊：
+- 易讓 AI 進入錯誤假設的段落：
+- 可加入的可讀性強化建議：
+
+## Follow-up recommendations
+- 建議的新 issue / follow-up:
+- 建議修正流程順序：
+- 是否建議再跑一次 dogfood（可選）：
+
+## Final verdict
+- Verdict: PASS / WARN / FAIL
+- Rationale:
+- Next action:
+- Re-test condition:
+- `spec-injector` 影響範圍（僅 workflow insight / 無 runtime mutation）:

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -84,6 +84,8 @@ spec evidence-check \
 
 CodeRabbit / Codex auto review findings 只能作為 auxiliary signals。`spec evidence-check` 可提醒 review finding assessment 是否存在，但不代表 approval，也不取代 human merge decision。
 
+Thread-level limitation：`spec evidence-check` 目前只做 read-only 輔助檢核，不會完整 enforce GitHub review thread / conversation closeout。它可提醒 PR body / evidence / HEAD / validation / findings shape，但不能保證每條 CodeRabbit / Codex / human thread 都已關閉。`PASS` 僅表示輔助欄位滿足程度，不是 merge approval。該 checker 不能 auto-comment、auto-resolve、auto-merge、auto-close，也不會 mutate GitHub issue / PR metadata；最終 thread-level closeout 必須由 human 逐條確認與接手。
+
 ## Worktree naming
 
 建議命名：


### PR DESCRIPTION
## Summary
- 新增 `docs/dogfood/TEMPLATE.md`
- 新增 `docs/cheatsheet.md`
- 文件化 evidence-check review thread-level 限制
- Closes #201

## Scope
- `docs/dogfood/TEMPLATE.md`
- `docs/cheatsheet.md`
- `docs/workflow.md`
- `AGENTS.md`
- `docs/validation.md`（未修改）

## Non-goals
- 不指定 dogfood target repo
- 不執行 dogfood
- 不修改 runtime
- 不修改 tests
- 不修改 CI
- 不實作 GraphQL thread reader
- 不處理 #149 remediation loop
- 不關閉 #120
- 不改 target repo

## Validation
- `git diff --check`
- `pnpm build`
- `pnpm test`
- `pnpm test:gh` not run / not required

## Implementation Evidence
- Branch: `docs/dogfood-workflow-template-201`
- Commit hash: `8ecdfa26e1ce011f6cd5e329d0e4d3b8b7c71ffe`
- Files changed:
  - `docs/dogfood/TEMPLATE.md`
  - `docs/cheatsheet.md`
  - `docs/workflow.md`
  - `AGENTS.md`
- #120 state: OPEN
- #149 state: OPEN
- #199 / #200 status: implemented
- issue evidence comment URLs:
  - https://github.com/Erick52106/spec-injector/issues/201#issuecomment-4408772184
  - https://github.com/Erick52106/spec-injector/issues/201#issuecomment-4408801368
  - https://github.com/Erick52106/spec-injector/issues/201#issuecomment-4408837133

## Review finding assessment
- Codex finding（採納）: `Restore workflow-rule validation requirements`（`docs/cheatsheet.md`）
  - Source: Codex review thread on PR #211
  - Classification: adopted
  - Action: update `docs/cheatsheet.md` 的 `Quick validation matrix`，補充 workflow-rule 文件與 ordinary docs-only 的分流驗證要求。
  - Validation: `git diff --check` pass、`pnpm build` pass、`pnpm test` pass
- CodeRabbit nitpick（採納）: `Add explicit thread-level limitation note next to evidence-check step`（`docs/cheatsheet.md`）
  - Source: CodeRabbit review comment on PR #211
  - Classification: adopted
  - Action: 在 `run evidence-check` 區段新增一句
    `不保證所有 CodeRabbit / Codex / human review threads 已關閉，thread closeout 仍需人工逐條確認`。
  - Validation: `git diff --check` pass、`pnpm build` pass、`pnpm test` pass

- dogfood remains future read-only report
- evidence-check PASS is auxiliary only, does not guarantee thread closeout
- no GraphQL thread reader implemented


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a workflow cheatsheet for quick-start guidance on creating worktrees, running validation, and opening pull requests.
  * Added a structured template for dogfood reports to document testing details, findings, and workflow impact assessments.
  * Clarified limitations of the evidence-check tool: it provides read-only assistance and does not enforce GitHub review approvals or auto-merge functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

