### PR TITLE
docs(workflow): add compact PR and issue evidence templates

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -76,6 +76,12 @@
 - metadata-only:
   - required: `gh pr view` / `gh issue view` readback（無 repo file change）
 
+## Compact evidence template quick view
+- PR body section order（compact）：`Summary`、`Scope`、`Non-goals`、`Validation`、`Implementation Evidence`、`Review finding assessment`
+- Implementation evidence comment 需含：
+  - Source issue / PR URL、branch、HEAD、files changed、scope / non-goals、validation、#120 / #149 state、readback、target repo mutation no、human merge boundary
+- full fields 在 `docs/workflow.md` 對應的 compact template section
+
 ## Do not do
 - no stash / clean / reset（除非 human 明確授權）
 - no target repo mutation（含 commit / push / branch / file edit / `.spec-injector/` / `spec init`）

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -420,7 +420,6 @@ Evidence comment 應包含：
 - Evidence-check boundary:
   - PASS ≠ merge approval
   - human merge approval required
-- Issue evidence URL: <paste permanent comment URL>
 ```
 
 ### PR body template

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -428,7 +428,7 @@ Evidence comment 應包含：
 ```text
 ## Summary
 - compact description
-- Closes #208
+- Closes #<issue-number>
 
 ## Scope
 - related issue / PR URL:

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -381,6 +381,158 @@ Evidence comment 應包含：
 
 若 evidence comment URL 需要回填 PR body，先建立 PR，再貼 issue comment，取得永久 comment URL 後更新 PR body，最後反查 PR body。
 
+## Compact evidence templates
+
+以下為 compact 版本，保留 evidence-check 所需欄位，但減少重複填寫。實際流程與權限邊界仍以本文件、`docs/validation.md` 與人類 merge 決策為準。
+
+### Implementation evidence comment template
+
+```text
+## Implementation evidence
+
+- Source issue URL:
+- PR URL:
+- Branch:
+- HEAD / commit hash:
+- Files changed:
+  - `path/to/file.md`
+- Scope:
+  - in-scope: ...
+  - out-of-scope: ...
+- Non-goals:
+  - 不放寬 evidence-check 要求
+  - 不代替 human merge decision
+  - 不修改 runtime / tests / CI / package script
+- Validation:
+  - git diff --check
+  - pnpm build
+  - pnpm test
+  - pnpm test:gh: not run / not required
+- Readback:
+  - PR body readback: VERIFIED
+  - Issue evidence readback: VERIFIED
+- Protected issue state:
+  - #120:
+  - #149:
+- Target repo safety:
+  - target repo mutation: no
+  - hidden mutation: no
+- Evidence-check boundary:
+  - PASS ≠ merge approval
+  - human merge approval required
+- Issue evidence URL: <paste permanent comment URL>
+```
+
+### PR body template
+
+```text
+## Summary
+- compact description
+- Closes #208
+
+## Scope
+- related issue / PR URL:
+- files changed:
+  - `docs/workflow.md`
+  - `docs/cheatsheet.md`
+- branch:
+- non-goals:
+  - 不放寬 evidence-check required section
+  - 不移除 readback verification
+  - 不移除 human merge authority
+  - 不新增 automation
+
+## Non-goals
+- 不修改 runtime
+- 不修改 tests
+- 不修改 CI
+- 不 close #120
+- 不處理 #149 remediation loop
+- 不修改 target repo
+
+## Validation
+- git diff --check
+- pnpm build
+- pnpm test
+- pnpm test:gh: not run / not required
+
+## Implementation Evidence
+- PR URL:
+- Branch:
+- Commit hash / HEAD:
+- Files changed:
+  - `...`
+- issue evidence URL:
+- PR body readback URL:
+- issue evidence readback URL:
+- #120 state:
+- #149 state:
+- target repo mutation confirmation: no
+
+## Review finding assessment
+- No automated findings yet.
+- If findings exist, add compact matrix below:
+  - source: CodeRabbit / Codex / human
+  - location: path#Lx (if any)
+  - classification: adopted / not adopted / optional polish / noise / not applicable / needs human review
+  - action:
+    - adopted: fix with evidence
+    - not adopted / noise / not applicable / optional polish: leave rationale
+    - needs human review: stop-and-report
+```
+
+### Review finding assessment template
+
+```text
+## Finding assessment
+
+- source:
+- location:
+- classification: adopted / not adopted / optional polish / noise / not applicable / needs human review
+- action:
+- rationale:
+- validation / evidence:
+- blocking?: yes / no
+```
+
+### Merge closeout summary template
+
+```text
+## Merge closeout summary
+
+- Merge method: squash / merge / rebase
+- Merge commit / squash commit:
+- Final HEAD:
+- PR URL:
+- issue URL:
+- Files changed:
+  - `...`
+- Validation / checks:
+  - gh pr checks:
+  - pnpm build:
+  - pnpm test:
+- Review closeout:
+  - actionable finding count:
+  - adopted findings and follow-up status:
+  - unresolved human-required finding: none
+- Issue state:
+  - #120:
+  - #149:
+- issue evidence URL:
+- PR body readback URL:
+- closeout comment URL:
+- Human merge decision:
+  - approved by human: yes / no
+  - auto-merge / auto-close: no
+- Cleanup:
+  - branch/worktree cleanup performed here: no
+```
+
+### Human decision boundary
+
+- PR body / issue evidence 寫入後仍需 readback verify。
+- `spec evidence-check` PASS 僅代表欄位完整；最終 merge 權限仍屬 human。
+
 ## Concurrency rules
 
 可併發：


### PR DESCRIPTION
## Summary
- 新增 compact implementation evidence / PR body / review finding / merge closeout templates。
- 保留 canonical workflow / validation policy，並維持 readback verification 與 human merge decision。
- Closes #208

## Scope
- docs/workflow.md
- docs/cheatsheet.md
- AGENTS.md (if changed: no)
- docs/validation.md (if changed: no)
- related PR URL: https://github.com/Erick52106/spec-injector/pull/215
- branch: `docs/compact-evidence-templates-208`

## Non-goals
- 不放寬 evidence-check required sections。
- 不移除 readback verification。
- 不移除 human merge authority。
- 不新增 automation。
- 不修改 runtime。
- 不修改 tests。
- 不修改 CI。
- 不修改 package scripts。
- 不處理 #149 remediation loop。
- 不關閉 #120。
- 不修改 target repo。

## Validation
- git diff --check
- pnpm build
- pnpm test
- pnpm test:gh not run / not required

## Implementation Evidence
- Branch: `docs/compact-evidence-templates-208`
- Commit hash / HEAD: `4129d6037dfe94767250656b8ad27f5d17f5b5f4`
- Files changed:
  - `docs/workflow.md`
  - `docs/cheatsheet.md`
- Related issue / PR URL:
  - issue: https://github.com/Erick52106/spec-injector/issues/208
  - PR: https://github.com/Erick52106/spec-injector/pull/215
- issue evidence URL:
  - https://github.com/Erick52106/spec-injector/issues/208#issuecomment-4409021605
  - https://github.com/Erick52106/spec-injector/issues/208#issuecomment-4409041336
  - https://github.com/Erick52106/spec-injector/issues/208#issuecomment-4409117748
- PR body readback:
  - status: verified
  - HEAD check: `4129d6037dfe94767250656b8ad27f5d17f5b5f4`
- Issue evidence readback:
  - status: verified
  - comment URL: https://github.com/Erick52106/spec-injector/issues/208#issuecomment-4409041336
- Scope / non-goals:
  - compact templates only, no behavior logic changes
  - no workflow automation added
- target repo safety:
  - mutation: none
  - hidden mutation claim: none
- #120 state: OPEN
- #149 state: OPEN

## Review finding assessment
- Codex finding (adopted): replace reusable template `Closes #208` with placeholder `Closes #<issue-number>` to避免其他 issue 複製時誤導 evidence-check 或對錯 issue 執行 readback。
- CodeRabbit finding (adopted): remove misplaced issue evidence URL from issue evidence comment template.
  - Source: CodeRabbit
  - Classification: adopted
  - Action: removed misplaced issue evidence URL from issue evidence comment template
  - Validation: `git diff --check` / `pnpm build` / `pnpm test` pass
- validation: git diff --check / pnpm build / pnpm test pass
- No automated findings pending.
- Future findings must be classified before changes with one of: adopted / not adopted / optional polish / noise / not applicable / needs human review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "Compact evidence templates" section with reusable templates for PR bodies, implementation evidence comments, review-finding assessments, merge closeout summaries, and human decision boundaries.
  * Added a quick-reference "Compact evidence template quick view" describing required compact PR evidence contents (links/IDs, files changed, scope/non-goals, validation, state/readback, verification) and clarifying that PASS ≠ merge approval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
