### PR TITLE
docs(readme): add conservative pipeline and docs map

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -89,6 +89,22 @@ The current implemented / documented capabilities can be understood in four stag
 | Output | Produces a bounded Markdown task package or compact planning prompt for an AI coding agent to read before implementation. | Output is handoff context, not an autonomous execution plan. |
 | Verify | Repo workflow docs define validation, implementation evidence comments, PR body evidence URLs, HEAD/readback checks, and review closeout. | Workflow guardrails are read-only / human-reviewed discipline, not a merge bot or remediation automation. |
 
+## Current pipeline and documentation map
+
+The current safe path is: a `request / GitHub issue` enters a deterministic issue parser / classifier, gathers repo docs, source references, and guardrails, preserves diagnostics such as missing / unreadable / alias hints, and emits a bounded task package / prompt for an AI coding agent to use inside a human-reviewed workflow. This current pipeline is a deterministic handoff context, not a hidden planner, target-repo mutation system, or merge automation path; implementation and merge decisions still stay with humans and repo workflow rules.
+
+Key documentation map:
+
+- [docs/issue-to-context-pipeline.md](docs/issue-to-context-pipeline.md): current pipeline and future-lane separation
+- [docs/source-trust.md](docs/source-trust.md): source-trust vocabulary and bounded-context caveats
+- [docs/validation.md](docs/validation.md): validation matrix and quality gates
+- [docs/workflow.md](docs/workflow.md): issue-to-PR workflow guardrails
+- [docs/cheatsheet.md](docs/cheatsheet.md): happy-path quick reference
+- [docs/dogfood/vitest-2026-05-09.md](docs/dogfood/vitest-2026-05-09.md): caveated dogfood evidence
+- [docs/design/layers.md](docs/design/layers.md): Layer 1-4 boundary model
+
+At the boundary level, current capability includes the deterministic compiler, source labels/categories, diagnostics, visible truncation metadata, and read-only `spec evidence-check` / `spec label-audit` guardrails. Caveated areas include source-trust vocabulary as partial runtime support rather than a full policy engine, context budget as bounded snippets / item limits rather than a full token/byte algorithm, dogfood evidence as cautious progress, and monorepo support as documentation guidance rather than a resolver. Future / design-only work remains with #206 zh-TW classifier support, #149 supervised remediation-loop evaluation, and companion/status, full trust-policy, and full budget-algorithm directions.
+
 ## Current capabilities
 
 - Compiles GitHub issues into bounded, agent-ready task context; see [issue-to-context pipeline](docs/issue-to-context-pipeline.md).

--- a/README.md
+++ b/README.md
@@ -105,6 +105,22 @@ GitHub Issue
 | Output | 產生 bounded Markdown task package 或 compact planning prompt，供 AI coding agent 開工前閱讀。 | Output 是 handoff context，不是 autonomous execution plan。 |
 | Verify | Repo workflow docs 規範 validation、implementation evidence comment、PR body evidence URL、HEAD/readback check 與 review closeout。 | Workflow guardrails 是 read-only / human-reviewed discipline，不是 merge bot 或 remediation automation。 |
 
+## 目前管線與文件地圖
+
+目前可安全描述的主線是：`request / GitHub issue` 進入 deterministic issue parser / classifier，收斂 repo docs、source references 與 guardrails，保留 missing / unreadable / alias hints 等 diagnostics，最後輸出 bounded task package / prompt，交給 AI coding agent 在 human-reviewed workflow 中實作。這條 current pipeline 的重點是 deterministic handoff context，不是 hidden planner、target repo mutation、merge automation，最終實作與 merge decision 仍由人與 repo workflow 決定。
+
+主要文件可對照：
+
+- [docs/issue-to-context-pipeline.md](docs/issue-to-context-pipeline.md)：current pipeline 與 future lane separation
+- [docs/source-trust.md](docs/source-trust.md)：source-trust vocabulary 與 bounded context caveats
+- [docs/validation.md](docs/validation.md)：validation matrix 與 quality gates
+- [docs/workflow.md](docs/workflow.md)：issue-to-PR workflow guardrails
+- [docs/cheatsheet.md](docs/cheatsheet.md)：happy-path quick reference
+- [docs/dogfood/vitest-2026-05-09.md](docs/dogfood/vitest-2026-05-09.md)：caveated dogfood evidence
+- [docs/design/layers.md](docs/design/layers.md)：Layer 1–4 boundary model
+
+邊界上，current 包含 deterministic compiler、source labels/categories、diagnostics、visible truncation metadata、read-only `spec evidence-check` / `spec label-audit` guardrails；caveated 部分包含 source-trust vocabulary 仍是 partial runtime support、context budget 仍以 bounded snippets / item limits 為主、dogfood evidence 是 cautious progress、monorepo 目前只有 docs guidance。future / design-only 則保留給 #206 zh-TW classifier、#149 supervised remediation loop，以及 companion/status、full trust policy engine、full budget algorithm 等後續方向。
+
 ## 目前能力
 
 - 將 GitHub issue 編譯為 bounded、agent-ready 的 task context；可參考 [issue-to-context pipeline](docs/issue-to-context-pipeline.md)。


### PR DESCRIPTION
## Summary
- 新增 conservative pipeline/docs map
- 連結 current Layer 1 / Layer 2 docs
- 標明 current / caveated / future / parked boundaries
- Related to #120

## Scope
- README.md
- README.en.md
- docs-only split PR A

## Non-goals
- 不關閉 #120
- 不做 full README showcase rewrite
- 不新增 assets / diagrams
- 不宣稱 #206 zh-TW classifier 已完成
- 不宣稱 #149 remediation loop 是 current capability
- 不宣稱 monorepo resolver / context budget algorithm / trust policy engine 已完成
- 不修改 runtime / tests / CI / package scripts
- 不修改 target repo

## Validation
- git diff --check
- pnpm build
- pnpm test
- pnpm test:gh not run / not required

## Implementation Evidence
- Branch: docs/readme-pipeline-docs-map-120
- Commit hash: e523b183449295facbecb5e694427a4de26990b8
- Files changed: README.md, README.en.md
- #120 state: OPEN
- #206 state: OPEN / deferred
- #149 state: OPEN / parked
- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/120#issuecomment-4413036546

## Review finding assessment
- No automated review findings yet.
- Future findings must be classified before changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new "Current pipeline and documentation map" section to README files
  * Expanded boundary and capability maps with detailed current scope and future work information
  * Included comprehensive key documentation file references and pipeline details for improved navigation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Erick52106/spec-injector/pull/218)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->