### PR TITLE
test(gh): add optional live label-audit smoke

### DIFF
--- a/tests/optional-gh.smoke.test.ts
+++ b/tests/optional-gh.smoke.test.ts
@@ -99,6 +99,30 @@ function assertNoLiveGhMutationCommands(logValue: string): void {
   }
 }
 
+function assertNoLabelAuditReadFailures(output: string): void {
+  const lowerOutput = output.toLowerCase();
+  const forbiddenPatterns = [
+    'could not read gh issue list output',
+    'could not read gh pr list output',
+    'could not parse gh issue list output',
+    'could not parse gh pr list output',
+    'could not parse accepted taxonomy markers',
+    'could not parse workflow layer-to-milestone mapping',
+    'gh issue list output is missing required fields',
+    'gh pr list output is missing required fields',
+    'failed to parse',
+    'api error',
+    'gh issue list failed',
+    'gh pr list failed',
+    'rate limit',
+    'authentication',
+  ];
+
+  for (const pattern of forbiddenPatterns) {
+    assert.ok(!lowerOutput.includes(pattern), `label-audit live smoke should not report read/parse/API failures, found: ${pattern}`);
+  }
+}
+
 test(
   'optional gh smoke test: `spec plan` against public issue 61',
   { skip: process.env.SPEC_INJECTOR_RUN_GH_TESTS !== '1' },
@@ -196,10 +220,13 @@ test(
 
       const combinedOutput = `${result.stdout}\n${result.stderr}`;
 
+      // Keep opt-in tolerance for metadata quality states (warning/needs-human-review),
+      // but fail fast when live GitHub reads / parsing are broken.
       assert.ok(result.code === 0 || result.code === 1, `expected exit code 0 or 1, got ${String(result.code)}`);
       assert.match(result.stdout, /Label audit summary:/i);
       assert.match(result.stdout, /Label audit summary:\s+(PASS|WARNING|NEEDS-HUMAN-REVIEW|FAIL)/i);
       assert.ok(result.stdout.length > 0 || result.stderr.length > 0, 'label-audit command should emit output');
+      assertNoLabelAuditReadFailures(combinedOutput);
 
       const ghLog = (await fs.readFile(liveGh.ghLogPath, 'utf8')).trim();
       assert.ok(

--- a/tests/optional-gh.smoke.test.ts
+++ b/tests/optional-gh.smoke.test.ts
@@ -5,10 +5,12 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { runCommand, runSpec, repoRoot } from './helpers/cli.ts';
-import { assertNoRawStackTrace } from './helpers/assertions.ts';
+import { assertNoGhMutationCommands, assertNoRawStackTrace } from './helpers/assertions.ts';
 
 const ISSUE_URL = 'https://github.com/Erick52106/spec-injector/issues/61';
 const ISSUE_NUMBER = '#61';
+const LABEL_AUDIT_REPO = 'Erick52106/spec-injector';
+const LABEL_AUDIT_LIMIT = '5';
 
 function formatSpecPlanFailure(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
@@ -27,6 +29,74 @@ function formatSpecPlanFailure(error: unknown): string {
   }
 
   return `Optional gh smoke test failed for live spec plan execution. This is optional and may be environment-dependent. ${message}`;
+}
+
+type LiveGhSpy = {
+  env: NodeJS.ProcessEnv;
+  ghLogPath: string;
+  cleanup: () => Promise<void>;
+};
+
+async function createLiveGhSpy(): Promise<LiveGhSpy> {
+  const whichResult = await runCommand('which', ['gh'], repoRoot);
+  const realGhPath = whichResult.stdout.trim();
+  if (!realGhPath) {
+    assert.fail('Optional gh smoke test precondition failed: unable to resolve real gh executable path.');
+  }
+
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'spec-injector-live-gh-smoke-'));
+  const ghLogPath = path.join(tempDir, 'gh.log');
+  const ghPath = path.join(tempDir, 'gh');
+
+  const escapedGhPath = realGhPath.replaceAll("'", "'\\''");
+  const escapedLogPath = ghLogPath.replaceAll("'", "'\\''");
+
+  await fs.writeFile(
+    ghPath,
+    [
+      '#!/usr/bin/env sh',
+      `REAL_GH='${escapedGhPath}'`,
+      `LOG_PATH='${escapedLogPath}'`,
+      'printf "%s\\n" "$*" >> "$LOG_PATH"',
+      'exec "$REAL_GH" "$@"',
+      '',
+    ].join('\n'),
+    'utf8'
+  );
+  await fs.chmod(ghPath, 0o755);
+
+  return {
+    env: {
+      ...process.env,
+      PATH: `${tempDir}${path.delimiter}${process.env.PATH ?? ''}`,
+    },
+    ghLogPath,
+    cleanup: async () => {
+      await fs.rm(tempDir, { force: true, recursive: true });
+    },
+  };
+}
+
+function assertNoLiveGhMutationCommands(logValue: string): void {
+  const lines = logValue.split('\n').map((line) => line.trim()).filter(Boolean);
+
+  assertNoGhMutationCommands(logValue);
+
+  for (const line of lines) {
+    const [resource, action] = line.split(/\s+/).map((value) => value.toLowerCase());
+    if (resource === 'label' && ['create', 'edit', 'delete'].includes(action ?? '')) {
+      assert.fail(`Unexpected mutating gh command: ${line}`);
+    }
+    if (resource === 'issue' && ['edit', 'close', 'comment', 'reopen'].includes(action ?? '')) {
+      assert.fail(`Unexpected mutating gh command: ${line}`);
+    }
+    if (resource === 'pr' && ['edit', 'merge', 'comment', 'close', 'reopen'].includes(action ?? '')) {
+      assert.fail(`Unexpected mutating gh command: ${line}`);
+    }
+    if (resource === 'api' && /\b(PATCH|POST|DELETE)\b/i.test(line)) {
+      assert.fail(`Unexpected mutating gh api command: ${line}`);
+    }
+  }
 }
 
 test(
@@ -90,5 +160,63 @@ test(
     assert.ok(result.stdout.includes('Read the referenced files as needed'), 'prompt output should include output contract tail text');
     assert.ok(result.stdout.length > 0, 'prompt output should not be empty');
     assertNoRawStackTrace(result);
+  }
+);
+
+test(
+  'optional gh smoke test: `spec label-audit` against this repo',
+  { skip: process.env.SPEC_INJECTOR_RUN_GH_TESTS !== '1' },
+  async () => {
+    try {
+      await runCommand('gh', ['--version'], repoRoot);
+    } catch (error) {
+      assert.fail(
+        'Optional gh smoke test precondition failed: gh CLI is not available or not callable. ' +
+          'Please install `gh` and ensure it is on PATH, then run `pnpm test:gh` again.\n' +
+          `Error: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+
+    try {
+      await runCommand('gh', ['auth', 'status', '--active', '--hostname', 'github.com'], repoRoot);
+    } catch (error) {
+      assert.fail(
+        'Optional gh smoke test precondition failed: gh auth status --active --hostname github.com is not usable.\n' +
+          'Please run `gh auth login --hostname github.com` before `pnpm test:gh`, or run `gh auth status --active --hostname github.com` to verify active GitHub auth.\n' +
+          `Error: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+
+    const liveGh = await createLiveGhSpy();
+    try {
+      const result = await runSpec(
+        ['label-audit', '--repo', LABEL_AUDIT_REPO, '--limit', LABEL_AUDIT_LIMIT],
+        { env: liveGh.env }
+      );
+
+      const combinedOutput = `${result.stdout}\n${result.stderr}`;
+
+      assert.ok(result.code === 0 || result.code === 1, `expected exit code 0 or 1, got ${String(result.code)}`);
+      assert.match(result.stdout, /Label audit summary:/i);
+      assert.match(result.stdout, /Label audit summary:\s+(PASS|WARNING|NEEDS-HUMAN-REVIEW|FAIL)/i);
+      assert.ok(result.stdout.length > 0 || result.stderr.length > 0, 'label-audit command should emit output');
+
+      const ghLog = (await fs.readFile(liveGh.ghLogPath, 'utf8')).trim();
+      assert.ok(
+        ghLog.includes('issue list') && ghLog.includes('--limit 5'),
+        'label-audit should execute gh issue list with the configured limit'
+      );
+      assert.ok(
+        ghLog.includes('pr list') && ghLog.includes('--limit 5'),
+        'label-audit should execute gh pr list with the configured limit'
+      );
+      assert.ok(ghLog.includes(LABEL_AUDIT_REPO), 'label-audit should be scoped to target repository');
+      assertNoLiveGhMutationCommands(ghLog);
+      assert.match(combinedOutput, /Label audit summary:/i);
+      assertNoRawStackTrace(result);
+
+    } finally {
+      await liveGh.cleanup();
+    }
   }
 );


### PR DESCRIPTION
## Summary
- 新增 optional live `spec label-audit` smoke test，僅在 `SPEC_INJECTOR_RUN_GH_TESTS=1` 時執行，並以 `--repo Erick52106/spec-injector --limit 5` 進行實際 `gh` 呼叫。
- 維持 `SPEC_INJECTOR_RUN_GH_TESTS=1` 的 opt-in gate，不影響預設測試路徑。
- 不進入 default `pnpm test`；不加入 CI。
- Closes #207

## Scope
- tests/optional-gh.smoke.test.ts
- test helper files if changed
- test-only live GH shape validation

## Non-goals
- 不修改 runtime
- 不修改 docs
- 不修改 CI
- 不改 GitHub labels / issues / PRs
- 不要求 exact pass severity
- 不處理 #120
- 不處理 #149 remediation loop
- 不修改 target repo

## Validation
- `git diff --check`
- `pnpm build`
- `pnpm test`
- `pnpm test:gh` not run / not required, or record result if explicitly run with opt-in

## Implementation Evidence
- Branch: test/live-label-audit-smoke-207
- Original implementation commit: 48b550c1e9a72d7afb62098a8eb91c4f3b285763
- Current merge HEAD: 323852c780e464594918f216a41e11ede6f7605e
- Files changed: tests/optional-gh.smoke.test.ts
- #200 status: implemented
- #120 state: OPEN
- #149 state: OPEN
- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/207#issuecomment-4409232521

## Review finding assessment
- Source: Codex
- Classification: adopted
- Action: fixed
- Rationale: 已新增 read/parse/API 失敗拒絕斷言，同時保留 opt-in gate、exit-code policy 與 no-mutation 保護。
- Validation summary: git diff --check / pnpm build / pnpm test pass

- Source: CodeRabbit
- Finding: minor redundancy in Label audit summary assertions around lines 200-202
- Classification: optional polish / not adopted
- Action: no code change
- Rationale: 這是低價值 assertion cleanup suggestion；重複 assertion 無害，不會造成 flaky，也不會弱化 read-failure rejection 或 no-mutation protections。現有測試已保留具體 status 檢查、read-failure 拒絕與 no-mutation 邊界，為此再追加 commit 不符合 #207 scope。

- Source: CodeRabbit
- Finding: combinedOutput Label audit summary assertion 與前面 result.stdout assertion 重複
- Classification: optional polish / not adopted
- Action: no code change
- Rationale: 此 finding 與前一則同屬低價值 assertion redundancy。重複檢查不影響測試穩定性、read-failure rejection、no-mutation protections 或 default CI behavior；目前不為純樣式清理再新增 commit。

