### PR TITLE
docs(discovery): document monorepo path guidance

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -204,6 +204,19 @@ Prompt output with `--format prompt` is shorter and designed for AI planning. It
 
 Task package details are documented in [docs/task-package.md](docs/task-package.md).
 
+Monorepo/discovery caveat:
+
+- `discovery.docs` and `discovery.source` are bounded, heuristic discovery inputs and are **not** a complete monorepo / workspace resolver.
+- For monorepo repos, prefer explicit package-level paths (for example):
+  - `packages/<name>/README.md`
+  - `packages/<name>/docs/...`
+  - `packages/<name>/package.json`
+  - `apps/<name>/README.md`
+  - `apps/<name>/docs/...`
+- If a configured path is a directory but expected as a file, `read failed (EISDIR)` can appear; treat it as a directory-vs-file input issue and adjust config explicitly.
+- `path alias hints` are diagnostic only and are not confirmed issue references; virtual import paths are not guaranteed to be automatically mapped to package internals by runtime today.
+- For stronger monorepo context, keep discovery explicit and consult [docs/source-trust.md](docs/source-trust.md) and [docs/issue-to-context-pipeline.md](docs/issue-to-context-pipeline.md).
+
 ## Concepts
 
 Key terms used across this project:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ Broader deterministic request-to-context adapters for fuzzy requests、markdown 
 - 現況 runtime 已輸出 source labels / source categories、bounded snippets / item-count limits、可視化 diagnostics。
 - 現況 runtime 尚未實作完整 trust-level policy engine，也尚未實作 token / byte budget 演算法。
 
+補充（monorepo / discovery）：
+- `discovery.docs` 與 `discovery.source` 是 **bounded、啟發式** 的候選來源；目前不保證能完整還原 monorepo package / workspace 解讀。
+- Brownfield monorepo 請盡量改用明確 package-level 路徑，例如：
+  - `packages/<name>/README.md`
+  - `packages/<name>/docs/...`
+  - `packages/<name>/package.json`
+  - `apps/<name>/README.md`
+  - `apps/<name>/docs/...`
+- 導入文件路徑時，若出現 `read failed (EISDIR)`，代表可能把資料夾當成檔案 path，需回到 [docs/source-trust.md](docs/source-trust.md) 與 [docs/issue-to-context-pipeline.md](docs/issue-to-context-pipeline.md) 的 directory / file guidance。
+- `path alias hints` 僅為診斷訊號，不等於 `issue-mentioned` 確認引用；虛擬 import 路徑也不代表 CLI 已完整映射到實際 package 檔案。
+
 ## Why this exists
 
 AI coding agent 常見的失誤不是「不會寫程式」，而是開工前沒有足夠清楚的邊界：

--- a/docs/issue-to-context-pipeline.md
+++ b/docs/issue-to-context-pipeline.md
@@ -144,10 +144,9 @@ Current discovery is deterministic and bounded; it is designed for initial conte
 For monorepo repos, use explicit package-level discovery paths first:
 
 - `packages/<name>/README.md`
-- `packages/<name>/docs/...`
-- `packages/<name>/package.json`
+- `packages/<name>/docs/architecture.md`
 - `apps/<name>/README.md`
-- `apps/<name>/docs/...`
+- `apps/<name>/docs/usage.md`
 
 Example config shape (sanitized):
 
@@ -156,11 +155,11 @@ Example config shape (sanitized):
   "discovery": {
     "docs": [
       "packages/<name>/README.md",
-      "packages/<name>/docs"
+      "packages/<name>/docs/architecture.md"
     ],
     "source": [
-      "packages/<name>/src/index.ts",
-      "packages/<name>/package.json"
+      "packages/<name>/src",
+      "packages/<name>/browser"
     ]
   }
 }
@@ -169,12 +168,14 @@ Example config shape (sanitized):
 Virtual/export path handling guidance:
 
 - If an issue mentions `vitest/browser/context.d.ts`, actual source may live under `packages/vitest/browser/context.d.ts`.
-- Add the concrete package file path explicitly to `discovery.source` when possible.
+- Current CLI `discovery.source` 行為只走目錄式來源，不保證可設定單一 file path；請視為 issue-mentioned 參考線索而非已實作的 explicit file config 支援。
+- 如需這類 file-level support，建議另開 follow-up issue；本次不在 #205 內實作。
 
 Troubleshooting `EISDIR`:
 
-- If you see `read failed (EISDIR)` for a configured path, verify whether the config entry points to a directory while the current discovery mode expects a file path in that spot.
-- Use explicit file paths or current supported discovery patterns in `.spec-injector/config.json` before adding broader workspace assumptions.
+- If you see `read failed (EISDIR)` for a configured path, verify whether the config entry shape matches current field expectations.
+- For `discovery.docs`, prefer explicit Markdown files; directory paths may trigger `read failed (EISDIR)` with current explicit-file loading.
+- For `discovery.source`, prefer directory roots that exist in the repo and are intended for recursive scanning.
 
 ### Evidence tie-in
 

--- a/docs/issue-to-context-pipeline.md
+++ b/docs/issue-to-context-pipeline.md
@@ -129,3 +129,55 @@ When this map is reused in README later:
 - [ ] Does it avoid hosted dashboard, RAG, hidden planner claims?
 - [ ] Does it avoid companion runtime / Spec Cat UI as current?
 - [ ] Does it keep #149 remediation loop out of current flow?
+
+## 9. Monorepo discovery guidance (Issue #205 docs-only follow-up)
+
+Current discovery is deterministic and bounded; it is designed for initial context collection and not a full monorepo resolver.
+
+- `issue-mentioned references` are treated differently from auto-discovered references.
+- `path alias hints` are weak diagnostic signals and are not confirmed issue references.
+- `missing`, `unreadable`, and `read failed` diagnostics (including `read failed (EISDIR)`) are expected outputs when configured paths are unreadable or directory inputs are not aligned.
+- Source snippets can be truncated when bounded output policy applies, and truncation reasons should remain visible.
+
+### Practical monorepo guidance
+
+For monorepo repos, use explicit package-level discovery paths first:
+
+- `packages/<name>/README.md`
+- `packages/<name>/docs/...`
+- `packages/<name>/package.json`
+- `apps/<name>/README.md`
+- `apps/<name>/docs/...`
+
+Example config shape (sanitized):
+
+```json
+{
+  "discovery": {
+    "docs": [
+      "packages/<name>/README.md",
+      "packages/<name>/docs"
+    ],
+    "source": [
+      "packages/<name>/src/index.ts",
+      "packages/<name>/package.json"
+    ]
+  }
+}
+```
+
+Virtual/export path handling guidance:
+
+- If an issue mentions `vitest/browser/context.d.ts`, actual source may live under `packages/vitest/browser/context.d.ts`.
+- Add the concrete package file path explicitly to `discovery.source` when possible.
+
+Troubleshooting `EISDIR`:
+
+- If you see `read failed (EISDIR)` for a configured path, verify whether the config entry points to a directory while the current discovery mode expects a file path in that spot.
+- Use explicit file paths or current supported discovery patterns in `.spec-injector/config.json` before adding broader workspace assumptions.
+
+### Evidence tie-in
+
+- The Vitest dogfood report `docs/dogfood/vitest-2026-05-09.md` (WARN verdict) shows monorepo path inference and directory input friction.
+- This supports documentation-first follow-up, and it does not itself justify a runtime monorepo walker in this issue.
+- It also does not imply runtime zh-TW classifier changes.

--- a/docs/source-trust.md
+++ b/docs/source-trust.md
@@ -280,25 +280,32 @@ Current auto-discovery 的定位是 deterministic 且 bounded；它能提供 bou
 
 - Brownfield monorepo 請優先使用 package / app 層級路徑：
   - `packages/<name>/README.md`
-  - `packages/<name>/docs/...`
-  - `packages/<name>/package.json`
+  - `packages/<name>/docs/architecture.md`
   - `apps/<name>/README.md`
-  - `apps/<name>/docs/...`
+  - `apps/<name>/docs/usage.md`
 - 虛擬/匯出路徑示例：
   - issue 可能提到 `vitest/browser/context.d.ts`
   - 實際檔案可能位於 `packages/vitest/browser/context.d.ts`
-  - 當你已知 package 實體位置，請直接把實體檔放進 `discovery.source`，不要假設 runtime 一定自動映射 alias。
+  - `discovery.source` 目前僅保證支援目錄輸入；issue path 無法直接當作已驗證的 `discovery.source` file entry。
+  - 若 issue 確認到實際檔案，請用 issue-mentioned 路徑納入上下文，並在 #205 之外另開 follow-up 討論 explicit file support。
+- 可放入 `discovery.source` 的常用目錄範例（非完整清單）：
+  - `packages/<name>/src`
+  - `packages/<name>/browser`
+  - `apps/<name>/src`
 
 ```json
 {
   "discovery": {
     "docs": [
       "packages/<name>/README.md",
-      "packages/<name>/docs"
+      "packages/<name>/docs/architecture.md",
+      "apps/<name>/README.md",
+      "apps/<name>/docs/usage.md"
     ],
     "source": [
-      "packages/<name>/package.json",
-      "packages/<name>/src/index.ts"
+      "packages/<name>/src",
+      "packages/<name>/browser",
+      "apps/<name>/src"
     ]
   }
 }
@@ -307,7 +314,7 @@ Current auto-discovery 的定位是 deterministic 且 bounded；它能提供 bou
 ### Directory input 與 `EISDIR` 的排障
 
 - 若看到 `read failed (EISDIR)`，先確認該路徑在設定上是否是「應為檔案卻填了目錄」。
-- 建議改為明確 file path，或先縮小到更小 scope 的目錄（例如 `packages/<name>/docs`）再逐步擴展。
+- 建議改為對應欄位可接受的形態（docs 用明確 md 檔，source 用目錄根），或先縮小到更小 scope 的目錄（例如 `packages/<name>/src`）再逐步擴展。
 - 若仍需要更完整套件推斷，請以 follow-up issue 紀錄，保持 runtime 行為不變（避免超出 #205 non-goals）。
 
 ### 狗食報告依據

--- a/docs/source-trust.md
+++ b/docs/source-trust.md
@@ -263,3 +263,55 @@ These criteria are for future implementation issues, not this PR's runtime behav
 | Not implemented | Not implemented | full trust-level runtime policy engine；token / byte budget algorithm；hidden scoring；semantic RAG / vector search；hidden summarization；LLM confidence |
 
 Issue `#149` remains parked / design-only. It is not current behavior and must not be implemented as auto-fix / auto-resolve / auto-merge / auto-close or target-repo mutation.
+
+## Monorepo discovery behavior and path-shape guidance
+
+### Current behavior (docs-only interpretation)
+
+Current auto-discovery 的定位是 deterministic 且 bounded；它能提供 bounded initial context，但不是完整 monorepo/package/workspace resolver。
+
+- `issue-mentioned paths` 與 `auto-discovered references` 的處理順序不同：issue 明確提到的 path 仍保有較高權重；alias hint 仍是診斷訊號。
+- `path alias hints` 不會被提升為 confirmed source；它們是 `diagnostic` / `ambiguous` 的輔助線索。
+- `missing` / `unreadable` / `read failed`（含 `read failed (EISDIR)`）是預期 diagnostic 輸出的一部份，需納入排錯流程。
+- source snippet 可能被截斷，且會保留截斷原因與 trust label，避免誤以為完整讀取。
+- `discovery.docs` / `discovery.source` 的目錄項目不一定會被視為遞迴套件級 discover；若未明確支援，請用更明確的 file/path pattern 設定。
+
+### Monorepo docs/source 設定建議（current docs）
+
+- Brownfield monorepo 請優先使用 package / app 層級路徑：
+  - `packages/<name>/README.md`
+  - `packages/<name>/docs/...`
+  - `packages/<name>/package.json`
+  - `apps/<name>/README.md`
+  - `apps/<name>/docs/...`
+- 虛擬/匯出路徑示例：
+  - issue 可能提到 `vitest/browser/context.d.ts`
+  - 實際檔案可能位於 `packages/vitest/browser/context.d.ts`
+  - 當你已知 package 實體位置，請直接把實體檔放進 `discovery.source`，不要假設 runtime 一定自動映射 alias。
+
+```json
+{
+  "discovery": {
+    "docs": [
+      "packages/<name>/README.md",
+      "packages/<name>/docs"
+    ],
+    "source": [
+      "packages/<name>/package.json",
+      "packages/<name>/src/index.ts"
+    ]
+  }
+}
+```
+
+### Directory input 與 `EISDIR` 的排障
+
+- 若看到 `read failed (EISDIR)`，先確認該路徑在設定上是否是「應為檔案卻填了目錄」。
+- 建議改為明確 file path，或先縮小到更小 scope 的目錄（例如 `packages/<name>/docs`）再逐步擴展。
+- 若仍需要更完整套件推斷，請以 follow-up issue 紀錄，保持 runtime 行為不變（避免超出 #205 non-goals）。
+
+### 狗食報告依據
+
+- `#202` 的 `docs/dogfood/vitest-2026-05-09.md` 顯示 monorepo 中 path inference / directory input 的 friction，並且驗證到 `EISDIR` 類 read-failed 狀況。
+- 這支持本次以 docs/guidance-first 為第一步，不在 #205 內實作 monorepo walker 或 workspace parser。
+- 目前不表示可以直接將 `#206`（zh-TW classifier）或其他 runtime 行為納入同一版實作。


### PR DESCRIPTION
## Summary
- 補充 monorepo discovery defaults 與 limitations，明確定義 auto-discovery 的 bounded、heuristic 邊界。
- 補充 `discovery.docs` / `discovery.source` 檔案形狀與 `EISDIR` / directory input 的排查方式。
- 以 `#202` 的 Vitest dogfood evidence 採 docs/guidance-first 作法，將 monorepo 路徑摩擦轉為可操作文件指引。
- Closes #205

## Scope
- 變更檔案：
  - `docs/source-trust.md`
  - `docs/issue-to-context-pipeline.md`
- docs-only 的 path-shape 對齊與 troubleshooting 說明。

## Non-goals
- 不實作 monorepo walker。
- 不解析 `pnpm-workspace.yaml`。
- 不加 glob support。
- 不改 config schema。
- 不改 runtime。
- 不改 tests。
- 不實作 #206 zh-TW classifier。
- 不關閉 #120。
- 不處理 #149 remediation loop。
- 不修改 target repo。

## Validation
- `git diff --check`
- `pnpm build`
- `pnpm test`
- `pnpm test:gh` not run / not required

## Implementation Evidence
- Branch: `docs/monorepo-discovery-guidance-205`
- Commit hash: `c344a6c070b031e24c5439146e8303ae4bb6e0ef`
- Files changed: `docs/source-trust.md`, `docs/issue-to-context-pipeline.md`
- `#202` dogfood evidence: 已根據 `docs/dogfood/vitest-2026-05-09.md` 做 docs-first 引導補強。
- `#120` state: OPEN
- `#149` state: OPEN
- Issue evidence comments:
  - https://github.com/Erick52106/spec-injector/issues/205#issuecomment-4409161606
  - https://github.com/Erick52106/spec-injector/issues/205#issuecomment-4409253343

## Review finding assessment
- Codex Finding 1（`docs/source-trust.md:290`）：
  - Source: Codex
  - Classification: adopted
  - Action: 已將 `discovery.source` 的建議從 file path 改為 directory root（`packages/<name>/src`、`packages/<name>/browser`、`apps/<name>/src`），並明確說明目前行為不支援 file-entry；`vitest/browser/context.d.ts` 類虛擬路徑改以 issue-mentioned 做 context 細節，不宣稱 runtime 自動 mapping。
- Codex Finding 2（`docs/issue-to-context-pipeline.md:157-160`）：
  - Source: Codex
  - Classification: adopted
  - Action: 已將 `discovery.docs` 實例改為 concrete Markdown 檔（如 `packages/<name>/README.md`、`packages/<name>/docs/architecture.md`、`apps/<name>/README.md`、`apps/<name>/docs/usage.md`），並補上目前只會對目錄讀取做限制的 `EISDIR` 排查。
- Validation summary: `git diff --check` / `pnpm build` / `pnpm test` 均通過。
- Docs-only boundary: 僅更新 `docs/source-trust.md`、`docs/issue-to-context-pipeline.md`。
- No monorepo walker implementation。
- No config schema change。
- No runtime implementation。
- No #206 zh-TW classifier。
- No target repo mutation。
