### PR TITLE
docs(readme): align source trust and diagnostics wording

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -364,7 +364,7 @@ Current implemented layer:
 
 Documented future-facing layers:
 
-- **Layer 2 AI workflow**: AI tool uses task package to draft an implementation plan, then waits for human approval before implementation.
+- **Layer 2 — Workflow Guardrails**: AI tool uses task package to draft an implementation plan, then waits for human approval before implementation.
 - **Layer 3 Protocolization**: richer evidence and protocol alignment for deterministic context handoff, while preserving deterministic and reviewable boundaries.
 - **Layer 4 Companion UX**: consistent human-facing guidance, boundary statements, and support for handoff quality, still design-oriented.
 

--- a/README.en.md
+++ b/README.en.md
@@ -23,6 +23,11 @@ Core positioning:
 - agent-agnostic: emits Markdown task packages / prompts for Codex, Claude Code, or other AI coding agents
 - no hidden LLM: does not call a hidden LLM, external AI API, or local model
 
+Boundary note (current implementation):
+- source-trust aware / context-budget aware is current guidance plus partial runtime support.
+- Current runtime emits source labels / source categories, bounded snippets / item-count limits, and visible diagnostics.
+- Current runtime does not ship a full trust-policy engine or a full token/byte context-budget algorithm.
+
 ## Why this exists
 
 Common AI coding agent failures are usually not about being unable to write code, but about starting work without clear enough boundaries:
@@ -46,7 +51,7 @@ The Layer 1 CLI of `spec-injector` guarantees these boundaries:
 - `spec plan --dry-run` only outputs to stdout and does not write a task package
 - non-dry-run output from `spec plan` only writes to `.spec-injector/out/issue-<number>-task-package.md`
 - task packages can surface missing files, unreadable files, path alias hints, and validation checklists so context gaps are visible
-- read-only workflow guardrails can check label / milestone taxonomy, PR evidence readback, and the optional live `gh` smoke path, but do not auto-fix metadata or merge
+- read-only workflow guardrails (including `spec evidence-check` / `spec label-audit`) are report/check only; `PASS` is not approval, and they do not auto-create/edit/delete metadata or merge
 - mutating commands must be explicit command behavior, such as `spec init`, `spec config add/remove always-read`, or `spec clean`
 - CLI core does not automatically create branches, commits, PRs, issue comments, or modify target repo source code
 
@@ -117,7 +122,7 @@ Boundary status is unchanged: #206 Traditional Chinese classifier support remain
 - Surfaces references and diagnostics so missing or unreadable context remains visible; see [workflow](docs/workflow.md) and [validation](docs/validation.md).
 - Uses source trust and context-budget design to keep task packages bounded; see [source trust](docs/source-trust.md).
 - Supports human-reviewed validation, evidence, readback, and finding-assessment workflows; see [workflow](docs/workflow.md) and [validation](docs/validation.md).
-- Includes read-only workflow guardrails like label/milestone audit; see [label taxonomy](docs/label-taxonomy.md).
+- Includes read-only `spec evidence-check` / `spec label-audit` guardrails that report workflow risk only and do not provide approval, merge authority, or metadata mutation; see [label taxonomy](docs/label-taxonomy.md).
 - Keeps companion, status, and remediation ideas documented as design-only, not shipped runtime behavior; see [current capability showcase planning doc](docs/readme-current-capability-showcase.md) and [readme showcase readiness](docs/readme-showcase-readiness.md).
 
 ## Quickstart
@@ -173,7 +178,7 @@ This test is intentionally `opt-in`; it does not run automatically in `pnpm test
 - `gh auth status --active --hostname github.com`
 - `spec plan https://github.com/Erick52106/spec-injector/issues/61 --dry-run --format prompt`
 
-The result must include the basic prompt sections, confirming issue URL parsing and the minimal live `spec plan` read path. If the environment does not have `gh` installed or authenticated, this test is not a default regression blocker; set up the environment first, then run it explicitly.
+The result must include the basic prompt sections, confirming issue URL parsing and the minimal live `spec plan` read path. This is a read-only smoke path, not a default CI gate and not an approval authority. If the environment does not have `gh` installed or authenticated, this test is not a default regression blocker; set up the environment first, then run it explicitly.
 
 Current local install and release details are documented in [docs/release.md](docs/release.md).
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ AI coding agent 常見的失誤不是「不會寫程式」，而是開工前沒�
 - `spec plan --dry-run` 只輸出到 stdout，不寫入 task package
 - `spec plan` 的 non-dry-run output 只寫入 `.spec-injector/out/issue-<number>-task-package.md`
 - task package 可以揭露 missing files、unreadable files、path alias hints 與 validation checklist，讓 context gaps 可被看見
-- read-only workflow guardrails 可以檢查 label / milestone taxonomy、PR evidence readback 與 optional live `gh` smoke path，但不自動修 metadata 或 merge
+- read-only workflow guardrails（含 `spec evidence-check` / `spec label-audit`）只能做 report/check；`PASS` 不是 approval，也不自動建立/修改/刪除 metadata 或 merge
 - mutating commands 必須是明確 command 行為，例如 `spec init`、`spec config add/remove always-read`、`spec clean`
 - CLI core 不會自動建立 branch、commit、PR、issue comment 或修改 target repo source code
 
@@ -133,7 +133,7 @@ GitHub Issue
 - 顯示 source references 與診斷資訊，讓缺漏或不可讀 context 保持可見；可參考 [workflow](docs/workflow.md) 與 [validation](docs/validation.md)。
 - 以 source trust 與 context-budget 設計約束 task package 邊界；可參考 [source trust](docs/source-trust.md)。
 - 支援 human-reviewed 的 validation / evidence / readback 與 review finding 分類流程；可參考 [workflow](docs/workflow.md) 與 [validation](docs/validation.md)。
-- 提供 read-only 的 workflow guardrail，例如 label / milestone audit；可參考 [label taxonomy](docs/label-taxonomy.md)。
+- 提供 read-only 的 `spec evidence-check` / `spec label-audit` guardrails，僅報告 workflow 風險、不做 approval / merge / metadata mutation；可參考 [label taxonomy](docs/label-taxonomy.md)。
 - 將 companion / status / remediation 相關方向保留為 design-only，不視為已實作功能；可參考 [current capability showcase planning doc](docs/readme-current-capability-showcase.md) 與 [readme showcase readiness](docs/readme-showcase-readiness.md)。
 
 ## Quickstart
@@ -189,7 +189,7 @@ pnpm test:gh
 - `gh auth status --active --hostname github.com`
 - `spec plan https://github.com/Erick52106/spec-injector/issues/61 --dry-run --format prompt`
 
-執行結果會要求至少包含基本 prompt sections，確認 issue URL 解析與 `spec plan` 最小 live 讀取鏈路。若環境未安裝 `gh` 或未登入，測試不會作為預設 regressions 阻擋；請先補齊環境後再執行。
+執行結果會要求至少包含基本 prompt sections，確認 issue URL 解析與 `spec plan` 最小 live 讀取鏈路。它是 read-only smoke，非預設 CI gate，也不代表 approval authority。若環境未安裝 `gh` 或未登入，測試不會作為預設 regressions 阻擋；請先補齊環境後再執行。
 
 Current local install and release details are documented in [docs/release.md](docs/release.md).
 


### PR DESCRIPTION
## Summary
- 對 README 的 source-trust / context-budget / diagnostics wording 做小範圍 claim-boundary pass
- 保留 read-only `spec evidence-check` / `spec label-audit` 邊界（report-only，非 approval / merge authority）
- 保留 #206 deferred 與 #149 parked 的邊界敘述
- 採納並修正 CodeRabbit finding：`Layer 2 AI workflow` 對齊為 canonical `Layer 2 — Workflow Guardrails`
- Related to #120

## Scope
- README.md
- README.en.md
- docs-only split PR D

## Non-goals
- 不關閉 #120
- 不做 full README showcase rewrite
- 不修改 source-trust runtime
- 不實作 trust policy engine
- 不實作 token/byte context budget algorithm
- 不實作 #206 zh-TW classifier
- 不宣稱 #149 remediation loop 是 current capability
- 不修改 runtime / tests / CI / package scripts
- 不修改 target repo

## Validation
- `git diff --check`
- `pnpm build`
- `pnpm test`
- `pnpm test:gh` not run / not required

## Implementation Evidence
- Branch: `docs/readme-source-trust-diagnostics-wording-120`
- Commit hash:
  - `f678272a531eff47281fb59908e59c4c4d7523f5`
  - `617bf7e775a1a344ea0b95b78df9a6af8007dae5`
- Files changed: `README.md`, `README.en.md`
- #120 state: OPEN
- #206 state: OPEN / deferred
- #149 state: OPEN / parked
- issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/120#issuecomment-4413088102

## Review finding assessment
- Finding: CodeRabbit / `README.en.md` around line 367 / layer naming drift
- Classification: adopted
- Action: fixed (`Layer 2 AI workflow` -> `Layer 2 — Workflow Guardrails`)
- Commit: `617bf7e775a1a344ea0b95b78df9a6af8007dae5`
- Validation summary: `git diff --check`, `pnpm build`, `pnpm test` passed; `pnpm test:gh` not run / not required


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified boundaries: source-trust and context-budget have partial runtime support (labels/snippets/limits, diagnostics) — not full engines.
  * Strengthened read-only workflow guardrails: evidence checks and label audits report only; no approval, metadata mutation, or merge authority.
  * Optional live smoke test: explicitly opt-in read-only path requiring basic prompt sections (issue URL parsing and minimal spec-plan read path).
  * Renamed Layer 2 roadmap item to “Workflow Guardrails.”

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Erick52106/spec-injector/pull/220)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->