### PR TITLE
docs(readme): add future roadmap boundary table

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -94,6 +94,18 @@ The current implemented / documented capabilities can be understood in four stag
 | Output | Produces a bounded Markdown task package or compact planning prompt for an AI coding agent to read before implementation. | Output is handoff context, not an autonomous execution plan. |
 | Verify | Repo workflow docs define validation, implementation evidence comments, PR body evidence URLs, HEAD/readback checks, and review closeout. | Workflow guardrails are read-only / human-reviewed discipline, not a merge bot or remediation automation. |
 
+## Roadmap boundaries
+
+This table keeps future docs and parked designs from being mistaken for current capability:
+
+| Lane | Status | What it means | What it does not mean |
+| --- | --- | --- | --- |
+| Current | Implemented / documented today | deterministic GitHub issue-to-context compiler; bounded task package / prompt output; source labels / source categories; missing / unreadable / read failed diagnostics; visible truncation metadata; read-only `spec evidence-check` / `spec label-audit`; opt-in live `gh` smoke. | Not a hosted control plane, agent orchestration platform, merge bot, hidden LLM planner, semantic RAG / vector search, or target repo mutation system. |
+| Current with caveat | Supported wording, partial runtime, or auxiliary report | source-trust vocabulary has partial runtime support, but is not a full policy engine; boundedness currently relies on item-count limits / truncation metadata, not a token / byte budget algorithm; monorepo support is guidance, not a full resolver; dogfood evidence is WARN / caveated; evidence-check / label-audit are auxiliary reports. | Does not mean approval authority, unconditional PASS, a complete monorepo package export resolver, or fully implemented future trust / budget policy. |
+| Future / design-only | Direction only until separate implementation exists | catalog / protocol direction; stronger trust policy design; future budget policy design; companion / Spec Cat / status UX; more dogfood evidence; #206 zh-TW classifier work only if evidence supports it. | Does not mean Layer 3 / Layer 4 runtime exists, and does not mean #206 has shipped. |
+| Parked | Explicitly not active implementation | #149 supervised remediation loop remains parked; thread-level review remediation must wait until safety prerequisites exist before it can be reconsidered. | Does not mean the remediation loop is current capability, and does not mean auto-fix / auto-resolve / auto-close / auto-merge can start. |
+| Explicit non-goals / must not claim | Must stay out of README claims | Do not claim a hosted control plane, agent orchestration platform, merge bot, companion runtime, hidden LLM planner, RAG / vector search, target repo auto-editing, automatic monorepo package export resolver, or shipped zh-TW classifier. | Future docs, design records, and parked issues must not be packaged as current product behavior. |
+
 ## Current pipeline and documentation map
 
 The current safe path is: a `request / GitHub issue` enters a deterministic issue parser / classifier, gathers repo docs, source references, and guardrails, preserves diagnostics such as missing / unreadable / alias hints, and emits a bounded task package / prompt for an AI coding agent to use inside a human-reviewed workflow. This current pipeline is a deterministic handoff context, not a hidden planner, target-repo mutation system, or merge automation path; implementation and merge decisions still stay with humans and repo workflow rules.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,18 @@ GitHub Issue
 | Output | 產生 bounded Markdown task package 或 compact planning prompt，供 AI coding agent 開工前閱讀。 | Output 是 handoff context，不是 autonomous execution plan。 |
 | Verify | Repo workflow docs 規範 validation、implementation evidence comment、PR body evidence URL、HEAD/readback check 與 review closeout。 | Workflow guardrails 是 read-only / human-reviewed discipline，不是 merge bot 或 remediation automation。 |
 
+## Roadmap 邊界
+
+這張表用來避免把 future docs 或 parked designs 誤讀成 current capability：
+
+| Lane | Status | What it means | What it does not mean |
+| --- | --- | --- | --- |
+| Current | Implemented / documented today | deterministic GitHub issue-to-context compiler；bounded task package / prompt output；source labels / source categories；missing / unreadable / read failed diagnostics；visible truncation metadata；read-only `spec evidence-check` / `spec label-audit`；opt-in live `gh` smoke。 | 不是 hosted control plane、agent orchestration platform、merge bot、hidden LLM planner、semantic RAG / vector search，且不修改 target repo。 |
+| Current with caveat | Supported wording, partial runtime, or auxiliary report | source-trust vocabulary 有 partial runtime support，但不是 full policy engine；boundedness 目前以 item-count limits / truncation metadata 為主，不是 token / byte budget algorithm；monorepo 是 guidance，不是 full resolver；dogfood evidence 是 WARN / caveated；evidence-check / label-audit 是 auxiliary reports。 | 不代表 approval authority、unconditional PASS、完整 monorepo package export resolver，或 future trust / budget policy 已全部實作。 |
+| Future / design-only | Direction only until separate implementation exists | catalog / protocol direction；stronger trust policy design；future budget policy design；companion / Spec Cat / status UX；更多 dogfood evidence；#206 zh-TW classifier 只有在 evidence 支持後才可能處理。 | 不代表 Layer 3 / Layer 4 runtime 已存在，也不代表 #206 已 shipped。 |
+| Parked | Explicitly not active implementation | #149 supervised remediation loop 仍 parked；thread-level review remediation 需等 safety prerequisites 存在後才可重新評估。 | 不代表 remediation loop 是 current capability，也不代表 auto-fix / auto-resolve / auto-close / auto-merge 可以開始做。 |
+| Explicit non-goals / must not claim | Must stay out of README claims | 不宣稱 hosted control plane、agent orchestration platform、merge bot、companion runtime、hidden LLM planner、RAG / vector search、target repo auto-editing、automatic monorepo package export resolver、zh-TW classifier shipped。 | 不應用 future docs、design records 或 parked issues 包裝成 current product behavior。 |
+
 ## 目前管線與文件地圖
 
 目前可安全描述的主線是：`request / GitHub issue` 進入 deterministic issue parser / classifier，收斂 repo docs、source references 與 guardrails，保留 missing / unreadable / alias hints 等 diagnostics，最後輸出 bounded task package / prompt，交給 AI coding agent 在 human-reviewed workflow 中實作。這條 current pipeline 的重點是 deterministic handoff context，不是 hidden planner、target repo mutation、merge automation，最終實作與 merge decision 仍由人與 repo workflow 決定。


### PR DESCRIPTION
## Summary
- 新增 future roadmap boundary table。
- 區分 current / caveated / future / parked / explicit non-goals。
- 保留 #206 deferred / #149 parked。
- Related to #120。

## Scope
- README.md
- README.en.md
- docs-only split PR E

## Non-goals
- 不關閉 #120。
- 不做 full README showcase rewrite。
- 不實作 #206 zh-TW classifier。
- 不 unpark #149。
- 不宣稱 companion / Spec Cat / status runtime 是 current capability。
- 不宣稱 catalog/protocol runtime 已完成。
- 不宣稱 remediation loop 是 current capability。
- 不修改 runtime / tests / CI / package scripts。
- 不修改 target repo。

## Validation
- git diff --check
- pnpm build
- pnpm test
- pnpm test:gh not run / not required

## Implementation Evidence
- Branch: docs/readme-future-roadmap-boundary-120
- Commit hash: 9d169350989afbcb955fecfc927cb9bcf87f4a14
- Files changed: README.md, README.en.md
- #120 state: OPEN
- #206 state: OPEN / deferred
- #149 state: OPEN / parked
- Issue evidence comment: https://github.com/Erick52106/spec-injector/issues/120#issuecomment-4413165958

## Review finding assessment
- Source: CodeRabbit
- Finding: hyphenate `read failed diagnostics` as `read-failed diagnostics`
- Classification: optional polish / not adopted
- Action: no code/docs change
- Rationale: preserve diagnostic taxonomy wording; `read failed` is used as diagnostic category wording across CLI/docs labels, and this style-only nitpick has no correctness, claim-boundary, safety, README bilingual meaning, or validation impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Roadmap boundaries" section clarifying the current capabilities, planned features, parked items, and explicit non-goals to help users understand what the tool does and does not support.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Erick52106/spec-injector/pull/221)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
