### PR TITLE
feat(workflow): add local-only workflow-check phases

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -166,6 +166,9 @@ spec init --repo .
 spec validate --repo .
 spec config suggest always-read --repo .
 spec plan <issue-number-or-url> --repo . --dry-run --format prompt --verbose
+spec workflow-check --repo . --phase start --issue <issue-number-or-url>
+spec workflow-check --repo . --phase commit --pr-body /path/to/pr-body.md
+spec workflow-check --repo . --phase merge --pr-body /path/to/pr-body.md --head-sha <sha>
 ```
 
 Notes:
@@ -175,6 +178,15 @@ Notes:
 - `spec config suggest always-read --repo .` prints deterministic suggestions only; it does not modify config.
 - `spec plan ... --dry-run --format prompt --verbose` is the recommended pre-implementation command for AI planning.
 - For a full generated task package file, omit `--dry-run`; output is written under `.spec-injector/out/`.
+- `spec workflow-check` is a local-only, stdout-first workflow gate for autonomous PR evidence. It does not edit GitHub, add/commit files, write task packages, comment, merge, or mutate downstream repos.
+- `spec workflow-check --format json` emits the same stable fields as text output: `phase`, `status`, `repo`, `head_sha`, `checked_at`, `missing_fields`, `warnings`, and `evidence_summary`.
+- Downstream repos such as `tachigo` / `tachiya` only need to copy or reference the workflow-check `status` and evidence `ref` in their PR body / ledger. Their Scope Police workflows should not parse full `spec plan` or task-package evidence.
+
+`spec workflow-check` phases:
+
+- `start`: validates repo config. With `--issue`, it performs a dry-run bounded context check through `spec plan --dry-run --format prompt --verbose` without writing a task package.
+- `commit`: checks staged files for `.spec-injector/`, generated task packages / spec output, and private context artifacts. With `--pr-body`, it also checks for spec gate status/ref or manual fallback evidence.
+- `merge`: checks a local PR body for final merge gate evidence, spec gate status/ref, and latest HEAD SHA. With `--head-sha`, stale or mismatched evidence fails.
 
 ## Optional live gh smoke test
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ spec init --repo .
 spec validate --repo .
 spec config suggest always-read --repo .
 spec plan <issue-number-or-url> --repo . --dry-run --format prompt --verbose
+spec workflow-check --repo . --phase start --issue <issue-number-or-url>
+spec workflow-check --repo . --phase commit --pr-body /path/to/pr-body.md
+spec workflow-check --repo . --phase merge --pr-body /path/to/pr-body.md --head-sha <sha>
 ```
 
 Notes:
@@ -186,6 +189,15 @@ Notes:
 - `spec config suggest always-read --repo .` prints deterministic suggestions only; it does not modify config.
 - `spec plan ... --dry-run --format prompt --verbose` is the recommended pre-implementation command for AI planning.
 - For a full generated task package file, omit `--dry-run`; output is written under `.spec-injector/out/`.
+- `spec workflow-check` is a local-only, stdout-first workflow gate for autonomous PR evidence. It does not edit GitHub, add/commit files, write task packages, comment, merge, or mutate downstream repos.
+- `spec workflow-check --format json` emits the same stable fields as the text output: `phase`, `status`, `repo`, `head_sha`, `checked_at`, `missing_fields`, `warnings`, and `evidence_summary`.
+- Downstream repos such as `tachigo` / `tachiya` only need to copy or reference the workflow-check `status` and evidence `ref` in their PR body / ledger. Their Scope Police workflows should not parse full `spec plan` or task-package evidence.
+
+`spec workflow-check` phases:
+
+- `start`: validates repo config. With `--issue`, it performs a dry-run bounded context check through `spec plan --dry-run --format prompt --verbose` without writing a task package.
+- `commit`: checks staged files for `.spec-injector/`, generated task packages / spec output, and private context artifacts. With `--pr-body`, it also checks for spec gate status/ref or manual fallback evidence.
+- `merge`: checks a local PR body for final merge gate evidence, spec gate status/ref, and latest HEAD SHA. With `--head-sha`, stale or mismatched evidence fails.
 
 ## Optional live gh smoke test
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -144,6 +144,38 @@ Safety:
     await preflight(opts);
   });
 
+// workflow-check subcommand
+program
+  .command('workflow-check')
+  .description('Run local-only workflow gate checks for autonomous PR evidence')
+  .option('--repo <path>', 'Path to target repo (default: CWD)')
+  .requiredOption('--phase <phase>', 'Workflow phase: start|commit|merge')
+  .option('--format <format>', 'Output format: text or json (default: text)')
+  .option('--issue <number-or-url>', 'Issue number or URL for start-phase dry-run bounded context checks')
+  .option('--pr-body <path>', 'Path to a local PR body markdown file for commit/merge evidence checks')
+  .option('--head-sha <sha>', 'Expected latest head SHA for merge evidence freshness checks')
+  .addHelpText('after', `
+Checks:
+  - start: validate config; with --issue, dry-run bounded context generation without writing a task package
+  - commit: detect staged .spec-injector/spec output/private context artifacts and optional PR body spec evidence
+  - merge: require final merge gate, spec gate status/ref, and latest HEAD evidence in the local PR body
+
+Safety:
+  Local-only workflow gate. Prints to stdout by default.
+  Does not edit GitHub, add/commit files, write task packages, comment, merge, or mutate downstream repos.
+`)
+  .action(async (opts: {
+    repo?: string;
+    phase: string;
+    format?: string;
+    issue?: string;
+    prBody?: string;
+    headSha?: string;
+  }) => {
+    const { workflowCheck } = await import('./workflow-check.js');
+    await workflowCheck(opts);
+  });
+
 // evidence-check subcommand
 program
   .command('evidence-check')

--- a/src/cli/workflow-check.ts
+++ b/src/cli/workflow-check.ts
@@ -102,8 +102,10 @@ async function runPhase(
 
   const staged = readStagedPaths(repoPath, config);
   warnings.push(...staged.warnings);
-  const dirtyWarning = getDirtyUnstagedWarning(repoPath);
-  if (dirtyWarning) warnings.push(dirtyWarning);
+  if (!hasStagedInspectionFailure(staged.forbidden)) {
+    const dirtyWarning = getDirtyUnstagedWarning(repoPath);
+    if (dirtyWarning) warnings.push(dirtyWarning);
+  }
 
   if (phase === 'commit') {
     return runCommitPhase(repoPath, opts, checkedAt, warnings, staged.forbidden);
@@ -193,7 +195,21 @@ async function runCommitPhase(
     });
   }
 
-  const evidence = await parsePrBodyEvidence(opts.prBody, opts.headSha);
+  let evidence: PrBodyEvidence;
+  try {
+    evidence = await parsePrBodyEvidence(opts.prBody, opts.headSha);
+  } catch (err) {
+    return buildResult({
+      phase: 'commit',
+      repoPath,
+      checkedAt,
+      status: 'fail',
+      missingFields: ['pr_body'],
+      warnings: [...warnings, `Could not read PR body: ${(err as Error).message}`],
+      evidenceSummary: 'commit gate failed: PR body evidence could not be read',
+    });
+  }
+
   if (evidence.hasManualFallback && !isBlockedSpecStatus(evidence.specStatus)) {
     return buildResult({
       phase: 'commit',
@@ -265,7 +281,21 @@ async function runMergePhase(
     });
   }
 
-  const evidence = await parsePrBodyEvidence(opts.prBody, opts.headSha);
+  let evidence: PrBodyEvidence;
+  try {
+    evidence = await parsePrBodyEvidence(opts.prBody, opts.headSha);
+  } catch (err) {
+    return buildResult({
+      phase: 'merge',
+      repoPath,
+      checkedAt,
+      status: 'fail',
+      missingFields: ['pr_body'],
+      warnings: [...warnings, `Could not read PR body: ${(err as Error).message}`],
+      evidenceSummary: 'merge gate failed: PR body evidence could not be read',
+    });
+  }
+
   const missingFields = missingMergeFields(evidence, Boolean(opts.headSha));
   if (isBlockedSpecStatus(evidence.specStatus)) {
     missingFields.push('ready_spec_gate_status');
@@ -313,14 +343,18 @@ function readStagedPaths(repoPath: string, config: Config): { forbidden: string[
   const result = run(['git', 'diff', '--cached', '--name-only', '--diff-filter=ACMR', '-z'], { cwd: repoPath });
   if (result.exitCode !== 0) {
     return {
-      forbidden: [],
-      warnings: [`Could not inspect staged files with git diff --cached: ${formatShellError(result)}`],
+      forbidden: [`could not inspect staged files with git diff --cached: ${formatShellError(result)}`],
+      warnings: [],
     };
   }
 
   const stagedPaths = result.stdout.split('\0').filter(Boolean).map(normalizeGitPath);
   const forbidden = stagedPaths.filter((stagedPath) => isForbiddenArtifactPath(stagedPath, config));
   return { forbidden, warnings: [] };
+}
+
+function hasStagedInspectionFailure(forbiddenStagedPaths: string[]): boolean {
+  return forbiddenStagedPaths.some((entry) => entry.startsWith('could not inspect staged files with git diff --cached:'));
 }
 
 function getDirtyUnstagedWarning(repoPath: string): string | null {

--- a/src/cli/workflow-check.ts
+++ b/src/cli/workflow-check.ts
@@ -1,0 +1,470 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { loadConfig } from '../config/loader.js';
+import { ensureRepoPath } from '../utils/fs.js';
+import { run } from '../utils/shell.js';
+import { plan } from './plan.js';
+import type { Config } from '../config/types.js';
+
+type WorkflowPhase = 'start' | 'commit' | 'merge';
+type WorkflowStatus = 'pass' | 'fail' | 'manual' | 'skipped';
+type OutputFormat = 'text' | 'json';
+
+type WorkflowCheckOptions = {
+  repo?: string;
+  phase: string;
+  format?: string;
+  issue?: string;
+  prBody?: string;
+  headSha?: string;
+};
+
+type WorkflowCheckResult = {
+  phase: WorkflowPhase;
+  status: WorkflowStatus;
+  repo: string;
+  head_sha: string;
+  checked_at: string;
+  missing_fields: string[];
+  warnings: string[];
+  evidence_summary: string;
+};
+
+type PrBodyEvidence = {
+  hasSpecStatus: boolean;
+  specStatus: 'pass' | 'fail' | 'manual' | 'skipped' | 'pending' | 'unknown' | null;
+  hasSpecRef: boolean;
+  hasManualFallback: boolean;
+  hasFinalMergeGate: boolean;
+  hasLatestHead: boolean;
+  headMatches: boolean | null;
+};
+
+const PHASES = new Set<WorkflowPhase>(['start', 'commit', 'merge']);
+const FORMATS = new Set<OutputFormat>(['text', 'json']);
+const SPEC_STATUS_PATTERN = /\b(?:spec(?:[-_ ](?:gate|workflow|workflow-check|evidence))?|workflow-check|spec_evidence_status)\b[^\n\r]{0,120}\b(pass|fail|manual|skipped|pending|unknown)\b/i;
+const SPEC_REF_PATTERN = /\b(?:spec[_ -]evidence[_ -]ref|spec[_ -]gate[_ -]ref|workflow-check[_ -]ref|spec gate evidence ref|spec gate evidence|workflow-check evidence)\b\s*[:=]?\s*\S+/i;
+const MANUAL_FALLBACK_PATTERN = /\bmanual(?: checklist)? fallback\b|\bmanual spec gate\b|\bmanual workflow gate\b/i;
+const FINAL_MERGE_GATE_PATTERN = /\bfinal merge gate\b|\bmerge gate\b/i;
+const LATEST_HEAD_PATTERN = /\b(?:latest head|head sha|commit hash|head)\b[^\n\r]{0,80}\b[0-9a-f]{7,40}\b/i;
+
+export async function workflowCheck(opts: WorkflowCheckOptions): Promise<void> {
+  const phase = parsePhase(opts.phase);
+  const format = parseFormat(opts.format ?? 'text');
+  const repoPath = path.resolve(opts.repo ?? process.cwd());
+  const checkedAt = new Date().toISOString();
+  const warnings: string[] = [];
+  let config: Config | null = null;
+
+  try {
+    ensureRepoPath(repoPath);
+    config = await loadConfig(repoPath);
+  } catch (err) {
+    const result = buildResult({
+      phase,
+      repoPath,
+      checkedAt,
+      status: 'fail',
+      missingFields: ['config'],
+      warnings,
+      evidenceSummary: `workflow-check could not validate repo config: ${(err as Error).message}`,
+    });
+    printResult(result, format);
+    process.exit(1);
+  }
+
+  const result = await runPhase(phase, repoPath, config, opts, checkedAt, warnings);
+  printResult(result, format);
+  if (result.status === 'fail') process.exit(1);
+}
+
+function parsePhase(value: string): WorkflowPhase {
+  if (PHASES.has(value as WorkflowPhase)) return value as WorkflowPhase;
+  throw new Error(`Unsupported workflow-check phase: ${value}. Expected start|commit|merge.`);
+}
+
+function parseFormat(value: string): OutputFormat {
+  if (FORMATS.has(value as OutputFormat)) return value as OutputFormat;
+  throw new Error(`Unsupported workflow-check format: ${value}. Expected text|json.`);
+}
+
+async function runPhase(
+  phase: WorkflowPhase,
+  repoPath: string,
+  config: Config,
+  opts: WorkflowCheckOptions,
+  checkedAt: string,
+  warnings: string[]
+): Promise<WorkflowCheckResult> {
+  if (phase === 'start') {
+    return runStartPhase(repoPath, opts, checkedAt, warnings);
+  }
+
+  const staged = readStagedPaths(repoPath, config);
+  warnings.push(...staged.warnings);
+  const dirtyWarning = getDirtyUnstagedWarning(repoPath);
+  if (dirtyWarning) warnings.push(dirtyWarning);
+
+  if (phase === 'commit') {
+    return runCommitPhase(repoPath, opts, checkedAt, warnings, staged.forbidden);
+  }
+
+  return runMergePhase(repoPath, opts, checkedAt, warnings, staged.forbidden);
+}
+
+async function runStartPhase(
+  repoPath: string,
+  opts: WorkflowCheckOptions,
+  checkedAt: string,
+  warnings: string[]
+): Promise<WorkflowCheckResult> {
+  if (!opts.issue) {
+    return buildResult({
+      phase: 'start',
+      repoPath,
+      checkedAt,
+      status: 'manual',
+      missingFields: ['issue'],
+      warnings: [...warnings, 'Start phase did not receive --issue; bounded context generation must be checked manually.'],
+      evidenceSummary: 'start gate requires manual fallback because --issue was not provided',
+    });
+  }
+
+  const dryRun = await captureConsole(async () => {
+    await plan(opts.issue as string, {
+      repo: repoPath,
+      dryRun: true,
+      format: 'prompt',
+      verbose: true,
+    });
+  });
+
+  if (!dryRun.ok) {
+    return buildResult({
+      phase: 'start',
+      repoPath,
+      checkedAt,
+      status: 'fail',
+      missingFields: ['bounded_context'],
+      warnings: [...warnings, ...dryRun.warnings],
+      evidenceSummary: `start gate could not generate bounded context: ${dryRun.error}`,
+    });
+  }
+
+  return buildResult({
+    phase: 'start',
+    repoPath,
+    checkedAt,
+    status: 'pass',
+    missingFields: [],
+    warnings: [...warnings, ...dryRun.warnings],
+    evidenceSummary: 'start gate passed: bounded context generated with dry-run stdout-only plan check',
+  });
+}
+
+async function runCommitPhase(
+  repoPath: string,
+  opts: WorkflowCheckOptions,
+  checkedAt: string,
+  warnings: string[],
+  forbiddenStagedPaths: string[]
+): Promise<WorkflowCheckResult> {
+  if (forbiddenStagedPaths.length > 0) {
+    return buildResult({
+      phase: 'commit',
+      repoPath,
+      checkedAt,
+      status: 'fail',
+      missingFields: ['staged_forbidden_artifacts'],
+      warnings,
+      evidenceSummary: `commit gate blocked: staged forbidden artifacts: ${forbiddenStagedPaths.join(', ')}`,
+    });
+  }
+
+  if (!opts.prBody) {
+    return buildResult({
+      phase: 'commit',
+      repoPath,
+      checkedAt,
+      status: 'manual',
+      missingFields: ['pr_body'],
+      warnings: [...warnings, 'PR body not provided; workflow-check can only inspect repo-local staged state.'],
+      evidenceSummary: 'commit gate requires manual fallback: PR body not provided; repo-local staged state is clean',
+    });
+  }
+
+  const evidence = await parsePrBodyEvidence(opts.prBody, opts.headSha);
+  if (evidence.hasManualFallback && !isBlockedSpecStatus(evidence.specStatus)) {
+    return buildResult({
+      phase: 'commit',
+      repoPath,
+      checkedAt,
+      status: 'manual',
+      missingFields: [],
+      warnings,
+      evidenceSummary: 'commit gate recorded manual fallback evidence and staged state is clean',
+    });
+  }
+
+  const missingFields = missingCommitFields(evidence);
+  if (isBlockedSpecStatus(evidence.specStatus)) {
+    missingFields.push('ready_spec_gate_status');
+  }
+
+  if (missingFields.length > 0) {
+    return buildResult({
+      phase: 'commit',
+      repoPath,
+      checkedAt,
+      status: 'fail',
+      missingFields,
+      warnings,
+      evidenceSummary: `commit gate missing ${missingFields.join(', ')}`,
+    });
+  }
+
+  return buildResult({
+    phase: 'commit',
+    repoPath,
+    checkedAt,
+    status: 'pass',
+    missingFields: [],
+    warnings,
+    evidenceSummary: 'commit gate passed: staged artifacts clean and PR body contains spec gate evidence',
+  });
+}
+
+async function runMergePhase(
+  repoPath: string,
+  opts: WorkflowCheckOptions,
+  checkedAt: string,
+  warnings: string[],
+  forbiddenStagedPaths: string[]
+): Promise<WorkflowCheckResult> {
+  if (forbiddenStagedPaths.length > 0) {
+    return buildResult({
+      phase: 'merge',
+      repoPath,
+      checkedAt,
+      status: 'fail',
+      missingFields: ['staged_forbidden_artifacts'],
+      warnings,
+      evidenceSummary: `merge gate blocked: staged forbidden artifacts: ${forbiddenStagedPaths.join(', ')}`,
+    });
+  }
+
+  if (!opts.prBody) {
+    return buildResult({
+      phase: 'merge',
+      repoPath,
+      checkedAt,
+      status: 'manual',
+      missingFields: ['pr_body'],
+      warnings: [...warnings, 'PR body not provided; merge evidence must be checked manually.'],
+      evidenceSummary: 'merge gate requires manual fallback because PR body was not provided',
+    });
+  }
+
+  const evidence = await parsePrBodyEvidence(opts.prBody, opts.headSha);
+  const missingFields = missingMergeFields(evidence, Boolean(opts.headSha));
+  if (isBlockedSpecStatus(evidence.specStatus)) {
+    missingFields.push('ready_spec_gate_status');
+  }
+  if (evidence.headMatches === false) {
+    missingFields.push('head_sha_freshness');
+  }
+
+  if (evidence.hasManualFallback && missingFields.length > 0 && !isBlockedSpecStatus(evidence.specStatus) && evidence.headMatches !== false) {
+    return buildResult({
+      phase: 'merge',
+      repoPath,
+      checkedAt,
+      status: 'manual',
+      missingFields,
+      warnings,
+      evidenceSummary: `merge gate requires manual fallback: missing ${missingFields.join(', ')}`,
+    });
+  }
+
+  if (missingFields.length > 0) {
+    return buildResult({
+      phase: 'merge',
+      repoPath,
+      checkedAt,
+      status: 'fail',
+      missingFields,
+      warnings,
+      evidenceSummary: renderMergeFailureSummary(missingFields),
+    });
+  }
+
+  return buildResult({
+    phase: 'merge',
+    repoPath,
+    checkedAt,
+    status: 'pass',
+    missingFields: [],
+    warnings,
+    evidenceSummary: 'merge gate passed: final merge gate, spec evidence, and HEAD freshness are present',
+  });
+}
+
+function readStagedPaths(repoPath: string, config: Config): { forbidden: string[]; warnings: string[] } {
+  const result = run(['git', 'diff', '--cached', '--name-only', '--diff-filter=ACMR', '-z'], { cwd: repoPath });
+  if (result.exitCode !== 0) {
+    return {
+      forbidden: [],
+      warnings: [`Could not inspect staged files with git diff --cached: ${formatShellError(result)}`],
+    };
+  }
+
+  const stagedPaths = result.stdout.split('\0').filter(Boolean).map(normalizeGitPath);
+  const forbidden = stagedPaths.filter((stagedPath) => isForbiddenArtifactPath(stagedPath, config));
+  return { forbidden, warnings: [] };
+}
+
+function getDirtyUnstagedWarning(repoPath: string): string | null {
+  const result = run(['git', 'status', '--porcelain=v1', '--untracked-files=normal'], { cwd: repoPath });
+  if (result.exitCode !== 0) return `Could not inspect dirty worktree state: ${formatShellError(result)}`;
+  return result.stdout.trim() ? 'Repo has dirty or untracked files; workflow-check did not modify or clean them.' : null;
+}
+
+function isForbiddenArtifactPath(gitPath: string, config: Config): boolean {
+  if (gitPath === '.spec-injector' || gitPath.startsWith('.spec-injector/')) return true;
+  if (gitPath.startsWith('spec-output/') || gitPath.startsWith('spec-outputs/')) return true;
+  if (/(^|\/)issue-\d+-task-package\.md$/i.test(gitPath)) return true;
+  if (/(^|\/)(?:task-package|spec-output|spec-evidence)(?:[.-][^/]*)?\.(?:md|json|txt)$/i.test(gitPath)) return true;
+  if (/(^|\/)\.?private[-_]context(\/|\.md$|\.json$|\.txt$)/i.test(gitPath)) return true;
+  return configuredPrivateExcludes(config).some((prefix) => gitPath === prefix || gitPath.startsWith(`${prefix}/`));
+}
+
+function configuredPrivateExcludes(config: Config): string[] {
+  return (config.specConfig.discovery?.exclude ?? [])
+    .map(normalizeGitPath)
+    .filter((entry) => /private|secret|credential|context/i.test(entry));
+}
+
+async function parsePrBodyEvidence(prBodyPath: string, expectedHeadSha?: string): Promise<PrBodyEvidence> {
+  const body = await fs.readFile(path.resolve(prBodyPath), 'utf8');
+  const statusMatch = body.match(SPEC_STATUS_PATTERN);
+  const specStatus = statusMatch?.[1]?.toLowerCase() as PrBodyEvidence['specStatus'] | undefined;
+  const hasLatestHead = Boolean(expectedHeadSha)
+    ? body.includes(expectedHeadSha as string)
+    : LATEST_HEAD_PATTERN.test(body);
+
+  return {
+    hasSpecStatus: Boolean(statusMatch),
+    specStatus: specStatus ?? null,
+    hasSpecRef: SPEC_REF_PATTERN.test(body),
+    hasManualFallback: MANUAL_FALLBACK_PATTERN.test(body),
+    hasFinalMergeGate: FINAL_MERGE_GATE_PATTERN.test(body),
+    hasLatestHead,
+    headMatches: expectedHeadSha ? body.includes(expectedHeadSha) : null,
+  };
+}
+
+function missingCommitFields(evidence: PrBodyEvidence): string[] {
+  const missing: string[] = [];
+  if (!evidence.hasSpecStatus) missing.push('spec_gate_status');
+  if (!evidence.hasSpecRef) missing.push('spec_evidence_ref');
+  return missing;
+}
+
+function missingMergeFields(evidence: PrBodyEvidence, expectedHeadProvided: boolean): string[] {
+  const missing = missingCommitFields(evidence);
+  if (!evidence.hasFinalMergeGate) missing.push('final_merge_gate');
+  if (!evidence.hasLatestHead) missing.push(expectedHeadProvided ? 'head_sha_freshness' : 'latest_head_sha');
+  return missing;
+}
+
+function isBlockedSpecStatus(status: PrBodyEvidence['specStatus']): boolean {
+  return status === 'fail' || status === 'pending' || status === 'unknown';
+}
+
+function renderMergeFailureSummary(missingFields: string[]): string {
+  if (missingFields.includes('spec_evidence_ref')) return 'merge gate missing spec evidence ref';
+  if (missingFields.includes('head_sha_freshness')) return 'merge gate evidence does not match expected head SHA';
+  return `merge gate missing ${missingFields.join(', ')}`;
+}
+
+function buildResult(input: {
+  phase: WorkflowPhase;
+  repoPath: string;
+  checkedAt: string;
+  status: WorkflowStatus;
+  missingFields: string[];
+  warnings: string[];
+  evidenceSummary: string;
+}): WorkflowCheckResult {
+  return {
+    phase: input.phase,
+    status: input.status,
+    repo: input.repoPath,
+    head_sha: getHeadSha(input.repoPath),
+    checked_at: input.checkedAt,
+    missing_fields: unique(input.missingFields),
+    warnings: unique(input.warnings),
+    evidence_summary: input.evidenceSummary,
+  };
+}
+
+function getHeadSha(repoPath: string): string {
+  const result = run(['git', 'rev-parse', 'HEAD'], { cwd: repoPath });
+  if (result.exitCode !== 0) return 'n/a';
+  return result.stdout.trim() || 'n/a';
+}
+
+function printResult(result: WorkflowCheckResult, format: OutputFormat): void {
+  if (format === 'json') {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  console.log(`phase=${result.phase}`);
+  console.log(`status=${result.status}`);
+  console.log(`repo=${result.repo}`);
+  console.log(`head_sha=${result.head_sha}`);
+  console.log(`checked_at=${result.checked_at}`);
+  console.log(`missing_fields=${result.missing_fields.length > 0 ? result.missing_fields.join(',') : 'none'}`);
+  console.log(`warnings=${result.warnings.length > 0 ? result.warnings.join(' | ') : 'none'}`);
+  console.log(`evidence_summary=${result.evidence_summary}`);
+}
+
+async function captureConsole(fn: () => Promise<void>): Promise<{ ok: true; warnings: string[] } | { ok: false; warnings: string[]; error: string }> {
+  const originalLog = console.log;
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  const warnings: string[] = [];
+
+  console.log = () => undefined;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.join(' '));
+  };
+  console.error = (...args: unknown[]) => {
+    warnings.push(args.join(' '));
+  };
+
+  try {
+    await fn();
+    return { ok: true, warnings };
+  } catch (err) {
+    return { ok: false, warnings, error: (err as Error).message };
+  } finally {
+    console.log = originalLog;
+    console.warn = originalWarn;
+    console.error = originalError;
+  }
+}
+
+function normalizeGitPath(value: string): string {
+  return value.replaceAll('\\', '/').replace(/^\.\/+/u, '').replace(/\/+$/u, '');
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function formatShellError(result: { stdout: string; stderr: string; exitCode: number }): string {
+  const message = `${result.stderr}\n${result.stdout}`.trim();
+  return message || `exit ${result.exitCode}`;
+}

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -779,6 +779,59 @@ test('spec workflow-check fails commit phase when .spec-injector artifacts are s
   assert.match(parsed.evidence_summary, /\.spec-injector\/out\/issue-224-task-package\.md/);
 });
 
+test('spec workflow-check fails commit phase when staged artifact inspection cannot run', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-git-fail-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  const prBodyPath = path.join(path.dirname(repoDir), `${path.basename(repoDir)}-pr-body.md`);
+  t.after(async () => {
+    await fs.rm(prBodyPath, { force: true });
+  });
+  await fs.writeFile(prBodyPath, [
+    '## Spec workflow gate',
+    '- spec gate status: pass',
+    '- spec evidence ref: workflow-check:start:manual',
+  ].join('\n'), 'utf8');
+  const env = await createFailingGitEnv(t, process.env);
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'commit',
+    '--pr-body', prBodyPath,
+    '--format', 'json',
+  ], { env });
+
+  assert.notEqual(result.code, 0);
+  assert.equal(result.stderr, '');
+  const parsed = JSON.parse(result.stdout) as { status: string; missing_fields: string[]; warnings: string[]; evidence_summary: string };
+  assert.equal(parsed.status, 'fail');
+  assert.ok(parsed.missing_fields.includes('staged_forbidden_artifacts'));
+  assert.deepEqual(parsed.warnings, []);
+  assert.match(parsed.evidence_summary, /could not inspect staged files/i);
+});
+
+test('spec workflow-check returns structured failure when commit PR body cannot be read', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-pr-body-missing-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'commit',
+    '--pr-body', path.join(repoDir, 'missing-pr-body.md'),
+    '--format', 'json',
+  ]);
+
+  assert.notEqual(result.code, 0);
+  assert.equal(result.stderr, '');
+  const parsed = JSON.parse(result.stdout) as { status: string; missing_fields: string[]; warnings: string[]; evidence_summary: string };
+  assert.equal(parsed.status, 'fail');
+  assert.ok(parsed.missing_fields.includes('pr_body'));
+  assert.match(parsed.warnings.join('\n'), /Could not read PR body/i);
+  assert.match(parsed.evidence_summary, /PR body evidence could not be read/i);
+});
+
 test('spec workflow-check fails merge phase when spec evidence ref is missing from PR body', async (t) => {
   const repoDir = await createTempRepo(t, 'spec-injector-workflow-merge-');
   await writeConfig(repoDir, { version: 2, guardrails: [] });
@@ -807,6 +860,29 @@ test('spec workflow-check fails merge phase when spec evidence ref is missing fr
   assert.equal(parsed.status, 'fail');
   assert.ok(parsed.missing_fields.includes('spec_evidence_ref'));
   assert.match(parsed.evidence_summary, /missing spec evidence ref/i);
+});
+
+test('spec workflow-check returns structured failure when merge PR body cannot be read', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-merge-pr-body-missing-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'merge',
+    '--pr-body', path.join(repoDir, 'missing-pr-body.md'),
+    '--head-sha', '1234567',
+    '--format', 'json',
+  ]);
+
+  assert.notEqual(result.code, 0);
+  assert.equal(result.stderr, '');
+  const parsed = JSON.parse(result.stdout) as { status: string; missing_fields: string[]; warnings: string[]; evidence_summary: string };
+  assert.equal(parsed.status, 'fail');
+  assert.ok(parsed.missing_fields.includes('pr_body'));
+  assert.match(parsed.warnings.join('\n'), /Could not read PR body/i);
+  assert.match(parsed.evidence_summary, /PR body evidence could not be read/i);
 });
 
 test('spec workflow-check returns manual fallback when commit phase has no PR body', async (t) => {

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -625,6 +625,7 @@ test('spec --help lists deterministic CLI purpose and available commands', async
   assert.match(result.stdout, /\bplan\b/);
   assert.match(result.stdout, /\bconfig\b/);
   assert.match(result.stdout, /\bclean\b/);
+  assert.match(result.stdout, /\bworkflow-check\b/);
   assert.match(result.stdout, /\bevidence-check\b/);
   assert.match(result.stdout, /\blabel-audit\b/);
   assert.match(result.stdout, /help \[command\]/i);
@@ -692,12 +693,165 @@ test('spec plan/config/clean help describe AI-facing usage and safety constraint
   assert.match(evidenceCheckHelp.stdout, /--expected-head <sha>/);
   assert.match(evidenceCheckHelp.stdout, /read-only guardrail/i);
 
+  const workflowCheckHelp = await runSpec(['workflow-check', '--help']);
+  assert.equal(workflowCheckHelp.code, 0, workflowCheckHelp.stderr);
+  assert.match(workflowCheckHelp.stdout, /local-only workflow gate/i);
+  assert.match(workflowCheckHelp.stdout, /--phase <phase>/);
+  assert.match(workflowCheckHelp.stdout, /start\|commit\|merge/);
+  assert.match(workflowCheckHelp.stdout, /--format <format>/);
+  assert.match(workflowCheckHelp.stdout, /stdout/i);
+  assert.match(workflowCheckHelp.stdout, /does not edit GitHub/i);
+
   const labelAuditHelp = await runSpec(['label-audit', '--help']);
   assert.equal(labelAuditHelp.code, 0, labelAuditHelp.stderr);
   assert.match(labelAuditHelp.stdout, /label and milestone metadata audit/i);
   assert.match(labelAuditHelp.stdout, /--repo <owner\/name>/);
   assert.match(labelAuditHelp.stdout, /reports only/i);
   assert.match(labelAuditHelp.stdout, /does not create, rename, delete, or mutate/i);
+});
+
+test('spec workflow-check rejects invalid phases before touching repo state', async () => {
+  const result = await runSpec(['workflow-check', '--repo', repoRoot, '--phase', 'review']);
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stderr, /Unsupported workflow-check phase/i);
+  assert.match(result.stderr, /start\|commit\|merge/);
+  assertNoRawStackTrace(result);
+});
+
+test('spec workflow-check emits stable JSON contract for commit phase PR body evidence', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-json-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+  const headSha = (await runCommand('git', ['rev-parse', 'HEAD'], repoDir)).stdout.trim();
+  const prBodyPath = path.join(path.dirname(repoDir), `${path.basename(repoDir)}-pr-body.md`);
+  t.after(async () => {
+    await fs.rm(prBodyPath, { force: true });
+  });
+  await fs.writeFile(prBodyPath, [
+    '## Spec workflow gate',
+    '- spec gate status: pass',
+    `- spec evidence ref: workflow-check:start:${headSha}`,
+  ].join('\n'), 'utf8');
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'commit',
+    '--pr-body', prBodyPath,
+    '--format', 'json',
+  ]);
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(result.stderr, '');
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.phase, 'commit');
+  assert.equal(parsed.status, 'pass');
+  assert.equal(parsed.repo, repoDir);
+  assert.equal(parsed.head_sha, headSha);
+  assert.match(String(parsed.checked_at), /^\d{4}-\d{2}-\d{2}T/);
+  assert.deepEqual(parsed.missing_fields, []);
+  assert.deepEqual(parsed.warnings, []);
+  assert.match(String(parsed.evidence_summary), /commit gate passed/i);
+});
+
+test('spec workflow-check fails commit phase when .spec-injector artifacts are staged', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-staged-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+  await writeRepoFiles(repoDir, {
+    '.spec-injector/out/issue-224-task-package.md': '# generated private context\n',
+  });
+  await runCommand('git', ['add', '.spec-injector/out/issue-224-task-package.md'], repoDir);
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'commit',
+    '--format', 'json',
+  ]);
+
+  assert.notEqual(result.code, 0);
+  assert.equal(result.stderr, '');
+  const parsed = JSON.parse(result.stdout) as { status: string; missing_fields: string[]; evidence_summary: string };
+  assert.equal(parsed.status, 'fail');
+  assert.ok(parsed.missing_fields.includes('staged_forbidden_artifacts'));
+  assert.match(parsed.evidence_summary, /\.spec-injector\/out\/issue-224-task-package\.md/);
+});
+
+test('spec workflow-check fails merge phase when spec evidence ref is missing from PR body', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-merge-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+  const headSha = (await runCommand('git', ['rev-parse', 'HEAD'], repoDir)).stdout.trim();
+  const prBodyPath = path.join(repoDir, 'pr-body.md');
+  await fs.writeFile(prBodyPath, [
+    '## Final merge gate',
+    '- latest head SHA: ' + headSha,
+    '- validation: pass',
+    '- spec gate status: pass',
+  ].join('\n'), 'utf8');
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'merge',
+    '--pr-body', prBodyPath,
+    '--head-sha', headSha,
+    '--format', 'json',
+  ]);
+
+  assert.notEqual(result.code, 0);
+  assert.equal(result.stderr, '');
+  const parsed = JSON.parse(result.stdout) as { status: string; missing_fields: string[]; evidence_summary: string };
+  assert.equal(parsed.status, 'fail');
+  assert.ok(parsed.missing_fields.includes('spec_evidence_ref'));
+  assert.match(parsed.evidence_summary, /missing spec evidence ref/i);
+});
+
+test('spec workflow-check returns manual fallback when commit phase has no PR body', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-manual-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'commit',
+  ]);
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /phase=commit/);
+  assert.match(result.stdout, /status=manual/);
+  assert.match(result.stdout, /PR body not provided/i);
+  assert.match(result.stdout, /missing_fields=pr_body/);
+});
+
+test('spec workflow-check start phase uses mocked gh read-only issue context and writes no task package', async (t) => {
+  const fixture = await createSpecPlanFixture(t);
+  await initCleanGitRepo(fixture.repoDir);
+  const before = await readDirectorySnapshot(fixture.repoDir);
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', fixture.repoDir,
+    '--phase', 'start',
+    '--issue', fixture.issueUrl,
+    '--format', 'json',
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(result.stderr, '');
+  const parsed = JSON.parse(result.stdout) as { phase: string; status: string; missing_fields: string[]; evidence_summary: string };
+  assert.equal(parsed.phase, 'start');
+  assert.equal(parsed.status, 'pass');
+  assert.deepEqual(parsed.missing_fields, []);
+  assert.match(parsed.evidence_summary, /bounded context generated/i);
+  await assertFileMissing(fixture.taskPackagePath);
+  assert.deepEqual(await readDirectorySnapshot(fixture.repoDir), before);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assert.match(ghLog, /issue view/);
+  assertNoGhMutationCommands(ghLog);
 });
 
 test('spec label-audit forwards --limit to gh issue and pr list', async (t) => {


### PR DESCRIPTION
Closes #224

## Source of truth
- #224

## Depends on PR
- none

## Summary
- 新增 local-only `spec workflow-check` CLI，支援 `--phase start|commit|merge` 與 `--format json`。
- `start` phase 會 validate repo config，且在提供 `--issue` 時用 dry-run `spec plan` 檢查 bounded context，不寫 task package。
- `commit` / `merge` phase 會檢查 staged forbidden artifacts、local PR body evidence、manual fallback 與 merge HEAD freshness。
- README / README.en 補 downstream usage，說明 tachigo / tachiya 只需引用 workflow-check status/ref，不需要讓 Scope Police parse full spec evidence。
- Review follow-up：PR body 讀取失敗與 staged artifact inspection 失敗現在都回傳 structured gate failure，不再繞過 text/JSON contract 或誤判 pass。

## Tests / validation
- `pnpm build && node --test tests/cli.integration.test.ts --test-name-pattern "workflow-check"`：160 pass
- `pnpm test`：192 pass / 2 skip
- `pnpm build`：pass
- `git diff --check`：pass

## Implementation Evidence
- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/224#issuecomment-4441111640
- Latest HEAD: `064eb42b02569c4516146051862543c2d1e4fa6a`
- Original implementation commit: `7d54bffd45eae015fce3be44369ef66f21ccd55a`
- Branch: `codex/workflow-check-224`

## Review finding assessment
- adopted: CodeRabbit/Codex staged inspection finding. `git diff --cached` failure now blocks the gate as `staged_forbidden_artifacts` instead of warning + pass.
- adopted: CodeRabbit PR body read failure finding. `commit` and `merge` phase now catch unreadable `--pr-body` and emit structured `fail` result with `missing_fields=[pr_body]`.
- not adopted: none.
- optional polish: none.
- noise / not applicable: CodeRabbit docstring coverage finishing-touch warning is not adopted; this repo does not use docstring coverage as a validation gate for TypeScript CLI helpers.

## Scope guard / non-goals confirmation
- 不做 GitHub mutation from the CLI command itself。
- 不做 hosted control plane。
- 不做 downstream repo Scope Police changes。
- 不自動寫 output file；`workflow-check` 預設只輸出 stdout。
- 不提交 downstream repo 的 `.spec-injector/`、generated output、private context。
- 不做 daemon、dashboard、auto-merge、auto-comment。

## Review closeout / final merge gate evidence
- Latest review-fix HEAD: `064eb42b02569c4516146051862543c2d1e4fa6a`。
- Merge 前仍需重新確認 latest HEAD、CI/checks、review threads、CodeRabbit / Codex auto review findings 與 evidence freshness。
- ready-to-merge evidence 不能是 pending/unknown；若後續 head 變更，需重新跑 validation 並刷新 evidence。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new CLI command to validate repository workflow across three phases (start, commit, merge), with text and stable JSON output and built-in help/validation for options.

* **Documentation**
  * Updated Quickstart with example commands, behavior notes, JSON output field list, and per-phase checks & failure conditions.

* **Tests**
  * Added integration tests covering phase behaviors, JSON output, error cases, and safety/read-only assertions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Erick52106/spec-injector/pull/225)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->