### PR TITLE
dogfood(plan): add second brownfield read-only report

### DIFF
--- a/docs/dogfood/vitest-2026-05-09.md
+++ b/docs/dogfood/vitest-2026-05-09.md
@@ -11,8 +11,10 @@
 - Name: `vitest-dev/vitest`
 - URL: https://github.com/vitest-dev/vitest
 - Branch / ref tested: `main`
-- Commit / HEAD under test: shallow clone on `main` at 2026-05-09 local snapshot
+- Commit / HEAD under test: `d77e93659d1703f9d96b58373b38738bf190289e`
 - Target repo status (clean/dirty): clean
+- Target status at readback: clean
+- Reproducibility note: this report is tied to the specific Vitest target commit above, not a floating `main` reference.
 - Why selected:
   - 公開可安全 read-only 存取，非 `tachigo` / `tachiya` / `storefront` / `spec-injector`
   - 真實 brownfield `pnpm` monorepo，含 `AGENTS.md`、`README.md`、`docs/`、`packages/`、`test/`
@@ -45,6 +47,7 @@
 - Target repo context snapshot (docs / files opened / constraints):
   - top-level read-only snapshot showed `AGENTS.md`, `CLAUDE.md`, `README.md`, `CONTRIBUTING.md`, `docs/`, `packages/`, `test/`
   - targeted grep confirmed relevant existing refs such as `packages/vitest/browser/context.d.ts` and `packages/vitest/package.json`
+  - target clone readback confirmed HEAD `d77e93659d1703f9d96b58373b38738bf190289e` with clean status
 - Dogfood run arguments or command intent:
   - baseline: external minimal config + `--dry-run --format prompt --verbose`
   - second pass: external monorepo-aware config + `--dry-run --format prompt --verbose`
@@ -65,6 +68,7 @@
 
 ### Target repo safety preflight
 - `git clone --depth 1 https://github.com/vitest-dev/vitest /tmp/spec-injector-dogfood-vitest-20260509`
+- `git rev-parse HEAD`
 - `git status --short`
 - `git branch --show-current`
 - `git remote -v`

--- a/docs/dogfood/vitest-2026-05-09.md
+++ b/docs/dogfood/vitest-2026-05-09.md
@@ -1,0 +1,296 @@
+# Dogfood Report Template (Read-Only)
+
+> 第二個 brownfield dogfood。僅執行 read-only `spec plan` 驗證，不修改 target repo、不建立 `.spec-injector/`、不做 target repo implementation。
+
+## Goal
+- 以陌生的 non-tachigo / non-spec-injector 公開 repo 驗證 `spec plan` 在 brownfield monorepo 的 deterministic issue-to-context usefulness。
+- 記錄 true positives、false positives、false negatives、scope gaps 與 diagnostics quality。
+- 評估是否已有足夠 evidence 支撐 #120 showcase，並判斷 #205 / #206 是否值得繼續。
+
+## Target repository
+- Name: `vitest-dev/vitest`
+- URL: https://github.com/vitest-dev/vitest
+- Branch / ref tested: `main`
+- Commit / HEAD under test: shallow clone on `main` at 2026-05-09 local snapshot
+- Target repo status (clean/dirty): clean
+- Why selected:
+  - 公開可安全 read-only 存取，非 `tachigo` / `tachiya` / `storefront` / `spec-injector`
+  - 真實 brownfield `pnpm` monorepo，含 `AGENTS.md`、`README.md`、`docs/`、`packages/`、`test/`
+  - Issue [vitest-dev/vitest#10280](https://github.com/vitest-dev/vitest/issues/10280) 直接涉及 npm workspaces / monorepo resolution，能測 discovery friction
+- Sensitivity check:
+  - public OSS repo
+  - 未讀取 secrets / tokens / `.env`
+  - report 不貼長段 source，只記錄摘要與 file references
+- Repo type / monorepo status:
+  - TypeScript/JavaScript monorepo
+  - `pnpm-workspace.yaml` 存在
+  - 多 package 結構明顯，適合測 #205 類型的 docs/guidance 需求
+
+## Safety checklist
+- [x] target repo remains read-only
+- [x] do not run `spec init` in target repo
+- [x] do not create `.spec-injector/` in target repo
+- [x] do not commit / push / branch in target repo
+- [x] do not modify target repo files
+- [x] do not paste sensitive source content or large private snippets
+- [x] stop if target repo is dirty or uncertain
+- [x] use external config path if repo-specific config is needed
+- [x] record commands run
+- [x] record no target repo mutation
+
+## Inputs
+- Source issue / request under test:
+  - `vitest-dev/vitest#10280`
+  - Title: `Types exports from vitest/browser are not found by typescript when using npm workspaces`
+- Target repo context snapshot (docs / files opened / constraints):
+  - top-level read-only snapshot showed `AGENTS.md`, `CLAUDE.md`, `README.md`, `CONTRIBUTING.md`, `docs/`, `packages/`, `test/`
+  - targeted grep confirmed relevant existing refs such as `packages/vitest/browser/context.d.ts` and `packages/vitest/package.json`
+- Dogfood run arguments or command intent:
+  - baseline: external minimal config + `--dry-run --format prompt --verbose`
+  - second pass: external monorepo-aware config + `--dry-run --format prompt --verbose`
+- Local constraints (monorepo / permissions / access):
+  - target repo must remain untouched
+  - config must stay outside target repo
+  - no `.spec-injector/` bootstrap allowed in target repo
+
+## Commands run
+### Preconditions
+- `git checkout main`
+- `git pull --ff-only`
+- `git status --short`
+- `gh pr list --repo Erick52106/spec-injector --state open --json number,title,headRefName,files,url`
+- `gh issue view 198|201|202|120|149|195|196|197 ...`
+- `test -f docs/dogfood/TEMPLATE.md`
+- `git worktree add -b docs/second-brownfield-dogfood-202 ../spec-injector-202 main`
+
+### Target repo safety preflight
+- `git clone --depth 1 https://github.com/vitest-dev/vitest /tmp/spec-injector-dogfood-vitest-20260509`
+- `git status --short`
+- `git branch --show-current`
+- `git remote -v`
+
+### Commands
+- `pnpm install --frozen-lockfile`
+- `pnpm build`
+- `node bin/spec.js plan --help`
+- `node bin/spec.js plan https://github.com/vitest-dev/vitest/issues/10280 --repo /tmp/spec-injector-dogfood-vitest-20260509 --config /tmp/spec-vitest-minimal-20260509.json --dry-run --format prompt --verbose`
+- `node bin/spec.js plan https://github.com/vitest-dev/vitest/issues/10280 --repo /tmp/spec-injector-dogfood-vitest-20260509 --config /tmp/spec-vitest-targeted-20260509.json --dry-run --format prompt --verbose`
+
+## Environment / tool versions, if known
+- Node: local `node` used from `spec-injector` worktree build environment
+- pnpm: local `pnpm` used from `spec-injector` worktree
+- OS / shell: macOS / `zsh`
+- Runtime env vars: none added for dogfood
+- External config path (if used):
+  - `/tmp/spec-vitest-minimal-20260509.json`
+  - `/tmp/spec-vitest-targeted-20260509.json`
+
+## Issue / request under test
+- Request title: `Types exports from vitest/browser are not found by typescript when using npm workspaces`
+- Request owner / link: `vitest-dev/vitest#10280`
+- Expected evidence scope:
+  - `vitest/browser` type export path
+  - workspace / optional peer dependency resolution
+  - monorepo package boundaries
+- Linked issue / PR context:
+  - no linked PR assumed in this dogfood
+  - issue language is English
+
+## Expected behavior
+- Expected `spec plan` behavior:
+  - identify the browser export path as a key source reference
+  - surface monorepo/workspace-specific context instead of generic docs noise
+  - provide actionable diagnostics when path resolution is ambiguous
+- Expected confidence / determinism expectations:
+  - read-only prompt should converge on a bounded set of browser/workspace files
+  - diagnostics should explain misses without requiring target repo mutation
+- Expected review thread / findings state assumptions:
+  - none; this is issue-to-context planning only
+
+## Observed output summary
+- Command outputs (sanitized):
+  - baseline run succeeded with `exit=0`, 95 lines
+  - monorepo-aware config run succeeded with `exit=0`, 105 lines
+- Exit code summary:
+  - both `spec plan` runs succeeded
+  - no target repo write was observed
+- Major observations:
+  - baseline run detected the issue and produced a compact prompt, but failed to find the key path `vitest/browser/context.d.ts`
+  - baseline run provided an alias hint and auto-discovered several docs, but found no source files
+  - monorepo-aware config improved repo-context loading (`AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `CLAUDE.md`) and surfaced source files, but many were noisy / weakly related
+  - monorepo-aware config produced `EISDIR` read-failed diagnostics for `docs` and `packages`, revealing ambiguity around directory-style config inputs
+  - neither run converged on the exact existing file `packages/vitest/browser/context.d.ts`
+- Confidence flags (if any):
+  - usable as a workflow evidence point
+  - not strong enough to claim high-precision monorepo source convergence yet
+
+## Source reference precision
+- 目標參考是否被成功收斂：
+  - 主要參考部分成功：issue clearly points to `vitest/browser/context.d.ts`, but planner missed the actual repo path `packages/vitest/browser/context.d.ts`
+  - 來源鏈有落空：沒有收斂到 `packages/vitest/package.json`、`test/config/package.json` 或 browser-related test fixtures
+  - 參考順序不穩定：second pass 加入 config 後，source refs 數量增加，但 precision 明顯下降
+- 參考 precision / recall 問題摘要：
+  - precision 問題：出現 `github-actions.ts`、`vm/types.ts`、`core.ts` 等弱相關 source refs
+  - recall 問題：漏掉 issue body 最關鍵的 existing path 與 workspace-adjacent package metadata
+
+## Diagnostics quality
+- Reported diagnostics 是否具體可操作：
+  - good: missing file diagnostics 明確指出 `vitest/browser/context.d.ts` not found，並提供 alias hint
+  - good: truncation metadata 清楚標示 `truncated to first 500 bytes`
+  - mixed: `EISDIR` 能提醒 config 使用方式不對，但沒有直接說明 discovery docs/source 是否應填 file path、glob、還是 directory root
+- 失真或過度含糊處：
+  - alias hint 偏向 `packages/browser-*` candidates，卻沒有提升到實際更接近 issue 的 `packages/vitest/browser/context.d.ts`
+  - domain detection 抓到 `docs`、`ci`、`frontend`，對這個 issue 而言偏噪音
+- 輸出中缺少的關鍵欄位：
+  - lack of stronger ranking/explanation for why certain source files were chosen
+  - no explicit signal that monorepo package export metadata should be prioritized
+
+## True positives
+- 可被實際採納的發現：
+  - issue was fetched and classified successfully
+  - missing-path diagnostic correctly recognized `vitest/browser/context.d.ts` as a key unresolved reference
+  - repo-level AI guidance files (`AGENTS.md`, `CLAUDE.md`) and core docs were discoverable in a read-only workflow
+  - truncation metadata was explicit instead of silently shortening source output
+- 為何可採納（含證據）：
+  - both runs exited cleanly and produced bounded prompts without any target repo mutation
+  - the missing-file diagnostic plus alias hint is materially better than silent omission
+
+## False positives
+- 可能為誤報的發現：
+  - detected domains `docs` and `ci`
+  - auto-discovered source files such as `packages/vitest/src/node/reporters/github-actions.ts`, `packages/vitest/src/runtime/vm/types.ts`, `packages/vitest/src/node/core.ts`
+  - baseline auto-discovered docs like file-system mocking docs that are only weakly related
+- 為何判斷為 FP：
+  - the issue is centered on browser type exports and workspace resolution, not GitHub Actions, VM runtime internals, or file-system mocking guidance
+
+## False negatives
+- 可能漏掉但重要的現象：
+  - `packages/vitest/browser/context.d.ts`
+  - `packages/vitest/package.json`
+  - workspace-adjacent package metadata and tests such as `test/config/package.json` or browser type tests
+- 漏掉原因（權限、截斷、噪音、流程限制）：
+  - issue path alias `vitest/browser/context.d.ts` was treated too literally
+  - monorepo package-root inference was not strong enough
+  - config guidance for directory-style discovery inputs is underspecified
+
+## Scope gaps
+- 本次 dogfood 未覆蓋但屬於流程或實作界外的項目：
+  - no runtime fix attempt
+  - no reproduction checkout of the separate reproduction repo
+  - no target repo implementation or validation inside Vitest itself
+- 建議拆 issue 的 follow-up：
+  - docs/guidance around monorepo discovery roots and file-vs-directory config expectations
+  - optional future fixture for alias-to-package-root path resolution
+
+## Monorepo / brownfield friction
+- Monorepo 導覽成本與障礙：
+  - issue refers to a virtual/export path while the actual file lives under a package subpath
+  - brownfield monorepo creates many plausible but weakly related candidates
+- Brownfield 文件/設定噪音：
+  - repo-level docs are abundant and discoverable, but source ranking becomes noisy quickly
+  - directory-style discovery config produced `EISDIR`, which is easy for a first-time user to hit
+- 權限與讀取邊界限制：
+  - read-only mode worked cleanly
+  - external config avoided any target repo bootstrap
+- 是否需要 #205 monorepo docs：
+  - yes, evidence supports continuing #205
+  - highest-value area is not new runtime logic first; it is clearer guidance for monorepo discovery defaults, path-shape expectations, and troubleshooting
+- 是否需要 implementation later：
+  - maybe, but this run mainly justifies docs/guidance first
+- 是否只是 config guidance 即可：
+  - partial yes; better docs/config examples look immediately useful
+  - however, exact-path false negatives suggest runtime heuristics may still deserve later follow-up if docs alone prove insufficient
+
+## zh-TW / language friction, if any
+- 用詞/命名歧義：
+  - no direct zh-TW issue-language signal in this target issue
+- 需求與 CLI output 的語言對齊問題：
+  - target issue and prompt output were fully English
+  - no classifier miss tied specifically to Traditional Chinese was observed
+- 需要補齊的中英對照：
+  - none discovered in this run
+- 是否需要 #206 zh-TW classifier：
+  - evidence from this dogfood alone is insufficient to justify proceeding
+  - keep #206 as conditional follow-up pending a repo/issue with real zh-TW phrasing
+
+## Context boundary / truncation / omission observations
+- 觀測到截斷 / 省略：
+  - second pass source refs were explicitly truncated to first 500 bytes
+- 忽略區段可能影響判斷的原因：
+  - truncation preserves safety/readability, but makes it harder to understand why a noisy source file was chosen
+- 輸出省略的可補充方式：
+  - keep truncation metadata
+  - improve ranking rationale rather than emitting more raw source
+
+## AI usability notes
+- 對 AI 實作者最有價值的資訊：
+  - issue summary
+  - missing-file diagnostic
+  - repo AI guidance files
+  - clear statement that planning is read-only and scope-bounded
+- 易讓 AI 進入錯誤假設的段落：
+  - broad detected domains
+  - noisy auto-discovered source list that does not clearly separate strong from weak evidence
+- 可加入的可讀性強化建議：
+  - prioritize package export metadata when issue mentions virtual module paths
+  - distinguish exact path hit vs alias guess vs same-basename candidate
+  - document valid monorepo discovery config patterns more explicitly
+- AI 是否能根據 prompt 產出 reasonable plan：
+  - partially yes
+  - enough to propose a cautious investigation plan
+  - not enough to confidently enumerate the best fix files without manual follow-up reading
+- 哪些 context 有幫助：
+  - repo AI docs and monorepo identity
+  - missing-path diagnostics
+- 哪些 context 多餘：
+  - weakly related CI/runtime files
+- 是否容易誤解 future / current boundary：
+  - low risk in this run; prompt still clearly framed planning, not autonomous editing
+
+## Follow-up recommendations
+- 建議的新 issue / follow-up:
+  - no new issue created in this run
+  - #205 should continue with emphasis on monorepo discovery defaults, path-shape examples, and directory-input troubleshooting
+- 建議修正流程順序：
+  - prefer docs/guidance before new heuristic work
+  - re-run a future dogfood on a zh-TW issue before deciding #206
+- 是否建議再跑一次 dogfood（可選）：
+  - yes, but only when a repo/issue offers either real zh-TW text or a different monorepo topology
+- continue / adjust #205?
+  - continue
+  - adjust scope toward user guidance first
+- continue / adjust #206?
+  - do not proceed yet based on this evidence alone
+- any docs caveat?
+  - clarify whether `discovery.docs` / `discovery.source` expect files, directories, or both
+- any test fixture idea?
+  - future fixture around alias path `vitest/browser/context.d.ts` mapping to package-root file
+- no immediate action if evidence insufficient
+
+## Final verdict
+- Verdict: WARN
+- Rationale:
+  - this dogfood does provide a legitimate second brownfield evidence point for #120 because it exercised a public, unfamiliar, non-tachigo monorepo in read-only mode
+  - it did not reveal a blocker for showcase direction, but it did reveal meaningful precision/recall limitations and monorepo-config friction
+  - evidence strongly supports #205
+  - evidence does not yet support #206
+  - target repo remained untouched throughout
+- Next action:
+  - land this report
+  - continue #205 with docs-first framing
+  - keep #206 conditional
+- Re-test condition:
+  - after improved monorepo discovery guidance or after selecting a real zh-TW target issue
+- `spec-injector` 影響範圍（僅 workflow insight / 無 runtime mutation）:
+  - workflow insight only
+  - no runtime mutation
+- Does this dogfood support continuing toward #120 showcase?
+  - yes, with caution
+- Does it reveal blocker?
+  - no hard blocker
+- Does it suggest #205 should proceed?
+  - yes
+- Does it suggest #206 should proceed?
+  - not yet
+- Did target repo remain untouched?
+  - yes


### PR DESCRIPTION
## Summary
- second brownfield dogfood report
- target repo read-only validation
- #120 readiness evidence
- Closes #202

## Scope
- docs/dogfood/vitest-2026-05-09.md

## Non-goals
- 不指定未來唯一 target repo
- 不修改 target repo
- 不執行 target repo implementation
- 不修改 runtime
- 不修改 tests
- 不修改 CI
- 不實作 #205 / #206
- 不關閉 #120
- 不處理 #149 remediation loop

## Validation
- git diff --check
- pnpm build
- pnpm test
- pnpm test:gh not run / not required

## Implementation Evidence
- Branch: `docs/second-brownfield-dogfood-202`
- Commit hash: `faaabbec74c107ee51aa877777fdfc149ef8c38a`
- Files changed: `docs/dogfood/vitest-2026-05-09.md`
- target repo remained read-only
- target repo commit / HEAD: `d77e93659d1703f9d96b58373b38738bf190289e`
- target repo status at readback: clean
- #120 state: OPEN
- #149 state: OPEN
- #201 status: implemented
- issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/202#issuecomment-4408945809
- issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/202#issuecomment-4408977202

## Review finding assessment
- Codex finding on `docs/dogfood/vitest-2026-05-09.md`: classification `adopted`
- Action: recorded the exact Vitest target HEAD, clean readback status, and clarified that the report is tied to that specific target commit rather than floating `main`
- Validation: `git diff --check`, `pnpm build`, and `pnpm test` passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new verification report documenting test results, diagnostic observations, and findings from a comprehensive validation run, including recommendations for continued improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
