### PR TITLE
feat(workflow): add hybrid AWP fallback gate

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -169,6 +169,7 @@ spec plan <issue-number-or-url> --repo . --dry-run --format prompt --verbose
 spec workflow-check --repo . --phase start --issue <issue-number-or-url>
 spec workflow-check --repo . --phase commit --pr-body /path/to/pr-body.md
 spec workflow-check --repo . --phase merge --pr-body /path/to/pr-body.md --head-sha <sha>
+spec workflow-check --repo . --phase commit --pr-body /path/to/pr-body.md --routing-evidence /path/to/start-gate.json
 ```
 
 Notes:
@@ -181,13 +182,14 @@ Notes:
 - `spec workflow-check` is a local-only, stdout-first workflow gate for autonomous PR evidence. It does not edit GitHub, add/commit files, write task packages, comment, merge, or mutate downstream repos.
 - Autonomous worker-routing flows can use the [Hybrid AWP routing policy](docs/hybrid-awp-routing-policy.md) as the start-gate source of truth before implementation begins.
 - `spec workflow-check --format json` emits the same stable fields as text output: `phase`, `status`, `repo`, `head_sha`, `checked_at`, `missing_fields`, `warnings`, and `evidence_summary`.
+- Hybrid AWP checks add optional JSON/text fields such as `routing_mode`, `routing_task_class`, `spark_required`, `worker_5_4_required`, `controller_role`, `controller_fallback`, `controller_fallback_reason`, `fallback_status`, `fallback_reason_quality`, and `routing_mismatch`.
 - Downstream repos such as `tachigo` / `tachiya` only need to copy or reference the workflow-check `status` and evidence `ref` in their PR body / ledger. Their Scope Police workflows should not parse full `spec plan` or task-package evidence.
 
 `spec workflow-check` phases:
 
-- `start`: validates repo config. With `--issue`, it performs a dry-run bounded context check through `spec plan --dry-run --format prompt --verbose` without writing a task package.
-- `commit`: checks staged files for `.spec-injector/`, generated task packages / spec output, and private context artifacts. With `--pr-body`, it also checks for spec gate status/ref or manual fallback evidence.
-- `merge`: checks a local PR body for final merge gate evidence, spec gate status/ref, and latest HEAD SHA. With `--head-sha`, stale or mismatched evidence fails.
+- `start`: validates repo config. With `--issue`, it performs a dry-run bounded context check through `spec plan --dry-run --format prompt --verbose` without writing a task package. If the issue has an AWP / Codex autonomous routing signal, it also emits a deterministic Hybrid AWP routing plan; if no autonomous signal is present, routing fields are `n/a` and ordinary workflows do not fail.
+- `commit`: checks staged files for `.spec-injector/`, generated task packages / spec output, and private context artifacts. With `--pr-body`, it also checks for spec gate status/ref or manual fallback evidence. With `--routing-evidence`, it checks local PR body routing status/ref, delegation log, Spark / ops evidence, 5.4 worker evidence, and explicit fallback quality.
+- `merge`: checks a local PR body for final merge gate evidence, spec gate status/ref, and latest HEAD SHA. With `--head-sha`, stale or mismatched evidence fails. With `--routing-evidence`, stale start-gate routing evidence or routing/PR-body mismatch fails.
 
 ## Optional live gh smoke test
 

--- a/README.en.md
+++ b/README.en.md
@@ -179,6 +179,7 @@ Notes:
 - `spec plan ... --dry-run --format prompt --verbose` is the recommended pre-implementation command for AI planning.
 - For a full generated task package file, omit `--dry-run`; output is written under `.spec-injector/out/`.
 - `spec workflow-check` is a local-only, stdout-first workflow gate for autonomous PR evidence. It does not edit GitHub, add/commit files, write task packages, comment, merge, or mutate downstream repos.
+- Autonomous worker-routing flows can use the [Hybrid AWP routing policy](docs/hybrid-awp-routing-policy.md) as the start-gate source of truth before implementation begins.
 - `spec workflow-check --format json` emits the same stable fields as text output: `phase`, `status`, `repo`, `head_sha`, `checked_at`, `missing_fields`, `warnings`, and `evidence_summary`.
 - Downstream repos such as `tachigo` / `tachiya` only need to copy or reference the workflow-check `status` and evidence `ref` in their PR body / ledger. Their Scope Police workflows should not parse full `spec plan` or task-package evidence.
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ spec plan <issue-number-or-url> --repo . --dry-run --format prompt --verbose
 spec workflow-check --repo . --phase start --issue <issue-number-or-url>
 spec workflow-check --repo . --phase commit --pr-body /path/to/pr-body.md
 spec workflow-check --repo . --phase merge --pr-body /path/to/pr-body.md --head-sha <sha>
+spec workflow-check --repo . --phase commit --pr-body /path/to/pr-body.md --routing-evidence /path/to/start-gate.json
 ```
 
 Notes:
@@ -192,13 +193,14 @@ Notes:
 - `spec workflow-check` is a local-only, stdout-first workflow gate for autonomous PR evidence. It does not edit GitHub, add/commit files, write task packages, comment, merge, or mutate downstream repos.
 - Autonomous worker-routing flow 可在 implementation 開始前使用 [Hybrid AWP routing policy](docs/hybrid-awp-routing-policy.md) 作為 start-gate source of truth。
 - `spec workflow-check --format json` emits the same stable fields as the text output: `phase`, `status`, `repo`, `head_sha`, `checked_at`, `missing_fields`, `warnings`, and `evidence_summary`.
+- Hybrid AWP checks add optional JSON/text fields such as `routing_mode`, `routing_task_class`, `spark_required`, `worker_5_4_required`, `controller_role`, `controller_fallback`, `controller_fallback_reason`, `fallback_status`, `fallback_reason_quality`, and `routing_mismatch`.
 - Downstream repos such as `tachigo` / `tachiya` only need to copy or reference the workflow-check `status` and evidence `ref` in their PR body / ledger. Their Scope Police workflows should not parse full `spec plan` or task-package evidence.
 
 `spec workflow-check` phases:
 
-- `start`: validates repo config. With `--issue`, it performs a dry-run bounded context check through `spec plan --dry-run --format prompt --verbose` without writing a task package.
-- `commit`: checks staged files for `.spec-injector/`, generated task packages / spec output, and private context artifacts. With `--pr-body`, it also checks for spec gate status/ref or manual fallback evidence.
-- `merge`: checks a local PR body for final merge gate evidence, spec gate status/ref, and latest HEAD SHA. With `--head-sha`, stale or mismatched evidence fails.
+- `start`: validates repo config. With `--issue`, it performs a dry-run bounded context check through `spec plan --dry-run --format prompt --verbose` without writing a task package. If the issue has an AWP / Codex autonomous routing signal, it also emits a deterministic Hybrid AWP routing plan; if no autonomous signal is present, routing fields are `n/a` and ordinary workflows do not fail.
+- `commit`: checks staged files for `.spec-injector/`, generated task packages / spec output, and private context artifacts. With `--pr-body`, it also checks for spec gate status/ref or manual fallback evidence. With `--routing-evidence`, it checks local PR body routing status/ref, delegation log, Spark / ops evidence, 5.4 worker evidence, and explicit fallback quality.
+- `merge`: checks a local PR body for final merge gate evidence, spec gate status/ref, and latest HEAD SHA. With `--head-sha`, stale or mismatched evidence fails. With `--routing-evidence`, stale start-gate routing evidence or routing/PR-body mismatch fails.
 
 ## Optional live gh smoke test
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Notes:
 - `spec plan ... --dry-run --format prompt --verbose` is the recommended pre-implementation command for AI planning.
 - For a full generated task package file, omit `--dry-run`; output is written under `.spec-injector/out/`.
 - `spec workflow-check` is a local-only, stdout-first workflow gate for autonomous PR evidence. It does not edit GitHub, add/commit files, write task packages, comment, merge, or mutate downstream repos.
+- Autonomous worker-routing flow 可在 implementation 開始前使用 [Hybrid AWP routing policy](docs/hybrid-awp-routing-policy.md) 作為 start-gate source of truth。
 - `spec workflow-check --format json` emits the same stable fields as the text output: `phase`, `status`, `repo`, `head_sha`, `checked_at`, `missing_fields`, `warnings`, and `evidence_summary`.
 - Downstream repos such as `tachigo` / `tachiya` only need to copy or reference the workflow-check `status` and evidence `ref` in their PR body / ledger. Their Scope Police workflows should not parse full `spec plan` or task-package evidence.
 

--- a/docs/hybrid-awp-routing-policy.md
+++ b/docs/hybrid-awp-routing-policy.md
@@ -1,0 +1,82 @@
+# Hybrid Autonomous Worker Profiles routing policy
+
+## Purpose
+
+Hybrid Autonomous Worker Profiles (Hybrid AWP) is a Layer 2 workflow guardrail for autonomous AI-assisted PR work. It defines how a controller decides, before implementation starts, whether a task should be handled by an ops / readback worker, a bounded implementation worker, or the controller itself.
+
+This policy is a source of truth for `spec plan` and `spec workflow-check --phase start` design. It is not a hosted control plane, worker runtime, daemon, dashboard, merge bot, or GitHub mutation system.
+
+## Applicability
+
+Hybrid AWP applies only when the target workflow has an explicit autonomous routing signal, such as:
+
+- an Autonomous Worker Profiles (AWP) instruction
+- a Codex autonomous PR workflow
+- an equivalent repo-local worker-routing contract
+
+Absence of autonomous routing signal must not fail ordinary human PRs or non-autonomous AI-assisted work. In that case, workflow gates should report `skipped`, `manual`, or `n/a` for AWP-only checks instead of failing solely because routing evidence is absent.
+
+Downstream Scope Police workflows should not enforce AWP routing sections for general human PRs.
+
+## Start gate
+
+Routing is decided at the start gate, before implementation starts and before the controller commits to a plan. The start gate should classify the task, decide which worker class is required, and record the controller's retained role.
+
+The required policy output fields are:
+
+- `routing_mode=hybrid_awp|strict_awp|controller_fallback`
+- `task_class=<class>`
+- `spark_required=yes|no`
+- `worker_5_4_required=yes|no`
+- `controller_role=<scope|architecture|review|merge_gate|fallback_executor>`
+- `controller_fallback=allowed|denied`
+- `controller_fallback_reason=<reason or n/a>`
+- `delegation_threshold=<short explanation>`
+
+These fields may be rendered as human-readable evidence or JSON in future CLI work. Downstream repos only need to reference the resulting routing status and evidence ref; they do not need to parse the full routing plan.
+
+## Task classes
+
+| Task class | Default route | Controller role | Delegation threshold |
+| --- | --- | --- | --- |
+| `trivial_readonly` | Controller fallback may be allowed. | `fallback_executor` or `review` | Only for 0-3 minute read-only checks with no repo mutation and no GitHub mutation. Record why delegation would add more overhead than value. |
+| `metadata_readback` | Ops / readback worker required when workers are available. | `review` | GitHub issue / PR / CI / review-thread / connector readback should be delegated because it is routine, bounded, and independently verifiable. |
+| `small_docs_template_test` | Bounded implementation worker preferred when workers are available. | `scope` and `review` | Narrow docs, template, fixture, or workflow-test patches can be delegated once allowed files and non-goals are clear. |
+| `workflow_policy` | Bounded implementation worker may edit; controller keeps final policy decision. | `scope`, `architecture`, and `review` | Scope Police, CI, evidence, workflow governance, or policy docs need controller ownership for scope and review, even when edits are delegated. |
+| `product_behavior` | Controller owns architecture; bounded implementation worker may handle slices. | `architecture` and `review` | Backend, frontend, runtime, auth, data, or user-visible behavior needs controller design ownership before any worker implementation slice. |
+| `merge_gate` | Controller-owned. | `merge_gate` | Review finding adoption, exact head SHA decisions, CI / review-thread closeout, and merge readiness stay with the controller. Routine readback can still be delegated. |
+
+## Fallback rules
+
+`controller_fallback=allowed` is acceptable only when the reason is explicit and bounded. Good reasons include:
+
+- no subagent or worker facility is available in the current environment
+- the task is `trivial_readonly` and delegation overhead exceeds the work
+- the human explicitly requested controller-only execution
+- an implementation worker is unavailable, but the controller can keep the change narrow and record the fallback
+
+`controller_fallback=denied` should be used when the task requires independent readback, bounded implementation, or merge-time evidence separation. Missing, vague, or self-justifying reasons should not be treated as meaningful fallback evidence.
+
+Controller fallback must not be used to bypass scope review, avoid tests, skip evidence freshness, or turn the CLI into an autonomous executor.
+
+## Downstream evidence contract
+
+Downstream repos such as `tachigo` and `tachiya` may keep their PR templates and Scope Police thin. They should reference:
+
+- routing status
+- routing evidence ref
+- spec gate status / ref
+- final merge gate status / ref
+
+They should not parse full `spec plan` output, task packages, worker transcripts, or private context. If richer routing evidence is needed, it should be linked as a local or PR-body evidence ref rather than expanded into downstream policy parsers.
+
+## Non-goals
+
+This policy does not:
+
+- spawn workers
+- call model providers
+- mutate GitHub issues, PRs, labels, comments, or reviews
+- write task packages or routing files by default
+- require non-autonomous users to provide routing plans
+- define a hosted control plane, daemon, dashboard, merge bot, or auto-commenter

--- a/docs/hybrid-awp-routing-policy.md
+++ b/docs/hybrid-awp-routing-policy.md
@@ -33,7 +33,7 @@ The required policy output fields are:
 - `controller_fallback_reason=<reason or n/a>`
 - `delegation_threshold=<short explanation>`
 
-These fields may be rendered as human-readable evidence or JSON in future CLI work. Downstream repos only need to reference the resulting routing status and evidence ref; they do not need to parse the full routing plan.
+`spec workflow-check --phase start --format json` renders these fields as local-only start-gate evidence when an autonomous routing signal is present. Downstream repos only need to reference the resulting routing status and evidence ref; they do not need to parse the full routing plan.
 
 ## Task classes
 
@@ -59,6 +59,14 @@ These fields may be rendered as human-readable evidence or JSON in future CLI wo
 
 Controller fallback must not be used to bypass scope review, avoid tests, skip evidence freshness, or turn the CLI into an autonomous executor.
 
+`spec workflow-check` reports fallback checks with:
+
+- `fallback_status=pass|fail|manual|n/a`
+- `fallback_reason_quality=strong|weak|missing|n/a`
+- `routing_mismatch=<comma-separated list or none>`
+
+Weak fallback reasons include empty values and low-signal text such as `n/a`, `none`, `small`, `done`, `ok`, or `trivial` without bounded context.
+
 ## Downstream evidence contract
 
 Downstream repos such as `tachigo` and `tachiya` may keep their PR templates and Scope Police thin. They should reference:
@@ -69,6 +77,15 @@ Downstream repos such as `tachigo` and `tachiya` may keep their PR templates and
 - final merge gate status / ref
 
 They should not parse full `spec plan` output, task packages, worker transcripts, or private context. If richer routing evidence is needed, it should be linked as a local or PR-body evidence ref rather than expanded into downstream policy parsers.
+
+Commit and merge gates may receive local start-gate routing evidence through:
+
+```bash
+spec workflow-check --repo . --phase commit --pr-body /tmp/pr.md --routing-evidence /tmp/start-gate.json
+spec workflow-check --repo . --phase merge --pr-body /tmp/pr.md --routing-evidence /tmp/start-gate.json --head-sha <sha>
+```
+
+The routing evidence file is local input only. The CLI does not fetch or mutate GitHub to resolve routing evidence refs.
 
 ## Non-goals
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -12,6 +12,8 @@ Dogfood finding、review blocker、CI failure、evidence freshness gap 與 repea
 
 Issue / PR label taxonomy、visual hierarchy、combination rules、migration staging 與 #110 label / milestone audit checker rules 見 [label-taxonomy.md](label-taxonomy.md)。
 
+Autonomous Worker Profiles / Codex autonomous PR work 的 start-gate routing source of truth 見 [Hybrid AWP routing policy](hybrid-awp-routing-policy.md)。該 policy 只適用於有明確 autonomous routing signal 的 workflow；一般 human PR 或非 autonomous work 不應因缺少 AWP routing evidence 而 fail。
+
 Future companion / workflow observability status vocabulary 見 [status-event-schema.md](status-event-schema.md)。該 schema 是 Layer 4 design proposal，不代表 daemon、companion UI、CLI JSON output、watcher、merge bot 或 target repo automation 已實作。
 
 `spec label-audit` 是 repo-local、human-readable 的 read-only guardrail。它讀取 accepted taxonomy 與 `gh issue list` / `gh pr list` metadata，輸出 `PASS` / `WARNING` / `NEEDS-HUMAN-REVIEW`；它只 report，不建立 labels、不修改 labels、不修改 milestones、不修改 issue / PR metadata。`needs human review` 代表 stop-and-report，不代表 checker 自動替 human 做 metadata 決策。

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -14,6 +14,8 @@ Issue / PR label taxonomy、visual hierarchy、combination rules、migration sta
 
 Autonomous Worker Profiles / Codex autonomous PR work 的 start-gate routing source of truth 見 [Hybrid AWP routing policy](hybrid-awp-routing-policy.md)。該 policy 只適用於有明確 autonomous routing signal 的 workflow；一般 human PR 或非 autonomous work 不應因缺少 AWP routing evidence 而 fail。
 
+若 autonomous workflow 有 start-gate routing evidence，可在 commit / merge 階段用 local file 傳入 `spec workflow-check --routing-evidence <path>`。該檢查只讀本地 PR body 與本地 routing JSON，驗證 status/ref、delegation log、Spark / ops evidence、5.4 worker evidence、explicit fallback reason 與 merge HEAD freshness；它不讀取或修改 GitHub remote state，也不要求 downstream Scope Police 解析完整 routing plan。
+
 Future companion / workflow observability status vocabulary 見 [status-event-schema.md](status-event-schema.md)。該 schema 是 Layer 4 design proposal，不代表 daemon、companion UI、CLI JSON output、watcher、merge bot 或 target repo automation 已實作。
 
 `spec label-audit` 是 repo-local、human-readable 的 read-only guardrail。它讀取 accepted taxonomy 與 `gh issue list` / `gh pr list` metadata，輸出 `PASS` / `WARNING` / `NEEDS-HUMAN-REVIEW`；它只 report，不建立 labels、不修改 labels、不修改 milestones、不修改 issue / PR metadata。`needs human review` 代表 stop-and-report，不代表 checker 自動替 human 做 metadata 決策。

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -154,11 +154,12 @@ program
   .option('--issue <number-or-url>', 'Issue number or URL for start-phase dry-run bounded context checks')
   .option('--pr-body <path>', 'Path to a local PR body markdown file for commit/merge evidence checks')
   .option('--head-sha <sha>', 'Expected latest head SHA for merge evidence freshness checks')
+  .option('--routing-evidence <path>', 'Path to local Hybrid AWP start-gate routing evidence JSON')
   .addHelpText('after', `
 Checks:
   - start: validate config; with --issue, dry-run bounded context generation without writing a task package
-  - commit: detect staged .spec-injector/spec output/private context artifacts and optional PR body spec evidence
-  - merge: require final merge gate, spec gate status/ref, and latest HEAD evidence in the local PR body
+  - commit: detect staged .spec-injector/spec output/private context artifacts and optional PR body spec/routing evidence
+  - merge: require final merge gate, spec gate status/ref, routing evidence alignment, and latest HEAD evidence in the local PR body
 
 Safety:
   Local-only workflow gate. Prints to stdout by default.
@@ -171,6 +172,7 @@ Safety:
     issue?: string;
     prBody?: string;
     headSha?: string;
+    routingEvidence?: string;
   }) => {
     const { workflowCheck } = await import('./workflow-check.js');
     await workflowCheck(opts);

--- a/src/cli/workflow-check.ts
+++ b/src/cli/workflow-check.ts
@@ -5,6 +5,8 @@ import { ensureRepoPath } from '../utils/fs.js';
 import { run } from '../utils/shell.js';
 import { plan } from './plan.js';
 import type { Config } from '../config/types.js';
+import { fetchIssue } from '../github/issue.js';
+import type { Issue } from '../github/types.js';
 
 type WorkflowPhase = 'start' | 'commit' | 'merge';
 type WorkflowStatus = 'pass' | 'fail' | 'manual' | 'skipped';
@@ -17,6 +19,7 @@ type WorkflowCheckOptions = {
   issue?: string;
   prBody?: string;
   headSha?: string;
+  routingEvidence?: string;
 };
 
 type WorkflowCheckResult = {
@@ -28,6 +31,18 @@ type WorkflowCheckResult = {
   missing_fields: string[];
   warnings: string[];
   evidence_summary: string;
+  routing_mode?: string;
+  routing_task_class?: string;
+  spark_required?: string;
+  worker_5_4_required?: string;
+  controller_role?: string;
+  controller_fallback?: string;
+  controller_fallback_reason?: string;
+  delegation_threshold?: string;
+  routing_evidence_ref?: string;
+  fallback_status?: string;
+  fallback_reason_quality?: string;
+  routing_mismatch?: string;
 };
 
 type PrBodyEvidence = {
@@ -38,6 +53,49 @@ type PrBodyEvidence = {
   hasFinalMergeGate: boolean;
   hasLatestHead: boolean;
   headMatches: boolean | null;
+  hasAutonomousSignal: boolean;
+  hasRoutingStatus: boolean;
+  routingStatus: 'pass' | 'fail' | 'manual' | 'skipped' | 'pending' | 'unknown' | null;
+  hasRoutingRef: boolean;
+  routingRef: string | null;
+  hasDelegationLog: boolean;
+  hasSparkEvidence: boolean;
+  hasWorker54Evidence: boolean;
+  claimsControllerOnly: boolean;
+  controllerFallback: 'allowed' | 'denied' | null;
+  controllerFallbackReason: string | null;
+};
+
+type RoutingTaskClass =
+  | 'trivial_readonly'
+  | 'metadata_readback'
+  | 'small_docs_template_test'
+  | 'workflow_policy'
+  | 'product_behavior'
+  | 'merge_gate'
+  | 'unknown';
+
+type RoutingEvidence = {
+  source_status?: WorkflowStatus;
+  source_missing_fields?: string[];
+  routing_mode: string;
+  routing_task_class: RoutingTaskClass | 'n/a';
+  spark_required: 'yes' | 'no' | 'n/a';
+  worker_5_4_required: 'yes' | 'no' | 'n/a';
+  controller_role: string;
+  controller_fallback: 'allowed' | 'denied' | 'n/a';
+  controller_fallback_reason: string;
+  delegation_threshold: string;
+  routing_evidence_ref: string;
+  head_sha?: string;
+  spark_readback_evidence?: string;
+  worker_5_4_evidence?: string;
+};
+
+type FallbackAssessment = {
+  fallback_status: 'pass' | 'fail' | 'manual' | 'n/a';
+  fallback_reason_quality: 'strong' | 'weak' | 'missing' | 'n/a';
+  routing_mismatch: string[];
 };
 
 const PHASES = new Set<WorkflowPhase>(['start', 'commit', 'merge']);
@@ -47,6 +105,12 @@ const SPEC_REF_PATTERN = /\b(?:spec[_ -]evidence[_ -]ref|spec[_ -]gate[_ -]ref|w
 const MANUAL_FALLBACK_PATTERN = /\bmanual(?: checklist)? fallback\b|\bmanual spec gate\b|\bmanual workflow gate\b/i;
 const FINAL_MERGE_GATE_PATTERN = /\bfinal merge gate\b|\bmerge gate\b/i;
 const LATEST_HEAD_PATTERN = /\b(?:latest head|head sha|commit hash|head)\b[^\n\r]{0,80}\b[0-9a-f]{7,40}\b/i;
+const ROUTING_STATUS_PATTERN = /\b(?:routing[_ -]evidence[_ -]status|routing status)\b\s*[:=]\s*(pass|fail|manual|skipped|pending|unknown)\s*$/im;
+const AUTONOMOUS_SIGNAL_PATTERN = /\b(?:Autonomous Worker Profiles|Hybrid AWP|AWP|Codex autonomous PR|autonomous worker-routing|controller_fallback|Delegation Execution Log)\b/i;
+const SPARK_EVIDENCE_PATTERN = /\b(?:ops_spark|spark(?: \/ ops)? worker|ops worker|spark_readback_evidence|readback evidence)\b/i;
+const WORKER_54_EVIDENCE_PATTERN = /\b(?:worker_5_4|5\.4 worker|implementation worker|bounded implementation worker)\b/i;
+const CONTROLLER_ONLY_PATTERN = /\b(?:controller-only|controller only|controller_fallback\s*[:=]\s*allowed|controller fallback\s*[:=]\s*allowed)\b/i;
+const WEAK_FALLBACK_REASONS = new Set(['', 'n/a', 'na', 'none', 'small', 'done', 'ok', 'trivial']);
 
 export async function workflowCheck(opts: WorkflowCheckOptions): Promise<void> {
   const phase = parsePhase(opts.phase);
@@ -129,6 +193,25 @@ async function runStartPhase(
       missingFields: ['issue'],
       warnings: [...warnings, 'Start phase did not receive --issue; bounded context generation must be checked manually.'],
       evidenceSummary: 'start gate requires manual fallback because --issue was not provided',
+      routing: noRoutingEvidence(),
+      fallback: noFallbackAssessment(),
+    });
+  }
+
+  let issue: Issue | null = null;
+  try {
+    issue = await fetchIssue(opts.issue, repoPath);
+  } catch (err) {
+    return buildResult({
+      phase: 'start',
+      repoPath,
+      checkedAt,
+      status: 'fail',
+      missingFields: ['issue'],
+      warnings,
+      evidenceSummary: `start gate could not read issue for routing: ${(err as Error).message}`,
+      routing: noRoutingEvidence(),
+      fallback: noFallbackAssessment(),
     });
   }
 
@@ -150,17 +233,30 @@ async function runStartPhase(
       missingFields: ['bounded_context'],
       warnings: [...warnings, ...dryRun.warnings],
       evidenceSummary: `start gate could not generate bounded context: ${dryRun.error}`,
+      routing: issue ? classifyRouting(issue) : noRoutingEvidence(),
+      fallback: noFallbackAssessment(),
     });
   }
+
+  const routing = classifyRouting(issue);
+  const fallback = assessFallback(routing);
+  const missingFields: string[] = [];
+  if (routing.routing_task_class === 'unknown') missingFields.push('routing_task_class');
+  if (fallback.fallback_status === 'fail') missingFields.push('controller_fallback_reason');
+  const status: WorkflowStatus = missingFields.length > 0 || fallback.fallback_status === 'manual' ? 'manual' : 'pass';
 
   return buildResult({
     phase: 'start',
     repoPath,
     checkedAt,
-    status: 'pass',
-    missingFields: [],
+    status,
+    missingFields,
     warnings: [...warnings, ...dryRun.warnings],
-    evidenceSummary: 'start gate passed: bounded context generated with dry-run stdout-only plan check',
+    evidenceSummary: status === 'pass'
+      ? 'start gate passed: bounded context generated and Hybrid AWP routing classified'
+      : 'start gate requires manual fallback: bounded context generated but routing needs review',
+    routing,
+    fallback,
   });
 }
 
@@ -196,6 +292,7 @@ async function runCommitPhase(
   }
 
   let evidence: PrBodyEvidence;
+  let routing: RoutingEvidence | null = null;
   try {
     evidence = await parsePrBodyEvidence(opts.prBody, opts.headSha);
   } catch (err) {
@@ -209,8 +306,37 @@ async function runCommitPhase(
       evidenceSummary: 'commit gate failed: PR body evidence could not be read',
     });
   }
+  try {
+    routing = opts.routingEvidence ? await readRoutingEvidence(opts.routingEvidence) : null;
+  } catch (err) {
+    return buildResult({
+      phase: 'commit',
+      repoPath,
+      checkedAt,
+      status: 'fail',
+      missingFields: ['routing_evidence'],
+      warnings: [...warnings, `Could not read routing evidence: ${(err as Error).message}`],
+      evidenceSummary: 'commit gate failed: routing evidence could not be read',
+    });
+  }
+
+  const routingCheck = routing ? assessRoutingAlignment(routing, evidence, 'commit', opts.headSha) : null;
 
   if (evidence.hasManualFallback && !isBlockedSpecStatus(evidence.specStatus)) {
+    const fallback = assessFallback(routing ?? evidenceToFallbackRouting(evidence), evidence);
+    if (routingCheck && routingCheck.fallback_status === 'fail') {
+      return buildResult({
+        phase: 'commit',
+        repoPath,
+        checkedAt,
+        status: 'fail',
+        missingFields: routingCheck.routing_mismatch,
+        warnings,
+        evidenceSummary: `commit gate routing alignment failed: ${routingCheck.routing_mismatch.join(', ')}`,
+        routing: routing ?? evidenceToFallbackRouting(evidence),
+        fallback: routingCheck,
+      });
+    }
     return buildResult({
       phase: 'commit',
       repoPath,
@@ -219,6 +345,8 @@ async function runCommitPhase(
       missingFields: [],
       warnings,
       evidenceSummary: 'commit gate recorded manual fallback evidence and staged state is clean',
+      routing: routing ?? evidenceToFallbackRouting(evidence),
+      fallback,
     });
   }
 
@@ -226,6 +354,7 @@ async function runCommitPhase(
   if (isBlockedSpecStatus(evidence.specStatus)) {
     missingFields.push('ready_spec_gate_status');
   }
+  if (routingCheck) missingFields.push(...routingCheck.routing_mismatch);
 
   if (missingFields.length > 0) {
     return buildResult({
@@ -236,6 +365,8 @@ async function runCommitPhase(
       missingFields,
       warnings,
       evidenceSummary: `commit gate missing ${missingFields.join(', ')}`,
+      routing: routing ?? undefined,
+      fallback: routingCheck ?? undefined,
     });
   }
 
@@ -247,6 +378,8 @@ async function runCommitPhase(
     missingFields: [],
     warnings,
     evidenceSummary: 'commit gate passed: staged artifacts clean and PR body contains spec gate evidence',
+    routing: routing ?? undefined,
+    fallback: routingCheck ?? inferFallbackFromEvidence(evidence),
   });
 }
 
@@ -282,6 +415,7 @@ async function runMergePhase(
   }
 
   let evidence: PrBodyEvidence;
+  let routing: RoutingEvidence | null = null;
   try {
     evidence = await parsePrBodyEvidence(opts.prBody, opts.headSha);
   } catch (err) {
@@ -295,6 +429,19 @@ async function runMergePhase(
       evidenceSummary: 'merge gate failed: PR body evidence could not be read',
     });
   }
+  try {
+    routing = opts.routingEvidence ? await readRoutingEvidence(opts.routingEvidence) : null;
+  } catch (err) {
+    return buildResult({
+      phase: 'merge',
+      repoPath,
+      checkedAt,
+      status: 'fail',
+      missingFields: ['routing_evidence'],
+      warnings: [...warnings, `Could not read routing evidence: ${(err as Error).message}`],
+      evidenceSummary: 'merge gate failed: routing evidence could not be read',
+    });
+  }
 
   const missingFields = missingMergeFields(evidence, Boolean(opts.headSha));
   if (isBlockedSpecStatus(evidence.specStatus)) {
@@ -303,6 +450,8 @@ async function runMergePhase(
   if (evidence.headMatches === false) {
     missingFields.push('head_sha_freshness');
   }
+  const routingCheck = routing ? assessRoutingAlignment(routing, evidence, 'merge', opts.headSha) : null;
+  if (routingCheck) missingFields.push(...routingCheck.routing_mismatch);
 
   if (evidence.hasManualFallback && missingFields.length > 0 && !isBlockedSpecStatus(evidence.specStatus) && evidence.headMatches !== false) {
     return buildResult({
@@ -313,6 +462,8 @@ async function runMergePhase(
       missingFields,
       warnings,
       evidenceSummary: `merge gate requires manual fallback: missing ${missingFields.join(', ')}`,
+      routing: routing ?? evidenceToFallbackRouting(evidence),
+      fallback: routingCheck ?? assessFallback(routing ?? evidenceToFallbackRouting(evidence), evidence),
     });
   }
 
@@ -325,6 +476,8 @@ async function runMergePhase(
       missingFields,
       warnings,
       evidenceSummary: renderMergeFailureSummary(missingFields),
+      routing: routing ?? undefined,
+      fallback: routingCheck ?? undefined,
     });
   }
 
@@ -336,6 +489,8 @@ async function runMergePhase(
     missingFields: [],
     warnings,
     evidenceSummary: 'merge gate passed: final merge gate, spec evidence, and HEAD freshness are present',
+    routing: routing ?? undefined,
+    fallback: routingCheck ?? inferFallbackFromEvidence(evidence),
   });
 }
 
@@ -382,6 +537,11 @@ async function parsePrBodyEvidence(prBodyPath: string, expectedHeadSha?: string)
   const body = await fs.readFile(path.resolve(prBodyPath), 'utf8');
   const statusMatch = body.match(SPEC_STATUS_PATTERN);
   const specStatus = statusMatch?.[1]?.toLowerCase() as PrBodyEvidence['specStatus'] | undefined;
+  const rawRoutingStatus = parseTextField(body, 'routing_evidence_status') ?? parseTextField(body, 'routing evidence status') ?? null;
+  const routingStatus = parseRoutingStatus(rawRoutingStatus);
+  const routingRef = parseTextField(body, 'routing_evidence_ref') ??
+    parseTextField(body, 'routing evidence ref') ??
+    parseTextField(body, 'routing_ref');
   const hasLatestHead = Boolean(expectedHeadSha)
     ? body.includes(expectedHeadSha as string)
     : LATEST_HEAD_PATTERN.test(body);
@@ -394,6 +554,46 @@ async function parsePrBodyEvidence(prBodyPath: string, expectedHeadSha?: string)
     hasFinalMergeGate: FINAL_MERGE_GATE_PATTERN.test(body),
     hasLatestHead,
     headMatches: expectedHeadSha ? body.includes(expectedHeadSha) : null,
+    hasAutonomousSignal: AUTONOMOUS_SIGNAL_PATTERN.test(body),
+    hasRoutingStatus: Boolean(rawRoutingStatus),
+    routingStatus: routingStatus ?? null,
+    hasRoutingRef: Boolean(routingRef),
+    routingRef,
+    hasDelegationLog: /\bDelegation Execution Log\b/i.test(body),
+    hasSparkEvidence: hasEvidenceRefValue(body, 'ops_spark readback evidence') ||
+      hasEvidenceRefValue(body, 'spark_readback_evidence') ||
+      hasEvidenceRefValue(body, 'spark readback evidence'),
+    hasWorker54Evidence: hasEvidenceRefValue(body, 'worker_5_4 evidence') ||
+      hasEvidenceRefValue(body, 'worker_5_4_evidence') ||
+      hasEvidenceRefValue(body, '5.4 worker evidence'),
+    claimsControllerOnly: CONTROLLER_ONLY_PATTERN.test(body),
+    controllerFallback: parseAllowedDeniedField(body, 'controller_fallback') ?? parseAllowedDeniedField(body, 'controller fallback'),
+    controllerFallbackReason: parseTextField(body, 'controller_fallback_reason') ?? parseTextField(body, 'fallback_reason'),
+  };
+}
+
+async function readRoutingEvidence(routingEvidencePath: string): Promise<RoutingEvidence> {
+  const raw = JSON.parse(await fs.readFile(path.resolve(routingEvidencePath), 'utf8')) as Record<string, unknown>;
+  const routingTaskClass = requiredEnum(
+    raw.routing_task_class ?? raw.task_class,
+    ['trivial_readonly', 'metadata_readback', 'small_docs_template_test', 'workflow_policy', 'product_behavior', 'merge_gate', 'unknown', 'n/a'],
+    'routing_task_class'
+  ) as RoutingEvidence['routing_task_class'];
+  return {
+    source_status: requiredEnum(raw.status, ['pass', 'fail', 'manual', 'skipped'], 'status') as WorkflowStatus,
+    source_missing_fields: readStringArray(raw.missing_fields, 'missing_fields'),
+    routing_mode: requiredEnum(raw.routing_mode, ['hybrid_awp', 'strict_awp', 'controller_fallback', 'n/a'], 'routing_mode'),
+    routing_task_class: routingTaskClass,
+    spark_required: requiredEnum(raw.spark_required, ['yes', 'no', 'n/a'], 'spark_required') as RoutingEvidence['spark_required'],
+    worker_5_4_required: requiredEnum(raw.worker_5_4_required, ['yes', 'no', 'n/a'], 'worker_5_4_required') as RoutingEvidence['worker_5_4_required'],
+    controller_role: String(raw.controller_role ?? 'n/a'),
+    controller_fallback: requiredEnum(raw.controller_fallback, ['allowed', 'denied', 'n/a'], 'controller_fallback') as RoutingEvidence['controller_fallback'],
+    controller_fallback_reason: String(raw.controller_fallback_reason ?? raw.fallback_reason ?? 'n/a'),
+    delegation_threshold: String(raw.delegation_threshold ?? 'n/a'),
+    routing_evidence_ref: requiredEvidenceRef(raw.routing_evidence_ref ?? raw.evidence_ref, 'routing_evidence_ref'),
+    head_sha: typeof raw.head_sha === 'string' ? raw.head_sha : undefined,
+    spark_readback_evidence: typeof raw.spark_readback_evidence === 'string' ? raw.spark_readback_evidence : undefined,
+    worker_5_4_evidence: typeof raw.worker_5_4_evidence === 'string' ? raw.worker_5_4_evidence : undefined,
   };
 }
 
@@ -429,8 +629,10 @@ function buildResult(input: {
   missingFields: string[];
   warnings: string[];
   evidenceSummary: string;
+  routing?: RoutingEvidence;
+  fallback?: FallbackAssessment;
 }): WorkflowCheckResult {
-  return {
+  const result: WorkflowCheckResult = {
     phase: input.phase,
     status: input.status,
     repo: input.repoPath,
@@ -440,6 +642,23 @@ function buildResult(input: {
     warnings: unique(input.warnings),
     evidence_summary: input.evidenceSummary,
   };
+  if (input.routing) {
+    result.routing_mode = input.routing.routing_mode;
+    result.routing_task_class = input.routing.routing_task_class;
+    result.spark_required = input.routing.spark_required;
+    result.worker_5_4_required = input.routing.worker_5_4_required;
+    result.controller_role = input.routing.controller_role;
+    result.controller_fallback = input.routing.controller_fallback;
+    result.controller_fallback_reason = input.routing.controller_fallback_reason;
+    result.delegation_threshold = input.routing.delegation_threshold;
+    result.routing_evidence_ref = input.routing.routing_evidence_ref;
+  }
+  if (input.fallback) {
+    result.fallback_status = input.fallback.fallback_status;
+    result.fallback_reason_quality = input.fallback.fallback_reason_quality;
+    result.routing_mismatch = input.fallback.routing_mismatch.length > 0 ? input.fallback.routing_mismatch.join(',') : 'none';
+  }
+  return result;
 }
 
 function getHeadSha(repoPath: string): string {
@@ -462,6 +681,270 @@ function printResult(result: WorkflowCheckResult, format: OutputFormat): void {
   console.log(`missing_fields=${result.missing_fields.length > 0 ? result.missing_fields.join(',') : 'none'}`);
   console.log(`warnings=${result.warnings.length > 0 ? result.warnings.join(' | ') : 'none'}`);
   console.log(`evidence_summary=${result.evidence_summary}`);
+  for (const key of [
+    'routing_mode',
+    'routing_task_class',
+    'spark_required',
+    'worker_5_4_required',
+    'controller_role',
+    'controller_fallback',
+    'controller_fallback_reason',
+    'delegation_threshold',
+    'routing_evidence_ref',
+    'fallback_status',
+    'fallback_reason_quality',
+    'routing_mismatch',
+  ] as const) {
+    if (result[key]) console.log(`${key}=${result[key]}`);
+  }
+}
+
+function classifyRouting(issue: Issue): RoutingEvidence {
+  const text = `${issue.title}\n${issue.body}\n${issue.labels.join('\n')}`;
+  if (!AUTONOMOUS_SIGNAL_PATTERN.test(text)) return noRoutingEvidence();
+
+  const taskClass = classifyRoutingTaskClass(text);
+  if (taskClass === 'unknown') {
+    return {
+      routing_mode: 'hybrid_awp',
+      routing_task_class: 'unknown',
+      spark_required: 'n/a',
+      worker_5_4_required: 'n/a',
+      controller_role: 'scope|review',
+      controller_fallback: 'denied',
+      controller_fallback_reason: 'n/a',
+      delegation_threshold: 'manual review required because deterministic routing could not classify the task',
+      routing_evidence_ref: `workflow-check:start:issue-${issue.number}`,
+    };
+  }
+
+  const defaults = routingDefaults(taskClass);
+  return {
+    ...defaults,
+    routing_mode: defaults.controller_fallback === 'allowed' ? 'controller_fallback' : 'hybrid_awp',
+    routing_task_class: taskClass,
+    controller_fallback_reason: defaults.controller_fallback === 'allowed' ? 'n/a' : 'n/a',
+    routing_evidence_ref: `workflow-check:start:issue-${issue.number}`,
+  };
+}
+
+function classifyRoutingTaskClass(text: string): RoutingTaskClass {
+  if (/\b(?:merge gate|final merge|review finding|head sha|merge readiness)\b/i.test(text)) return 'merge_gate';
+  if (/\breadback\b/i.test(text) || (/\b(?:GitHub|issue metadata|PR metadata|CI|review-thread|connector|CodeRabbit)\b/i.test(text) && /\b(?:metadata|readback|checks?|status)\b/i.test(text))) return 'metadata_readback';
+  if (/\b(?:Scope Police|workflow policy|workflow governance|routing policy|guardrail|workflow-check|CI workflow)\b/i.test(text)) return 'workflow_policy';
+  if (/\b(?:docs?|README|template|fixture|test)\b/i.test(text) && /\b(?:small|narrow|docs?|template|fixture|test)\b/i.test(text)) return 'small_docs_template_test';
+  if (/\b(?:backend|frontend|runtime|auth|database|user-visible|product behavior)\b/i.test(text)) return 'product_behavior';
+  if (/\b(?:trivial|0-3 minute|read-only)\b/i.test(text)) return 'trivial_readonly';
+  return 'unknown';
+}
+
+function routingDefaults(
+  taskClass: Exclude<RoutingTaskClass, 'unknown'>
+): Omit<RoutingEvidence, 'routing_mode' | 'routing_task_class' | 'routing_evidence_ref' | 'controller_fallback_reason'> {
+  const defaults: Record<Exclude<RoutingTaskClass, 'unknown'>, Omit<RoutingEvidence, 'routing_mode' | 'routing_task_class' | 'routing_evidence_ref' | 'controller_fallback_reason'>> = {
+    trivial_readonly: {
+      spark_required: 'no',
+      worker_5_4_required: 'no',
+      controller_role: 'fallback_executor',
+      controller_fallback: 'allowed',
+      delegation_threshold: '0-3 minute read-only checks may use controller fallback with an explicit bounded reason',
+    },
+    metadata_readback: {
+      spark_required: 'yes',
+      worker_5_4_required: 'no',
+      controller_role: 'review',
+      controller_fallback: 'denied',
+      delegation_threshold: 'routine GitHub, CI, PR, issue, or review readback should route to ops / Spark evidence',
+    },
+    small_docs_template_test: {
+      spark_required: 'no',
+      worker_5_4_required: 'yes',
+      controller_role: 'scope|review',
+      controller_fallback: 'allowed',
+      delegation_threshold: 'narrow docs, template, fixture, or workflow-test patches should use a bounded worker when available',
+    },
+    workflow_policy: {
+      spark_required: 'no',
+      worker_5_4_required: 'yes',
+      controller_role: 'scope|architecture|review',
+      controller_fallback: 'denied',
+      delegation_threshold: 'workflow policy changes need controller scope and review with bounded implementation worker support',
+    },
+    product_behavior: {
+      spark_required: 'no',
+      worker_5_4_required: 'yes',
+      controller_role: 'architecture|review',
+      controller_fallback: 'denied',
+      delegation_threshold: 'product behavior needs controller architecture ownership and bounded implementation slices',
+    },
+    merge_gate: {
+      spark_required: 'yes',
+      worker_5_4_required: 'no',
+      controller_role: 'merge_gate',
+      controller_fallback: 'denied',
+      delegation_threshold: 'merge readiness decisions stay controller-owned while routine readback can be delegated',
+    },
+  };
+  return defaults[taskClass];
+}
+
+function assessRoutingAlignment(
+  routing: RoutingEvidence,
+  evidence: PrBodyEvidence,
+  phase: WorkflowPhase,
+  expectedHeadSha?: string
+): FallbackAssessment {
+  const mismatch: string[] = [];
+  if (routing.source_status && routing.source_status !== 'pass') mismatch.push('ready_routing_evidence_status');
+  for (const field of routing.source_missing_fields ?? []) mismatch.push(`routing_evidence.${field}`);
+  if (!evidence.hasRoutingStatus) mismatch.push('routing_evidence_status');
+  if (isBlockedRoutingStatus(evidence.routingStatus)) mismatch.push('ready_routing_evidence_status');
+  if (!evidence.hasRoutingRef) mismatch.push('routing_evidence_ref');
+  if (routing.routing_evidence_ref !== 'n/a' && evidence.routingRef !== routing.routing_evidence_ref) mismatch.push('routing_evidence_ref_match');
+  if (!evidence.hasDelegationLog) mismatch.push('delegation_execution_log');
+  if (routing.spark_required === 'yes' && !evidence.hasSparkEvidence && !isEvidenceRefValue(routing.spark_readback_evidence)) mismatch.push('spark_readback_evidence');
+  if (routing.worker_5_4_required === 'yes' && !evidence.hasWorker54Evidence && !isEvidenceRefValue(routing.worker_5_4_evidence)) mismatch.push('worker_5_4_evidence');
+  if (routing.controller_fallback === 'denied' && evidence.claimsControllerOnly) mismatch.push('controller_fallback_denied');
+  if (phase === 'merge' && expectedHeadSha && routing.head_sha && routing.head_sha !== expectedHeadSha) mismatch.push('routing_evidence_freshness');
+
+  const fallback = assessFallback(routing, evidence);
+  if (fallback.fallback_status === 'fail' || fallback.fallback_status === 'manual') mismatch.push('controller_fallback_reason');
+  return {
+    fallback_status: mismatch.length > 0 || fallback.fallback_status === 'fail' || fallback.fallback_status === 'manual' ? 'fail' : fallback.fallback_status,
+    fallback_reason_quality: fallback.fallback_reason_quality,
+    routing_mismatch: unique(mismatch),
+  };
+}
+
+function assessFallback(routing: RoutingEvidence, evidence?: PrBodyEvidence): FallbackAssessment {
+  const fallbackUsed = Boolean(
+    evidence?.controllerFallback === 'allowed' ||
+      evidence?.claimsControllerOnly ||
+      evidence?.hasManualFallback
+  );
+  if (!fallbackUsed) {
+    return noFallbackAssessment();
+  }
+  const reason = evidence?.controllerFallbackReason ?? routing.controller_fallback_reason;
+  const quality = fallbackReasonQuality(reason);
+  if (quality === 'strong') {
+    return { fallback_status: 'pass', fallback_reason_quality: 'strong', routing_mismatch: [] };
+  }
+  return {
+    fallback_status: quality === 'missing' ? 'manual' : 'fail',
+    fallback_reason_quality: quality,
+    routing_mismatch: ['controller_fallback_reason'],
+  };
+}
+
+function isBlockedRoutingStatus(status: PrBodyEvidence['routingStatus']): boolean {
+  return status === 'fail' || status === 'pending' || status === 'unknown';
+}
+
+function inferFallbackFromEvidence(evidence: PrBodyEvidence): FallbackAssessment | undefined {
+  if (evidence.controllerFallback !== 'allowed' && !evidence.hasManualFallback) return undefined;
+  return assessFallback(evidenceToFallbackRouting(evidence), evidence);
+}
+
+function evidenceToFallbackRouting(evidence: PrBodyEvidence): RoutingEvidence {
+  return {
+    routing_mode: evidence.hasAutonomousSignal ? 'controller_fallback' : 'n/a',
+    routing_task_class: 'n/a',
+    spark_required: 'n/a',
+    worker_5_4_required: 'n/a',
+    controller_role: 'fallback_executor',
+    controller_fallback: evidence.controllerFallback ?? (evidence.hasManualFallback ? 'allowed' : 'n/a'),
+    controller_fallback_reason: evidence.controllerFallbackReason ?? 'n/a',
+    delegation_threshold: 'manual checklist fallback evidence supplied in PR body',
+    routing_evidence_ref: 'n/a',
+  };
+}
+
+function fallbackReasonQuality(reason: string | null | undefined): FallbackAssessment['fallback_reason_quality'] {
+  const normalized = String(reason ?? '').trim().toLowerCase();
+  if (!normalized || normalized === 'n/a') return 'missing';
+  if (WEAK_FALLBACK_REASONS.has(normalized)) return 'weak';
+  return normalized.length >= 12 ? 'strong' : 'weak';
+}
+
+function noRoutingEvidence(): RoutingEvidence {
+  return {
+    routing_mode: 'n/a',
+    routing_task_class: 'n/a',
+    spark_required: 'n/a',
+    worker_5_4_required: 'n/a',
+    controller_role: 'n/a',
+    controller_fallback: 'n/a',
+    controller_fallback_reason: 'n/a',
+    delegation_threshold: 'n/a',
+    routing_evidence_ref: 'n/a',
+  };
+}
+
+function noFallbackAssessment(): FallbackAssessment {
+  return {
+    fallback_status: 'n/a',
+    fallback_reason_quality: 'n/a',
+    routing_mismatch: [],
+  };
+}
+
+function parseAllowedDeniedField(body: string, fieldName: string): 'allowed' | 'denied' | null {
+  const value = parseTextField(body, fieldName);
+  if (!value) return null;
+  const normalized = value.toLowerCase();
+  if (normalized.startsWith('allowed')) return 'allowed';
+  if (normalized.startsWith('denied')) return 'denied';
+  return null;
+}
+
+function parseTextField(body: string, fieldName: string): string | null {
+  const escaped = fieldName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = body.match(new RegExp(`(?:^|\\n)\\s*(?:[-*]\\s*)?${escaped}\\s*[:=]\\s*([^\\n\\r]+)`, 'i'));
+  return match?.[1]?.trim() ?? null;
+}
+
+function hasEvidenceRefValue(body: string, fieldName: string): boolean {
+  return isEvidenceRefValue(parseTextField(body, fieldName));
+}
+
+function isEvidenceRefValue(value: string | null | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.trim().toLowerCase();
+  if (WEAK_FALLBACK_REASONS.has(normalized)) return false;
+  if (['missing', 'pending', 'unknown', 'fail', 'failed'].includes(normalized)) return false;
+  return /^https?:\/\//i.test(value) || /^workflow-check:/i.test(value) || /#issuecomment-\d+/.test(value);
+}
+
+function requiredEnum(value: unknown, allowed: string[], fieldName: string): string {
+  if (typeof value !== 'string' || !allowed.includes(value)) {
+    throw new Error(`${fieldName} must be one of ${allowed.join('|')}`);
+  }
+  return value;
+}
+
+function readStringArray(value: unknown, fieldName: string): string[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== 'string')) {
+    throw new Error(`${fieldName} must be an array of strings`);
+  }
+  return value;
+}
+
+function requiredEvidenceRef(value: unknown, fieldName: string): string {
+  if (typeof value !== 'string' || !isEvidenceRefValue(value)) {
+    throw new Error(`${fieldName} must be a URL or workflow-check evidence ref`);
+  }
+  return value;
+}
+
+function parseRoutingStatus(value: string | null): PrBodyEvidence['routingStatus'] {
+  if (value === null) return null;
+  const normalized = value.trim().toLowerCase();
+  if (['pass', 'fail', 'manual', 'skipped', 'pending', 'unknown'].includes(normalized)) {
+    return normalized as PrBodyEvidence['routingStatus'];
+  }
+  return 'unknown';
 }
 
 async function captureConsole(fn: () => Promise<void>): Promise<{ ok: true; warnings: string[] } | { ok: false; warnings: string[]; error: string }> {

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -699,6 +699,7 @@ test('spec plan/config/clean help describe AI-facing usage and safety constraint
   assert.match(workflowCheckHelp.stdout, /--phase <phase>/);
   assert.match(workflowCheckHelp.stdout, /start\|commit\|merge/);
   assert.match(workflowCheckHelp.stdout, /--format <format>/);
+  assert.match(workflowCheckHelp.stdout, /--routing-evidence <path>/);
   assert.match(workflowCheckHelp.stdout, /stdout/i);
   assert.match(workflowCheckHelp.stdout, /does not edit GitHub/i);
 
@@ -928,6 +929,682 @@ test('spec workflow-check start phase uses mocked gh read-only issue context and
   const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
   assert.match(ghLog, /issue view/);
   assertNoGhMutationCommands(ghLog);
+});
+
+test('spec workflow-check start phase emits Hybrid AWP routing fields for autonomous issues', async (t) => {
+  const fixture = await createSpecPlanFixture(t, {
+    issue: {
+      number: 227,
+      title: 'feat(workflow): emit Hybrid AWP routing plans from start gate',
+      body: [
+        'Autonomous Worker Profiles routing is required for this Codex autonomous PR.',
+        'Implement workflow policy guardrails for spec workflow-check start gate.',
+        'The controller keeps scope, architecture, and review ownership.',
+      ].join('\n'),
+      labels: [{ name: 'area:workflow' }, { name: 'area:agent' }, { name: 'area:cli' }],
+      url: 'https://github.com/Erick52106/spec-injector/issues/227',
+    },
+  });
+  await initCleanGitRepo(fixture.repoDir);
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', fixture.repoDir,
+    '--phase', 'start',
+    '--issue', fixture.issueUrl,
+    '--format', 'json',
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.status, 'pass');
+  assert.equal(parsed.routing_mode, 'hybrid_awp');
+  assert.equal(parsed.routing_task_class, 'workflow_policy');
+  assert.equal(parsed.spark_required, 'no');
+  assert.equal(parsed.worker_5_4_required, 'yes');
+  assert.equal(parsed.controller_role, 'scope|architecture|review');
+  assert.equal(parsed.controller_fallback, 'denied');
+  assert.equal(parsed.controller_fallback_reason, 'n/a');
+  assert.equal(parsed.fallback_status, 'n/a');
+  assert.equal(parsed.fallback_reason_quality, 'n/a');
+  assert.equal(parsed.routing_mismatch, 'none');
+  await assertFileMissing(fixture.taskPackagePath);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec workflow-check start phase does not fail non-autonomous issues for missing AWP routing', async (t) => {
+  const fixture = await createSpecPlanFixture(t, {
+    issue: {
+      number: 231,
+      title: 'docs: update README wording',
+      body: 'Small human-authored README wording cleanup. No autonomous worker routing is requested.',
+      labels: [{ name: 'docs' }],
+      url: 'https://github.com/Erick52106/spec-injector/issues/231',
+    },
+  });
+  await initCleanGitRepo(fixture.repoDir);
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', fixture.repoDir,
+    '--phase', 'start',
+    '--issue', fixture.issueUrl,
+    '--format', 'json',
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.status, 'pass');
+  assert.equal(parsed.routing_mode, 'n/a');
+  assert.equal(parsed.fallback_status, 'n/a');
+  assert.deepEqual(parsed.missing_fields, []);
+});
+
+test('spec workflow-check start phase routes autonomous metadata readback to Spark evidence', async (t) => {
+  const fixture = await createSpecPlanFixture(t, {
+    issue: {
+      number: 232,
+      title: 'Codex autonomous PR CI workflow status readback',
+      body: [
+        'Autonomous Worker Profiles routing is required.',
+        'Read GitHub PR checks, CI workflow status, issue metadata, and review-thread readback.',
+        'No implementation worker should be required for this metadata readback.',
+      ].join('\n'),
+      labels: [{ name: 'area:workflow' }, { name: 'area:agent' }],
+      url: 'https://github.com/Erick52106/spec-injector/issues/232',
+    },
+  });
+  await initCleanGitRepo(fixture.repoDir);
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', fixture.repoDir,
+    '--phase', 'start',
+    '--issue', fixture.issueUrl,
+    '--format', 'json',
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.routing_task_class, 'metadata_readback');
+  assert.equal(parsed.spark_required, 'yes');
+  assert.equal(parsed.worker_5_4_required, 'no');
+  assert.equal(parsed.controller_role, 'review');
+});
+
+test('spec workflow-check commit phase rejects weak explicit controller fallback reasons', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-fallback-weak-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+  const headSha = (await runCommand('git', ['rev-parse', 'HEAD'], repoDir)).stdout.trim();
+  const prBodyPath = path.join(repoDir, 'pr-body.md');
+  const routingPath = path.join(repoDir, 'routing.json');
+  await fs.writeFile(prBodyPath, [
+    '## Spec gate evidence',
+    '- spec gate status: pass',
+    '- spec evidence ref: workflow-check:start:weak-fallback',
+    '## Delegation Execution Log',
+    '- routing evidence status: pass',
+    '- routing evidence ref: workflow-check:start:weak-fallback',
+    '- controller_fallback: allowed',
+    '- controller_fallback_reason: ok',
+  ].join('\n'), 'utf8');
+  await fs.writeFile(routingPath, JSON.stringify({
+    phase: 'start',
+    status: 'pass',
+    head_sha: headSha,
+    routing_mode: 'controller_fallback',
+    routing_task_class: 'small_docs_template_test',
+    spark_required: 'no',
+    worker_5_4_required: 'no',
+    controller_role: 'fallback_executor',
+    controller_fallback: 'allowed',
+    controller_fallback_reason: 'ok',
+    routing_evidence_ref: 'workflow-check:start:weak-fallback',
+  }), 'utf8');
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'commit',
+    '--pr-body', prBodyPath,
+    '--routing-evidence', routingPath,
+    '--format', 'json',
+  ]);
+
+  assert.notEqual(result.code, 0);
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.status, 'fail');
+  assert.equal(parsed.fallback_status, 'fail');
+  assert.equal(parsed.fallback_reason_quality, 'weak');
+  assert.ok((parsed.missing_fields as string[]).includes('controller_fallback_reason'));
+});
+
+test('spec workflow-check commit phase rejects missing explicit controller fallback reasons', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-fallback-missing-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+  const headSha = (await runCommand('git', ['rev-parse', 'HEAD'], repoDir)).stdout.trim();
+  const prBodyPath = path.join(repoDir, 'pr-body.md');
+  const routingPath = path.join(repoDir, 'routing.json');
+  await fs.writeFile(prBodyPath, [
+    '## Spec gate evidence',
+    '- spec gate status: pass',
+    '- spec evidence ref: workflow-check:start:missing-fallback',
+    '## Delegation Execution Log',
+    '- routing evidence status: pass',
+    '- routing evidence ref: workflow-check:start:missing-fallback',
+    '- controller_fallback: allowed',
+    '- controller_fallback_reason: n/a',
+  ].join('\n'), 'utf8');
+  await fs.writeFile(routingPath, JSON.stringify({
+    phase: 'start',
+    status: 'pass',
+    head_sha: headSha,
+    routing_mode: 'controller_fallback',
+    routing_task_class: 'small_docs_template_test',
+    spark_required: 'no',
+    worker_5_4_required: 'no',
+    controller_role: 'fallback_executor',
+    controller_fallback: 'allowed',
+    controller_fallback_reason: 'n/a',
+    routing_evidence_ref: 'workflow-check:start:missing-fallback',
+  }), 'utf8');
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'commit',
+    '--pr-body', prBodyPath,
+    '--routing-evidence', routingPath,
+    '--format', 'json',
+  ]);
+
+  assert.notEqual(result.code, 0);
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.status, 'fail');
+  assert.equal(parsed.fallback_status, 'fail');
+  assert.equal(parsed.fallback_reason_quality, 'missing');
+  assert.ok((parsed.missing_fields as string[]).includes('controller_fallback_reason'));
+});
+
+test('spec workflow-check commit phase reports missing Spark and 5.4 worker evidence against routing plan', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-routing-missing-workers-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+  const headSha = (await runCommand('git', ['rev-parse', 'HEAD'], repoDir)).stdout.trim();
+  const prBodyPath = path.join(repoDir, 'pr-body.md');
+  const routingPath = path.join(repoDir, 'routing.json');
+  await fs.writeFile(prBodyPath, [
+    '## Spec gate evidence',
+    '- spec gate status: pass',
+    '- spec evidence ref: workflow-check:start:routing',
+    '## Delegation Execution Log',
+    '- routing evidence status: pass',
+    '- routing evidence ref: workflow-check:start:routing',
+    '- controller_fallback: denied',
+  ].join('\n'), 'utf8');
+  await fs.writeFile(routingPath, JSON.stringify({
+    phase: 'start',
+    status: 'pass',
+    head_sha: headSha,
+    routing_mode: 'hybrid_awp',
+    routing_task_class: 'workflow_policy',
+    spark_required: 'yes',
+    worker_5_4_required: 'yes',
+    controller_role: 'scope|architecture|review',
+    controller_fallback: 'denied',
+    controller_fallback_reason: 'n/a',
+    routing_evidence_ref: 'workflow-check:start:routing',
+  }), 'utf8');
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'commit',
+    '--pr-body', prBodyPath,
+    '--routing-evidence', routingPath,
+    '--format', 'json',
+  ]);
+
+  assert.notEqual(result.code, 0);
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.status, 'fail');
+  assert.ok((parsed.missing_fields as string[]).includes('spark_readback_evidence'));
+  assert.ok((parsed.missing_fields as string[]).includes('worker_5_4_evidence'));
+  assert.match(String(parsed.routing_mismatch), /spark_readback_evidence/);
+  assert.match(String(parsed.routing_mismatch), /worker_5_4_evidence/);
+});
+
+test('spec workflow-check accepts downstream thin-wiring PR bodies with status/ref routing evidence', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-thin-wiring-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+  const headSha = (await runCommand('git', ['rev-parse', 'HEAD'], repoDir)).stdout.trim();
+  const prBodyPath = path.join(repoDir, 'pr-body.md');
+  const routingPath = path.join(repoDir, 'routing.json');
+  const thinBody = await fs.readFile(path.join(repoRoot, 'tests', 'fixtures', 'workflow', 'tachigo-thin-pr-body.md'), 'utf8');
+  assert.ok(!thinBody.includes('spawn_count'));
+  assert.ok(!thinBody.includes('ci_rerun_count'));
+  assert.ok(!thinBody.includes('threshold_decision'));
+  assert.ok(!thinBody.includes('ops_spark'));
+  assert.ok(!thinBody.includes('worker_5_4'));
+  await fs.writeFile(prBodyPath, thinBody.replaceAll('__HEAD_SHA__', headSha), 'utf8');
+  await fs.writeFile(routingPath, JSON.stringify({
+    phase: 'start',
+    status: 'pass',
+    head_sha: headSha,
+    routing_mode: 'hybrid_awp',
+    routing_task_class: 'workflow_policy',
+    spark_required: 'yes',
+    worker_5_4_required: 'yes',
+    controller_role: 'scope|architecture|review',
+    controller_fallback: 'denied',
+    controller_fallback_reason: 'n/a',
+    routing_evidence_ref: 'https://github.com/Erick52106/spec-injector/issues/229#issuecomment-1002',
+    spark_readback_evidence: 'https://github.com/Erick52106/spec-injector/pull/229#issuecomment-1003',
+    worker_5_4_evidence: 'https://github.com/Erick52106/spec-injector/pull/229#issuecomment-1004',
+  }), 'utf8');
+
+  const commitResult = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'commit',
+    '--pr-body', prBodyPath,
+    '--routing-evidence', routingPath,
+    '--format', 'json',
+  ]);
+  assert.equal(commitResult.code, 0, commitResult.stderr);
+  assert.equal(JSON.parse(commitResult.stdout).status, 'pass');
+
+  const mergeResult = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'merge',
+    '--pr-body', prBodyPath,
+    '--routing-evidence', routingPath,
+    '--head-sha', headSha,
+    '--format', 'json',
+  ]);
+  assert.equal(mergeResult.code, 0, mergeResult.stderr);
+  assert.equal(JSON.parse(mergeResult.stdout).status, 'pass');
+});
+
+test('spec workflow-check accepts fallback-allowed routing when delegation actually ran', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-fallback-allowed-delegated-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+  const headSha = (await runCommand('git', ['rev-parse', 'HEAD'], repoDir)).stdout.trim();
+  const prBodyPath = path.join(repoDir, 'pr-body.md');
+  const routingPath = path.join(repoDir, 'routing.json');
+  await fs.writeFile(prBodyPath, [
+    '## Spec gate evidence',
+    '- spec gate status: pass',
+    '- spec evidence ref: workflow-check:start:small-docs',
+    '## Delegation Execution Log',
+    '- routing evidence status: pass',
+    '- routing evidence ref: workflow-check:start:small-docs',
+    '- controller_fallback: denied',
+  ].join('\n'), 'utf8');
+  await fs.writeFile(routingPath, JSON.stringify({
+    phase: 'start',
+    status: 'pass',
+    missing_fields: [],
+    head_sha: headSha,
+    routing_mode: 'controller_fallback',
+    routing_task_class: 'small_docs_template_test',
+    spark_required: 'no',
+    worker_5_4_required: 'yes',
+    controller_role: 'scope|review',
+    controller_fallback: 'allowed',
+    controller_fallback_reason: 'n/a',
+    routing_evidence_ref: 'workflow-check:start:small-docs',
+    worker_5_4_evidence: 'https://github.com/Erick52106/spec-injector/pull/231#issuecomment-1010',
+  }), 'utf8');
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'commit',
+    '--pr-body', prBodyPath,
+    '--routing-evidence', routingPath,
+    '--format', 'json',
+  ]);
+
+  assert.equal(result.code, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.status, 'pass');
+  assert.equal(parsed.fallback_status, 'n/a');
+  assert.equal(parsed.fallback_reason_quality, 'n/a');
+});
+
+test('spec workflow-check merge phase fails stale routing evidence head SHA', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-stale-routing-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+  const headSha = (await runCommand('git', ['rev-parse', 'HEAD'], repoDir)).stdout.trim();
+  const prBodyPath = path.join(repoDir, 'pr-body.md');
+  const routingPath = path.join(repoDir, 'routing.json');
+  const thinBody = await fs.readFile(path.join(repoRoot, 'tests', 'fixtures', 'workflow', 'tachigo-thin-pr-body.md'), 'utf8');
+  await fs.writeFile(prBodyPath, thinBody.replaceAll('__HEAD_SHA__', headSha), 'utf8');
+  await fs.writeFile(routingPath, JSON.stringify({
+    phase: 'start',
+    status: 'pass',
+    head_sha: '1111111111111111111111111111111111111111',
+    routing_mode: 'hybrid_awp',
+    routing_task_class: 'workflow_policy',
+    spark_required: 'yes',
+    worker_5_4_required: 'yes',
+    controller_role: 'scope|architecture|review',
+    controller_fallback: 'denied',
+    controller_fallback_reason: 'n/a',
+    routing_evidence_ref: 'https://github.com/Erick52106/spec-injector/issues/229#issuecomment-1002',
+    spark_readback_evidence: 'https://github.com/Erick52106/spec-injector/pull/229#issuecomment-1003',
+    worker_5_4_evidence: 'https://github.com/Erick52106/spec-injector/pull/229#issuecomment-1004',
+  }), 'utf8');
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'merge',
+    '--pr-body', prBodyPath,
+    '--routing-evidence', routingPath,
+    '--head-sha', headSha,
+    '--format', 'json',
+  ]);
+
+  assert.notEqual(result.code, 0);
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.status, 'fail');
+  assert.ok((parsed.missing_fields as string[]).includes('routing_evidence_freshness'));
+});
+
+test('spec workflow-check commit phase rejects non-pass local routing evidence status', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-local-routing-status-fail-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+  const headSha = (await runCommand('git', ['rev-parse', 'HEAD'], repoDir)).stdout.trim();
+  const prBodyPath = path.join(repoDir, 'pr-body.md');
+  const routingPath = path.join(repoDir, 'routing.json');
+  await fs.writeFile(prBodyPath, [
+    '## Spec gate evidence',
+    '- spec gate status: pass',
+    '- spec evidence ref: workflow-check:start:local-fail',
+    '## Delegation Execution Log',
+    '- routing evidence status: pass',
+    '- routing evidence ref: workflow-check:start:local-fail',
+    '- controller_fallback: denied',
+  ].join('\n'), 'utf8');
+  await fs.writeFile(routingPath, JSON.stringify({
+    phase: 'start',
+    status: 'fail',
+    missing_fields: ['controller_fallback_reason'],
+    head_sha: headSha,
+    routing_mode: 'hybrid_awp',
+    routing_task_class: 'workflow_policy',
+    spark_required: 'no',
+    worker_5_4_required: 'no',
+    controller_role: 'scope|architecture|review',
+    controller_fallback: 'denied',
+    controller_fallback_reason: 'n/a',
+    routing_evidence_ref: 'workflow-check:start:local-fail',
+  }), 'utf8');
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'commit',
+    '--pr-body', prBodyPath,
+    '--routing-evidence', routingPath,
+    '--format', 'json',
+  ]);
+
+  assert.notEqual(result.code, 0);
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.status, 'fail');
+  assert.ok((parsed.missing_fields as string[]).includes('ready_routing_evidence_status'));
+  assert.ok((parsed.missing_fields as string[]).includes('routing_evidence.controller_fallback_reason'));
+});
+
+test('spec workflow-check commit phase rejects failed routing evidence status and mismatched refs', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-routing-status-fail-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+  const headSha = (await runCommand('git', ['rev-parse', 'HEAD'], repoDir)).stdout.trim();
+  const prBodyPath = path.join(repoDir, 'pr-body.md');
+  const routingPath = path.join(repoDir, 'routing.json');
+  await fs.writeFile(prBodyPath, [
+    '## Spec gate evidence',
+    '- spec gate status: pass',
+    '- spec evidence ref: workflow-check:start:routing-fail',
+    '## Delegation Execution Log',
+    '- routing evidence status: fail',
+    '- routing evidence ref: workflow-check:start:wrong-ref',
+    '- controller_fallback: denied',
+  ].join('\n'), 'utf8');
+  await fs.writeFile(routingPath, JSON.stringify({
+    phase: 'start',
+    status: 'pass',
+    head_sha: headSha,
+    routing_mode: 'hybrid_awp',
+    routing_task_class: 'workflow_policy',
+    spark_required: 'no',
+    worker_5_4_required: 'no',
+    controller_role: 'scope|architecture|review',
+    controller_fallback: 'denied',
+    controller_fallback_reason: 'n/a',
+    routing_evidence_ref: 'workflow-check:start:expected-ref',
+  }), 'utf8');
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'commit',
+    '--pr-body', prBodyPath,
+    '--routing-evidence', routingPath,
+    '--format', 'json',
+  ]);
+
+  assert.notEqual(result.code, 0);
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.status, 'fail');
+  assert.ok((parsed.missing_fields as string[]).includes('ready_routing_evidence_status'));
+  assert.ok((parsed.missing_fields as string[]).includes('routing_evidence_ref_match'));
+});
+
+test('spec workflow-check commit phase rejects malformed routing evidence JSON enums', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-routing-malformed-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+  const prBodyPath = path.join(repoDir, 'pr-body.md');
+  const routingPath = path.join(repoDir, 'routing.json');
+  await fs.writeFile(prBodyPath, [
+    '## Spec gate evidence',
+    '- spec gate status: pass',
+    '- spec evidence ref: workflow-check:start:routing',
+    '## Delegation Execution Log',
+    '- routing evidence status: pass',
+    '- routing evidence ref: workflow-check:start:routing',
+  ].join('\n'), 'utf8');
+	  await fs.writeFile(routingPath, JSON.stringify({
+	    status: 'pass',
+	    routing_mode: 'hybrid_awp',
+	    routing_task_class: 'surprise',
+	    spark_required: 'maybe',
+    worker_5_4_required: 'yes',
+    controller_role: 'scope|review',
+    controller_fallback: 'allowed',
+    controller_fallback_reason: 'bounded fallback reason',
+  }), 'utf8');
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'commit',
+    '--pr-body', prBodyPath,
+    '--routing-evidence', routingPath,
+    '--format', 'json',
+  ]);
+
+  assert.notEqual(result.code, 0);
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.status, 'fail');
+  assert.ok((parsed.missing_fields as string[]).includes('routing_evidence'));
+  assert.match((parsed.warnings as string[]).join('\n'), /routing_task_class/i);
+});
+
+test('spec workflow-check commit phase rejects missing routing evidence ref in JSON', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-routing-missing-ref-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+  const prBodyPath = path.join(repoDir, 'pr-body.md');
+  const routingPath = path.join(repoDir, 'routing.json');
+  await fs.writeFile(prBodyPath, [
+    '## Spec gate evidence',
+    '- spec gate status: pass',
+    '- spec evidence ref: workflow-check:start:routing',
+    '## Delegation Execution Log',
+    '- routing evidence status: pass',
+    '- routing evidence ref: workflow-check:start:any-pr-ref',
+    '- controller_fallback: denied',
+  ].join('\n'), 'utf8');
+	  await fs.writeFile(routingPath, JSON.stringify({
+	    status: 'pass',
+	    routing_mode: 'hybrid_awp',
+	    routing_task_class: 'workflow_policy',
+	    spark_required: 'no',
+    worker_5_4_required: 'no',
+    controller_role: 'scope|review',
+    controller_fallback: 'denied',
+    controller_fallback_reason: 'n/a',
+  }), 'utf8');
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'commit',
+    '--pr-body', prBodyPath,
+    '--routing-evidence', routingPath,
+    '--format', 'json',
+  ]);
+
+  assert.notEqual(result.code, 0);
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.status, 'fail');
+  assert.ok((parsed.missing_fields as string[]).includes('routing_evidence'));
+  assert.match((parsed.warnings as string[]).join('\n'), /routing_evidence_ref/i);
+});
+
+test('spec workflow-check commit phase rejects malformed routing status values', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-routing-status-malformed-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+  const prBodyPath = path.join(repoDir, 'pr-body.md');
+  const routingPath = path.join(repoDir, 'routing.json');
+  await fs.writeFile(prBodyPath, [
+    '## Spec gate evidence',
+    '- spec gate status: pass',
+    '- spec evidence ref: workflow-check:start:routing',
+    '## Delegation Execution Log',
+    '- routing evidence status: not pass',
+    '- routing evidence ref: workflow-check:start:routing',
+    '- controller_fallback: denied',
+  ].join('\n'), 'utf8');
+	  await fs.writeFile(routingPath, JSON.stringify({
+	    status: 'pass',
+	    routing_mode: 'hybrid_awp',
+	    routing_task_class: 'workflow_policy',
+	    spark_required: 'no',
+    worker_5_4_required: 'no',
+    controller_role: 'scope|review',
+    controller_fallback: 'denied',
+    controller_fallback_reason: 'n/a',
+    routing_evidence_ref: 'workflow-check:start:routing',
+  }), 'utf8');
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'commit',
+    '--pr-body', prBodyPath,
+    '--routing-evidence', routingPath,
+    '--format', 'json',
+  ]);
+
+  assert.notEqual(result.code, 0);
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.status, 'fail');
+  assert.ok((parsed.missing_fields as string[]).includes('ready_routing_evidence_status'));
+});
+
+test('spec workflow-check commit phase rejects non-ref worker evidence values', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-worker-evidence-non-ref-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+  const prBodyPath = path.join(repoDir, 'pr-body.md');
+  const routingPath = path.join(repoDir, 'routing.json');
+  await fs.writeFile(prBodyPath, [
+    '## Spec gate evidence',
+    '- spec gate status: pass',
+    '- spec evidence ref: workflow-check:start:routing',
+    '## Delegation Execution Log',
+    '- routing evidence status: pass',
+    '- routing evidence ref: workflow-check:start:routing',
+    '- controller_fallback: denied',
+  ].join('\n'), 'utf8');
+	  await fs.writeFile(routingPath, JSON.stringify({
+	    status: 'pass',
+	    routing_mode: 'hybrid_awp',
+	    routing_task_class: 'workflow_policy',
+	    spark_required: 'yes',
+    worker_5_4_required: 'yes',
+    controller_role: 'scope|review',
+    controller_fallback: 'denied',
+    controller_fallback_reason: 'n/a',
+    routing_evidence_ref: 'workflow-check:start:routing',
+    spark_readback_evidence: 'complete',
+    worker_5_4_evidence: 'yes-done',
+  }), 'utf8');
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'commit',
+    '--pr-body', prBodyPath,
+    '--routing-evidence', routingPath,
+    '--format', 'json',
+  ]);
+
+  assert.notEqual(result.code, 0);
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.status, 'fail');
+  assert.ok((parsed.missing_fields as string[]).includes('spark_readback_evidence'));
+  assert.ok((parsed.missing_fields as string[]).includes('worker_5_4_evidence'));
+});
+
+test('spec workflow-check accepts manual checklist fallback for downstream repos without spec-injector', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-manual-thin-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+  const headSha = (await runCommand('git', ['rev-parse', 'HEAD'], repoDir)).stdout.trim();
+  const prBodyPath = path.join(repoDir, 'pr-body.md');
+  const manualBody = await fs.readFile(path.join(repoRoot, 'tests', 'fixtures', 'workflow', 'tachiya-manual-pr-body.md'), 'utf8');
+  await fs.writeFile(prBodyPath, manualBody.replaceAll('__HEAD_SHA__', headSha), 'utf8');
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'commit',
+    '--pr-body', prBodyPath,
+    '--format', 'json',
+  ]);
+
+  assert.equal(result.code, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.status, 'manual');
+  assert.equal(parsed.fallback_status, 'pass');
+  assert.equal(parsed.fallback_reason_quality, 'strong');
 });
 
 test('spec label-audit forwards --limit to gh issue and pr list', async (t) => {

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -965,6 +965,7 @@ test('spec workflow-check start phase emits Hybrid AWP routing fields for autono
   assert.equal(parsed.controller_role, 'scope|architecture|review');
   assert.equal(parsed.controller_fallback, 'denied');
   assert.equal(parsed.controller_fallback_reason, 'n/a');
+  assert.ok(typeof parsed.delegation_threshold === 'string' && parsed.delegation_threshold.length > 0);
   assert.equal(parsed.fallback_status, 'n/a');
   assert.equal(parsed.fallback_reason_quality, 'n/a');
   assert.equal(parsed.routing_mismatch, 'none');

--- a/tests/fixtures/workflow/tachigo-thin-pr-body.md
+++ b/tests/fixtures/workflow/tachigo-thin-pr-body.md
@@ -1,0 +1,18 @@
+Closes #229
+
+## Spec gate evidence
+- spec gate status: pass
+- spec evidence ref: https://github.com/Erick52106/spec-injector/issues/229#issuecomment-1001
+
+## Delegation Execution Log
+- routing evidence status: pass
+- routing evidence ref: https://github.com/Erick52106/spec-injector/issues/229#issuecomment-1002
+- controller_fallback: denied
+- controller_fallback_reason: n/a
+
+## Final merge gate
+- latest head SHA: __HEAD_SHA__
+- ready_to_merge: yes
+
+## Scope guard
+Downstream Scope Police only reads status/ref fields. Full routing details live behind the evidence refs.

--- a/tests/fixtures/workflow/tachiya-manual-pr-body.md
+++ b/tests/fixtures/workflow/tachiya-manual-pr-body.md
@@ -1,0 +1,12 @@
+Closes #230
+
+## Spec gate evidence
+- manual checklist fallback: repo does not use spec-injector for this PR.
+
+## Delegation Execution Log
+- controller_fallback: allowed
+- controller_fallback_reason: human explicitly requested controller-only execution for a narrow docs-only checklist update.
+
+## Final merge gate
+- latest head SHA: __HEAD_SHA__
+- ready_to_merge: manual

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -122,7 +122,12 @@ export function createMissingPath(): string {
   return path.join(os.tmpdir(), `spec-injector-missing-${process.pid}-${Date.now()}`);
 }
 
-export async function createSpecPlanFixture(t: TestLifecycle): Promise<PlanFixture> {
+export async function createSpecPlanFixture(
+  t: TestLifecycle,
+  options: {
+    issue?: Partial<IssuePayload>;
+  } = {}
+): Promise<PlanFixture> {
   const repoDir = await createTempRepo(t);
   const alwaysReadLongBody = [
     'ALWAYS_READ_LONG_BODY_SENTINEL',
@@ -183,6 +188,7 @@ export async function createSpecPlanFixture(t: TestLifecycle): Promise<PlanFixtu
     labels: [{ name: 'test' }, { name: 'backend' }, { name: 'auth' }, { name: 'database' }],
     url: 'https://github.com/Erick52106/spec-injector/issues/57',
     state: 'OPEN',
+    ...options.issue,
   };
   const fakeGh = await createFakeGh(t, issue);
 
@@ -509,7 +515,7 @@ process.stdout.write(fs.readFileSync(process.env.FAKE_GH_RESPONSE_FILE, 'utf8'))
       PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
       FAKE_GH_RESPONSE_FILE: responsePath,
       FAKE_GH_LOG: logPath,
-      FAKE_GH_EXPECT_REF: '57',
+      FAKE_GH_EXPECT_REF: String(issuePayload.number),
       FAKE_GH_EXPECT_REPO: 'Erick52106/spec-injector',
     },
     logPath,

--- a/tests/hybrid-awp-routing-policy.test.ts
+++ b/tests/hybrid-awp-routing-policy.test.ts
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { repoRoot } from './helpers/cli.ts';
+
+test('Hybrid AWP routing policy remains linked from workflow-check docs', async () => {
+  const policyPath = path.join(repoRoot, 'docs', 'hybrid-awp-routing-policy.md');
+  const readmePath = path.join(repoRoot, 'README.md');
+  const englishReadmePath = path.join(repoRoot, 'README.en.md');
+  const workflowPath = path.join(repoRoot, 'docs', 'workflow.md');
+
+  const [policy, readme, englishReadme, workflow] = await Promise.all([
+    fs.readFile(policyPath, 'utf8'),
+    fs.readFile(readmePath, 'utf8'),
+    fs.readFile(englishReadmePath, 'utf8'),
+    fs.readFile(workflowPath, 'utf8'),
+  ]);
+
+  assert.match(policy, /Hybrid Autonomous Worker Profiles routing policy/);
+  assert.match(policy, /routing_mode=hybrid_awp\|strict_awp\|controller_fallback/);
+  assert.match(policy, /Absence of autonomous routing signal/);
+  assert.match(policy, /Downstream Scope Police/);
+
+  assert.match(readme, /\[Hybrid AWP routing policy\]\(docs\/hybrid-awp-routing-policy\.md\)/);
+  assert.match(englishReadme, /\[Hybrid AWP routing policy\]\(docs\/hybrid-awp-routing-policy\.md\)/);
+  assert.match(workflow, /\[Hybrid AWP routing policy\]\(hybrid-awp-routing-policy\.md\)/);
+});


### PR DESCRIPTION
Closes #226
Closes #227
Closes #228
Closes #229
Closes #230

## Summary
- 新增 Hybrid AWP routing policy entrypoint，並把 README / README.en / `docs/workflow.md` 連到 durable workflow docs。
- 擴充 `spec workflow-check` start gate，針對 autonomous issue signal 輸出 deterministic routing plan：task class、Spark / 5.4 worker requirement、controller role、fallback allowance、delegation threshold 與 routing evidence ref。
- 新增 local-only `--routing-evidence <path>` 給 commit / merge phase 使用，不讀寫 GitHub remote state，讓 downstream PR body 只需引用 routing status/ref，不需要 Scope Police parse full evidence。
- commit / merge phase 會檢查 spec gate status/ref、routing evidence status/ref、local routing JSON `status` / `missing_fields`、worker evidence refs、fallback reason quality、final merge gate 與 head SHA freshness。
- 新增 tachigo / tachiya thin-wiring fixtures 與 node:test regression coverage，涵蓋 malformed routing status、stale routing head、missing/weak fallback reason、non-ref worker evidence、manual checklist fallback，以及 fallback allowed 但實際 delegation 已執行的路徑。

## Tests / validation
- `pnpm build && node --test --test-name-pattern "Hybrid AWP|workflow-check start phase emits Hybrid AWP" tests/cli.integration.test.ts tests/hybrid-awp-routing-policy.test.ts`
- `pnpm build && node --test --test-name-pattern "workflow-check|local routing evidence status|fallback-allowed" tests/cli.integration.test.ts`
- `pnpm test` → 211 tests, 209 pass, 2 skipped optional gh smoke tests
- `pnpm build`
- `git diff --check`

## Implementation Evidence
- Issue evidence comments:
  - #226: https://github.com/Erick52106/spec-injector/issues/226#issuecomment-4442182120
  - #227: https://github.com/Erick52106/spec-injector/issues/227#issuecomment-4442182453
  - #228: https://github.com/Erick52106/spec-injector/issues/228#issuecomment-4442182794
  - #229: https://github.com/Erick52106/spec-injector/issues/229#issuecomment-4442183056
  - #230: https://github.com/Erick52106/spec-injector/issues/230#issuecomment-4442183313
- Commits:
  - `60284d64b0a7debed28ee8bf17cda8c1d6f92ea2` - #226 policy/docs/assertion
  - `6cdc8e2f526c40b06753dc8ddf17e57ffb0a8a67` - #227~#230 CLI gates/tests/docs/fixtures
  - `13f6e6a544b0949939bc8a0be791a7a6eddb4ce3` - #227 review follow-up: assert `delegation_threshold` in start-phase JSON
- Latest head SHA: `13f6e6a544b0949939bc8a0be791a7a6eddb4ce3`

## Scope
- Hybrid AWP routing policy, `spec workflow-check` local routing evidence gates, downstream thin-wiring fixtures, and focused regression coverage for #226~#230.

## Non-goals
- No GitHub issue / PR / label / comment / review mutation is performed by the CLI feature.
- No hosted control plane, daemon, dashboard, auto-merge, auto-comment, or worker runtime.
- No downstream repo Scope Police parser changes.
- No automatic output-file writes; `workflow-check` stays stdout-first and local-only.
- No downstream `.spec-injector/`, generated output, or private context artifacts are committed.

## Review closeout / final merge gate evidence
- Review feedback from local AWP reviewer was assessed and adopted for blocking findings:
  - local `--routing-evidence` JSON `status` / `missing_fields` now participates in commit/merge gate failure.
  - `controller_fallback=allowed` now means fallback is permitted, not actually used; fallback reason is required only when PR/manual evidence claims fallback usage.
  - CodeRabbit review follow-up adopted: start-phase JSON test now asserts non-empty `delegation_threshold`.
  - CodeRabbit nitpick not adopted: extracting routing regex constants is optional maintainability polish and would add refactor churn outside this PR's merge gate.
  - CodeRabbit nitpick not adopted: rewriting negative routing fixtures around a shared known-good object is optional test cleanup; current focused regressions already validate the targeted failure surfaces and passed full validation.
- Human authorization received on 2026-05-14 for #231 merge closeout.
- This PR is ready for human review. Merge is not performed by the agent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI accepts local routing evidence (--routing-evidence) and includes routing/fallback fields in JSON output; start/commit/merge phases report routing alignment and failure conditions.

* **Documentation**
  * Added Hybrid AWP routing policy and workflow docs; Quickstart updated with routing-evidence examples and stable JSON field descriptions.

* **Tests**
  * New tests for docs, CLI help, gate behaviors, and routing-evidence validation (including freshness/mismatch checks).

* **Chores**
  * Test fixtures/helpers updated to support configurable issue payloads and dynamic refs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Erick52106/spec-injector/pull/231)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



