### PR TITLE
docs(readme): add dogfood evidence caveats

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -105,6 +105,12 @@ Key documentation map:
 
 At the boundary level, current capability includes the deterministic compiler, source labels/categories, diagnostics, visible truncation metadata, and read-only `spec evidence-check` / `spec label-audit` guardrails. Caveated areas include source-trust vocabulary as partial runtime support rather than a full policy engine, context budget as bounded snippets / item limits rather than a full token/byte algorithm, dogfood evidence as cautious progress, and monorepo support as documentation guidance rather than a resolver. Future / design-only work remains with #206 zh-TW classifier support, #149 supervised remediation-loop evaluation, and companion/status, full trust-policy, and full budget-algorithm directions.
 
+## Dogfood evidence and limitations
+
+[docs/dogfood/vitest-2026-05-09.md](docs/dogfood/vitest-2026-05-09.md) captures the second brownfield dogfood against the public monorepo target `vitest-dev/vitest`, pinned to commit `d77e93659d1703f9d96b58373b38738bf190289e`, and executed in read-only mode. The run shows the deterministic issue-to-context flow can produce useful planning context while keeping diagnostics, truncation metadata, and path caveats visible, so it supports cautious README progress.
+However, the Vitest report is a WARN / caveated evidence result, not an unconditional PASS. It does not justify claims such as “production-ready for all brownfield repos,” and it does not claim a shipped monorepo resolver. Monorepo support remains #205 documentation guidance, not runtime resolver behavior.
+Boundary status is unchanged: #206 Traditional Chinese classifier support remains evidence-gated, #149 supervised remediation remains parked/design-only, and `spec-injector` does not perform target repo mutation or automatic remediation/merge actions.
+
 ## Current capabilities
 
 - Compiles GitHub issues into bounded, agent-ready task context; see [issue-to-context pipeline](docs/issue-to-context-pipeline.md).

--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ GitHub Issue
 
 邊界上，current 包含 deterministic compiler、source labels/categories、diagnostics、visible truncation metadata、read-only `spec evidence-check` / `spec label-audit` guardrails；caveated 部分包含 source-trust vocabulary 仍是 partial runtime support、context budget 仍以 bounded snippets / item limits 為主、dogfood evidence 是 cautious progress、monorepo 目前只有 docs guidance。future / design-only 則保留給 #206 zh-TW classifier、#149 supervised remediation loop，以及 companion/status、full trust policy engine、full budget algorithm 等後續方向。
 
+## Dogfood 證據與限制
+
+[docs/dogfood/vitest-2026-05-09.md](docs/dogfood/vitest-2026-05-09.md) 記錄了第二個 brownfield dogfood，target 為公開 monorepo `vitest-dev/vitest`，並固定在 commit `d77e93659d1703f9d96b58373b38738bf190289e` 進行 read-only 驗證。這份 evidence 顯示 deterministic issue-to-context flow 已足以產生可用的 planning context，也能看見 diagnostics、truncation metadata 與 path caveats，因此可支持 README 以保守方式前進。
+但該次 dogfood 的結論是 WARN / caveated evidence，不是 unconditional PASS：它不支持「所有 brownfield repo 都 production-ready」的宣稱，也不支持 monorepo resolver 已完成的宣稱。對 monorepo 的現況是 #205 提供 docs guidance，而非 runtime resolver。
+同時，本 repo 仍維持邊界：#206 傳統中文 classifier 仍是 evidence-gated、#149 supervised remediation 仍是 parked/design-only、`spec-injector` 不做 target repo mutation 或自動修復/合併。
+
 ## 目前能力
 
 - 將 GitHub issue 編譯為 bounded、agent-ready 的 task context；可參考 [issue-to-context pipeline](docs/issue-to-context-pipeline.md)。


### PR DESCRIPTION
## Summary
- 新增 dogfood evidence caveats。
- 連結 `docs/dogfood/vitest-2026-05-09.md`。
- 標明 Vitest dogfood 為 WARN / caveated evidence，不是 unconditional PASS。
- Related to #120。

## Scope
- README.md
- README.en.md
- docs-only split PR C

## Non-goals
- 不關閉 #120
- 不做 full README showcase rewrite
- 不修改 dogfood report
- 不宣稱 monorepo resolver 已完成
- 不宣稱 #206 zh-TW classifier 已完成
- 不宣稱 #149 remediation loop 是 current capability
- 不修改 runtime / tests / CI / package scripts
- 不修改 target repo

## Validation
- `git diff --check`
- `pnpm build`
- `pnpm test`
- `pnpm test:gh` not run / not required

## Implementation Evidence
- Branch: `docs/readme-dogfood-evidence-caveats-120`
- Commit hash: `62befcdf515759e448f54f7d2ba023a403a14b11`
- Files changed:
  - `README.md`
  - `README.en.md`
- #120 state: OPEN
- #202 status: CLOSED / COMPLETED / status:implemented
- #205 status: CLOSED / COMPLETED / status:implemented
- #206 state: OPEN / deferred
- #149 state: OPEN / parked
- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/120#issuecomment-4413069804

## Review finding assessment
- No automated review findings yet.
- Future findings must be classified before changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with dogfood testing evidence and explicit limitations
  * Clarified boundary status for features currently in evidence-gated state
  * Added caveats about testing results to set accurate expectations regarding system capabilities and constraints

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Erick52106/spec-injector/pull/219)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->