### PR TITLE
test(cli): add diagnostics-heavy prompt golden sample

### DIFF
--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -4309,6 +4309,104 @@ test('spec plan truncates auto-discovered source on UTF-8 boundaries', async (t)
   assert.equal(truncatedBytes <= originalBytes, true);
 });
 
+test('spec plan prompt diagnostics-heavy sample stays bounded and reference-oriented', async (t) => {
+  const fixture = await createExplicitPathPlanFixture(t, {
+    issueNumber: 204,
+    title: 'Prompt diagnostics-heavy output stability sample',
+    bodyLines: [
+      'Validate prompt-mode output is reference-oriented and bounded under diagnostics-heavy context.',
+      'Keep explicit references discoverable and missing/read diagnostics explicit:',
+      '- `docs/issue-mentioned-doc.md`',
+      '- `src/issue-mentioned-source.ts`',
+      '- `src/missing-issue-source.ts`',
+      '- `src/unreadable-source.ts`',
+      '- `alias-source.ts`',
+      '',
+      'Auto-discovery should surface additional diagnostics and truncation context from repository candidates.',
+      'This issue is about diagnostics, truncation, and source read behavior.',
+    ],
+    config: {
+      discovery: {
+        docs: [],
+        source: ['src'],
+        max_docs: 4,
+        max_source_files: 8,
+      },
+    },
+    repoFiles: {
+      'docs/issue-mentioned-doc.md': '# Issue Mentioned Doc\n\nISSUE_MENTIONED_DOC_SENTINEL\n',
+      'docs/diagnostics-guide.md': '# Diagnostics Guide\n\nAuto-discovered diagnostics reference for source-boundary checks.\n',
+      'src/issue-mentioned-source.ts': 'export const issueMentionedSource = "ISSUE_MENTIONED_SOURCE_SENTINEL";\n',
+      'src/runtime/alias-source.ts': 'export const aliasSource = "ALIAS_SOURCE_SENTINEL";\n',
+      'src/diagnostics-source.ts': 'export const diagnosticsSource = "AUTO_DISCOVERED_SOURCE_SENTINEL";\n',
+      'src/auto-discovered-truncation-source.ts': [
+        'export const longSourceContent = `TRUNCATION_HEAD_SENTINEL',
+        `${'A'.repeat(520)}`,
+        'TRUNCATION_TAIL_SENTINEL`;',
+      ].join('\n'),
+      'src/auto-discovered-read-failed-source.ts': 'export const readFailedSource = "AUTO_DISCOVERED_READ_FAILED_SOURCE_SENTINEL";\n',
+      'src/unreadable-source.ts': 'export const unreadableSource = "UNREADABLE_SOURCE_SENTINEL";\n',
+    },
+  });
+
+  const env = await createReadFailureEnv(t, fixture.env, [
+    ['src/unreadable-source.ts', 'EACCES'],
+    ['src/auto-discovered-read-failed-source.ts', 'EIO'],
+  ]);
+
+  const result = await runSpec(
+    ['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'],
+    { env }
+  );
+
+  assert.equal(result.code, 0, result.stderr);
+  assertNoRawStackTrace(result);
+
+  assertOrderedSubstrings(result.stdout, [
+    '# Implementation Plan Prompt:',
+    '## 1. Issue Summary',
+    '## 2. Detected Domains',
+    '## 3. Guardrails',
+    '## 4. Relevant File References',
+    '### Issue-Mentioned Docs',
+    '### Issue-Mentioned Source Files',
+    '### Auto-Discovered Docs',
+    '### Rule-Matched Docs',
+    '### Auto-Discovered Source Files',
+    '## 5. Missing Files',
+    '## 6. Instructions',
+  ]);
+
+  const promptIssueDocs = sectionBetween(result.stdout, '### Issue-Mentioned Docs', '### Issue-Mentioned Source Files');
+  const promptIssueSources = sectionBetween(result.stdout, '### Issue-Mentioned Source Files', '### Auto-Discovered Docs');
+  const promptAutoDocs = sectionBetween(result.stdout, '### Auto-Discovered Docs', '### Rule-Matched Docs');
+  const promptAutoSources = sectionBetween(result.stdout, '### Auto-Discovered Source Files', '## 5. Missing Files');
+  const promptMissing = sectionBetween(result.stdout, '## 5. Missing Files', '## 6. Instructions');
+
+  assert.match(promptIssueDocs, /`docs\/issue-mentioned-doc\.md` — issue-mentioned; mentioned in issue/);
+  assert.match(promptIssueSources, /`src\/issue-mentioned-source\.ts` — issue-mentioned; mentioned in issue/);
+  assert.match(promptAutoDocs, /`docs\/diagnostics-guide\.md` — auto-discovered/);
+  assert.match(promptAutoSources, /`src\/diagnostics-source\.ts` — auto-discovered/);
+  assert.match(
+    promptAutoSources,
+    /`src\/auto-discovered-truncation-source\.ts` — auto-discovered; truncated to first \d+ bytes; full file at src\/auto-discovered-truncation-source\.ts/
+  );
+
+  assert.match(
+    promptMissing,
+    /`alias-source\.ts` — not found \(issue-mentioned; mentioned in issue; path alias hint: possible moved path `src\/runtime\/alias-source\.ts` \(same basename; not a confirmed issue reference\)\)/
+  );
+  assert.match(promptMissing, /`src\/missing-issue-source\.ts` — not found \(issue-mentioned; mentioned in issue\)/);
+  assert.match(promptMissing, /`src\/unreadable-source\.ts` — unreadable \(EACCES; [^)]+mentioned in issue\)/);
+  assert.match(promptMissing, /`src\/auto-discovered-read-failed-source\.ts` — read failed \(EIO; auto-discovered\)/);
+
+  assert.match(result.stderr, /Unreadable: src\/unreadable-source\.ts \(EACCES\)/);
+  assert.match(result.stderr, /Read failed: src\/auto-discovered-read-failed-source\.ts \(EIO\)/);
+  assert.doesNotMatch(result.stdout, /TRUNCATION_TAIL_SENTINEL/);
+  assert.doesNotMatch(result.stdout, /ISSUE_MENTIONED_DOC_SENTINEL/);
+  assert.doesNotMatch(result.stdout, /AUTO_DISCOVERED_SOURCE_SENTINEL/);
+});
+
 test('spec plan ignores API and route paths when extracting file references', async (t) => {
   const fixture = await createExplicitPathPlanFixture(t, {
     issueNumber: 83,

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -4385,8 +4385,13 @@ test('spec plan prompt diagnostics-heavy sample stays bounded and reference-orie
 
   assert.match(promptIssueDocs, /`docs\/issue-mentioned-doc\.md` — issue-mentioned; mentioned in issue/);
   assert.match(promptIssueSources, /`src\/issue-mentioned-source\.ts` — issue-mentioned; mentioned in issue/);
+  assert.doesNotMatch(
+    promptIssueSources,
+    /src\/unreadable-source\.ts|src\/missing-issue-source\.ts|alias-source\.ts/
+  );
   assert.match(promptAutoDocs, /`docs\/diagnostics-guide\.md` — auto-discovered/);
   assert.match(promptAutoSources, /`src\/diagnostics-source\.ts` — auto-discovered/);
+  assert.doesNotMatch(promptAutoSources, /src\/auto-discovered-read-failed-source\.ts/);
   assert.match(
     promptAutoSources,
     /`src\/auto-discovered-truncation-source\.ts` — auto-discovered; truncated to first \d+ bytes; full file at src\/auto-discovered-truncation-source\.ts/
@@ -4403,8 +4408,13 @@ test('spec plan prompt diagnostics-heavy sample stays bounded and reference-orie
   assert.match(result.stderr, /Unreadable: src\/unreadable-source\.ts \(EACCES\)/);
   assert.match(result.stderr, /Read failed: src\/auto-discovered-read-failed-source\.ts \(EIO\)/);
   assert.doesNotMatch(result.stdout, /TRUNCATION_TAIL_SENTINEL/);
+  assert.doesNotMatch(result.stdout, /TRUNCATION_HEAD_SENTINEL/);
   assert.doesNotMatch(result.stdout, /ISSUE_MENTIONED_DOC_SENTINEL/);
+  assert.doesNotMatch(result.stdout, /ISSUE_MENTIONED_SOURCE_SENTINEL/);
   assert.doesNotMatch(result.stdout, /AUTO_DISCOVERED_SOURCE_SENTINEL/);
+  assert.doesNotMatch(result.stdout, /ALIAS_SOURCE_SENTINEL/);
+  assert.doesNotMatch(result.stdout, /UNREADABLE_SOURCE_SENTINEL/);
+  assert.doesNotMatch(result.stdout, /AUTO_DISCOVERED_READ_FAILED_SOURCE_SENTINEL/);
 });
 
 test('spec plan ignores API and route paths when extracting file references', async (t) => {


### PR DESCRIPTION
## Summary
- 新增 diagnostics-heavy prompt-mode golden sample
- 覆蓋 missing / unreadable / read failed / alias hint / truncated source metadata 等輸出形狀
- Closes #204

## Scope
- tests/cli.integration.test.ts
- Test-only Layer 1 output stability for prompt mode

## Non-goals
- 不修改 runtime
- 不修改 templates
- 不做 #203 runtime changes
- 不處理 #205 monorepo discovery
- 不處理 #206 zh-TW classifier
- 不處理 #149 remediation loop
- 不修改 target repo

## Validation
- git diff --check
- pnpm build
- pnpm test
- pnpm test:gh not run / not required

## Implementation Evidence
- Branch: test/diagnostics-prompt-golden-204
- Commit hash: 1c7485724d9ef79d6f0f709278b201f196de681f
- Files changed: tests/cli.integration.test.ts
- #120 state: OPEN
- #149 state: OPEN
- #199 / #200 / #203 status: implemented

## Review finding assessment
- CodeRabbit nitpick (`tests/cli.integration.test.ts:4380-4408`) classification: adopted
- Action: fixed `promptIssueSources` and `promptAutoSources` reference-only negative assertions; added source-content sentinel leakage checks in stdout while preserving required stderr diagnostics assertions.
- Validation summary: git diff --check pass; pnpm build pass; pnpm test pass


- Issue evidence comment:
  - https://github.com/Erick52106/spec-injector/issues/204#issuecomment-4408925034
  - https://github.com/Erick52106/spec-injector/issues/204#issuecomment-4408962894



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration tests for the `spec plan --dry-run --format prompt` command, validating proper error handling and output formatting for unreadable files, missing files, and read failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


