### PR TITLE
feat(cli): add AWP doctor and bootstrap contract

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -174,6 +174,7 @@ spec awp-review-check --repo . --evidence /path/to/awp-review-evidence.json
 spec workflow-check --repo . --phase merge --pr-body /path/to/pr-body.md --finding-disposition /path/to/findings.json
 spec workflow-check --repo . --phase merge --pr-body /path/to/pr-body.md --threshold-evidence /path/to/threshold.json
 spec workflow-check --repo . --phase merge --pr <number-or-url> --format json
+spec doctor --workflow awp --format json
 ```
 
 Notes:
@@ -185,6 +186,7 @@ Notes:
 - For a full generated task package file, omit `--dry-run`; output is written under `.spec-injector/out/`.
 - `spec workflow-check` is a local-only, stdout-first workflow gate for autonomous PR evidence. It does not edit GitHub, add/commit files, write task packages, comment, merge, or mutate downstream repos.
 - Autonomous worker-routing flows can use the [Hybrid AWP routing policy](docs/hybrid-awp-routing-policy.md) as the start-gate source of truth before implementation begins.
+- Downstream AI entrypoints can reference the [AI bootstrap install contract](docs/ai-bootstrap-install-contract.md) for the `SPEC_INJECTOR_DIR` local runner fallback and `spec doctor --workflow awp --format json` capability check without requiring global installation.
 - `spec workflow-check --format json` emits the same stable fields as text output: `phase`, `status`, `repo`, `head_sha`, `checked_at`, `missing_fields`, `warnings`, and `evidence_summary`.
 - Hybrid AWP checks add optional JSON/text fields such as `routing_mode`, `routing_task_class`, `spark_required`, `worker_5_4_required`, `controller_role`, `controller_fallback`, `controller_fallback_reason`, `fallback_status`, `fallback_reason_quality`, `routing_mismatch`, `human_review_status`, and `draft_status`.
 - Downstream repos such as `tachigo` / `tachiya` only need to copy or reference the workflow-check `status` and evidence `ref` in their PR body / ledger. Their Scope Police workflows should not parse full `spec plan` or task-package evidence. See the [target repo adoption contract](docs/target-repo-adoption-contract.md).

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ spec awp-review-check --repo . --evidence /path/to/awp-review-evidence.json
 spec workflow-check --repo . --phase merge --pr-body /path/to/pr-body.md --finding-disposition /path/to/findings.json
 spec workflow-check --repo . --phase merge --pr-body /path/to/pr-body.md --threshold-evidence /path/to/threshold.json
 spec workflow-check --repo . --phase merge --pr <number-or-url> --format json
+spec doctor --workflow awp --format json
 ```
 
 Notes:
@@ -196,6 +197,7 @@ Notes:
 - For a full generated task package file, omit `--dry-run`; output is written under `.spec-injector/out/`.
 - `spec workflow-check` is a local-only, stdout-first workflow gate for autonomous PR evidence. It does not edit GitHub, add/commit files, write task packages, comment, merge, or mutate downstream repos.
 - Autonomous worker-routing flow 可在 implementation 開始前使用 [Hybrid AWP routing policy](docs/hybrid-awp-routing-policy.md) 作為 start-gate source of truth。
+- Downstream AI entrypoints 可引用 [AI bootstrap install contract](docs/ai-bootstrap-install-contract.md)，用 `SPEC_INJECTOR_DIR` local runner fallback 與 `spec doctor --workflow awp --format json` 檢查 AWP capability，不需要 global install。
 - `spec workflow-check --format json` emits the same stable fields as the text output: `phase`, `status`, `repo`, `head_sha`, `checked_at`, `missing_fields`, `warnings`, and `evidence_summary`.
 - Hybrid AWP checks add optional JSON/text fields such as `routing_mode`, `routing_task_class`, `spark_required`, `worker_5_4_required`, `controller_role`, `controller_fallback`, `controller_fallback_reason`, `fallback_status`, `fallback_reason_quality`, `routing_mismatch`, `human_review_status`, and `draft_status`.
 - Downstream repos such as `tachigo` / `tachiya` only need to copy or reference the workflow-check `status` and evidence `ref` in their PR body / ledger. Their Scope Police workflows should not parse full `spec plan` or task-package evidence. See the [target repo adoption contract](docs/target-repo-adoption-contract.md).

--- a/docs/ai-bootstrap-install-contract.md
+++ b/docs/ai-bootstrap-install-contract.md
@@ -1,0 +1,96 @@
+# AI Bootstrap Install Contract
+
+Downstream AI entrypoints for `tachigo`, `tachiya`, and other target repos can reference this contract when they need `spec-injector` before running Hybrid AWP gates. The canonical source repo is:
+
+```text
+https://github.com/Erick52106/spec-injector
+```
+
+This is an install and capability-readiness contract, not a hosted control plane. It does not authorize target repo mutation, daemon behavior, auto-commenting, auto-merge, or hidden LLM wrapping.
+
+## Capability-First Check
+
+Before cloning or updating anything, prefer the already available `spec` command:
+
+```bash
+command -v spec
+spec doctor --workflow awp --format json
+spec workflow-check --help
+```
+
+The AWP workflow requires `workflow-check` support for:
+
+- `--phase start|commit|merge`
+- `--finding-disposition`
+- `--threshold-evidence`
+- `--pr`
+
+`spec doctor --workflow awp --format json` is the stable machine-readable readiness check. A `status` of `pass` means the installed CLI exposes the current AWP workflow capabilities. A `status` of `fail` means the bootstrap should use the local runner fallback below or stop for human review.
+
+## Local Runner Fallback
+
+Downstream agents do not need global `pnpm link`. They can keep a local checkout outside the target repo and invoke the built CLI directly:
+
+```bash
+export SPEC_INJECTOR_DIR="${SPEC_INJECTOR_DIR:-$HOME/.cache/spec-injector}"
+
+if [ ! -d "$SPEC_INJECTOR_DIR/.git" ]; then
+  git clone https://github.com/Erick52106/spec-injector "$SPEC_INJECTOR_DIR"
+else
+  git -C "$SPEC_INJECTOR_DIR" pull --ff-only
+fi
+
+corepack enable
+pnpm -C "$SPEC_INJECTOR_DIR" install
+pnpm -C "$SPEC_INJECTOR_DIR" build
+
+node "$SPEC_INJECTOR_DIR/dist/cli/index.js" doctor --workflow awp --format json
+node "$SPEC_INJECTOR_DIR/dist/cli/index.js" workflow-check --help
+```
+
+The target repo should call `node "$SPEC_INJECTOR_DIR/dist/cli/index.js"` when it needs a pinned local runner and should avoid copying generated output back into the target repo.
+
+## Verbatim Downstream Snippet
+
+Target repo AI bootstrap docs may copy this shape:
+
+```bash
+if command -v spec >/dev/null 2>&1 && spec doctor --workflow awp --format json >/tmp/spec-doctor.json; then
+  SPEC_RUNNER="spec"
+else
+  export SPEC_INJECTOR_DIR="${SPEC_INJECTOR_DIR:-$HOME/.cache/spec-injector}"
+  if [ ! -d "$SPEC_INJECTOR_DIR/.git" ]; then
+    git clone https://github.com/Erick52106/spec-injector "$SPEC_INJECTOR_DIR"
+  else
+    git -C "$SPEC_INJECTOR_DIR" pull --ff-only
+  fi
+  corepack enable
+  pnpm -C "$SPEC_INJECTOR_DIR" install
+  pnpm -C "$SPEC_INJECTOR_DIR" build
+  node "$SPEC_INJECTOR_DIR/dist/cli/index.js" doctor --workflow awp --format json >/tmp/spec-doctor.json
+  SPEC_RUNNER="node $SPEC_INJECTOR_DIR/dist/cli/index.js"
+fi
+```
+
+Target repo docs can then invoke:
+
+```bash
+$SPEC_RUNNER workflow-check --repo . --phase start --issue <number-or-url> --format json
+$SPEC_RUNNER workflow-check --repo . --phase commit --pr-body /path/to/pr-body.md --format json
+$SPEC_RUNNER workflow-check --repo . --phase merge --pr <number-or-url> --format json
+```
+
+## Boundaries
+
+- Do not commit `.spec-injector/out/`, generated task packages, local doctor output, local routing JSON, private context, or private ledgers into target repos.
+- Do not let target repo Scope Police parse full `spec plan` output, full task packages, or full AWP ledgers.
+- Do not auto-install into system-wide locations unless a human explicitly chooses that environment.
+- Do not use this bootstrap as a daemon, dashboard, hosted control plane, merge bot, auto-commenter, or hidden LLM wrapper.
+- Do not treat doctor `pass` as human merge approval.
+- Do not mutate target repo GitHub state from `spec doctor`; it is local-only and does not call GitHub.
+
+## When Target Repos Still Need Their Own PRs
+
+`spec-injector` can provide the bootstrap contract and local checker behavior, but `tachigo`, `tachiya`, or any other target repo still need their own PR when they change repo-local docs, `AGENTS.md`, `CLAUDE.md`, PR templates, CI, Scope Police enforcement, labels, or merge policy.
+
+Use target repo PRs for repo policy changes. Use this contract for a stable install/readiness snippet and for the status/ref evidence shape that target repo docs can reference.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -20,6 +20,8 @@ Autonomous review follow-up 的 batching、freshness、duplicate collapse、root
 
 Downstream target repo 如何採用 `spec workflow-check` status/ref evidence、何時仍需要 target repo PR、以及 tachigo / tachiya thin-wiring examples，見 [target repo adoption contract](target-repo-adoption-contract.md)。該 contract 明確保留 local-only、read-only、no target repo mutation 邊界。
 
+Downstream AI entrypoints 若需要安裝、更新或檢查 `spec-injector` AWP capability，請引用 [AI bootstrap install contract](ai-bootstrap-install-contract.md)。該 contract 定義 canonical repo URL、`SPEC_INJECTOR_DIR` local runner fallback、`spec doctor --workflow awp --format json` readiness check，以及 no generated output / no target repo mutation 邊界。
+
 Future companion / workflow observability status vocabulary 見 [status-event-schema.md](status-event-schema.md)。該 schema 是 Layer 4 design proposal，不代表 daemon、companion UI、CLI JSON output、watcher、merge bot 或 target repo automation 已實作。
 
 `spec label-audit` 是 repo-local、human-readable 的 read-only guardrail。它讀取 accepted taxonomy 與 `gh issue list` / `gh pr list` metadata，輸出 `PASS` / `WARNING` / `NEEDS-HUMAN-REVIEW`；它只 report，不建立 labels、不修改 labels、不修改 milestones、不修改 issue / PR metadata。`needs human review` 代表 stop-and-report，不代表 checker 自動替 human 做 metadata 決策。

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1,0 +1,184 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { run } from '../utils/shell.js';
+
+type DoctorOptions = {
+  workflow?: string;
+  format?: string;
+};
+
+type DoctorStatus = 'pass' | 'fail' | 'manual' | 'skipped';
+type OutputFormat = 'text' | 'json';
+
+type Capability = {
+  id: string;
+  status: DoctorStatus;
+  required: boolean;
+  evidence: string;
+};
+
+type DoctorResult = {
+  workflow: string;
+  status: DoctorStatus;
+  checked_at: string;
+  executable: string;
+  version: string;
+  commit: string;
+  missing_capabilities: string[];
+  warnings: string[];
+  capabilities: Capability[];
+  evidence_summary: string;
+};
+
+const SUPPORTED_WORKFLOWS = new Set(['awp']);
+const SUPPORTED_FORMATS = new Set(['text', 'json']);
+
+export async function doctor(opts: DoctorOptions): Promise<void> {
+  const workflow = parseWorkflow(opts.workflow ?? 'awp');
+  const format = parseFormat(opts.format ?? 'text');
+  const result = await runDoctor(workflow);
+  printDoctorResult(result, format);
+  if (result.status === 'fail') process.exit(1);
+}
+
+async function runDoctor(workflow: string): Promise<DoctorResult> {
+  const checkedAt = new Date().toISOString();
+  const executable = doctorExecutableLabel();
+  const [version, commit] = await Promise.all([readPackageVersion(), readCommit()]);
+  const rootHelp = runSpecHelp(['--help']);
+  const workflowHelp = runSpecHelp(['workflow-check', '--help']);
+  const awpReviewHelp = runSpecHelp(['awp-review-check', '--help']);
+
+  const workflowOutput = `${workflowHelp.stdout}\n${workflowHelp.stderr}`;
+  const capabilities: Capability[] = [
+    {
+      id: 'workflow_check_command',
+      status: rootHelp.exitCode === 0 && /\bworkflow-check\b/.test(rootHelp.stdout) && workflowHelp.exitCode === 0 ? 'pass' : 'fail',
+      required: true,
+      evidence: 'spec --help; spec workflow-check --help',
+    },
+    {
+      id: 'workflow_check_phase_start_commit_merge',
+      status: /\bstart\|commit\|merge\b/.test(workflowOutput) ? 'pass' : 'fail',
+      required: true,
+      evidence: 'spec workflow-check --help includes start|commit|merge',
+    },
+    {
+      id: 'workflow_check_finding_disposition',
+      status: /--finding-disposition\b/.test(workflowOutput) ? 'pass' : 'fail',
+      required: true,
+      evidence: 'spec workflow-check --help includes --finding-disposition',
+    },
+    {
+      id: 'workflow_check_threshold_evidence',
+      status: /--threshold-evidence\b/.test(workflowOutput) ? 'pass' : 'fail',
+      required: true,
+      evidence: 'spec workflow-check --help includes --threshold-evidence',
+    },
+    {
+      id: 'workflow_check_pr_readback',
+      status: hasLongOption(workflowOutput, 'pr') ? 'pass' : 'fail',
+      required: true,
+      evidence: 'spec workflow-check --help includes --pr',
+    },
+    {
+      id: 'awp_review_check_command',
+      status: awpReviewHelp.exitCode === 0 ? 'pass' : 'skipped',
+      required: false,
+      evidence: 'spec awp-review-check --help',
+    },
+  ];
+
+  const missingCapabilities = capabilities
+    .filter((capability) => capability.required && capability.status !== 'pass')
+    .map((capability) => capability.id);
+  const warnings = capabilities
+    .filter((capability) => !capability.required && capability.status !== 'pass')
+    .map((capability) => `${capability.id} unavailable; AWP review ledger checks may need manual fallback.`);
+  const status: DoctorStatus = missingCapabilities.length > 0 ? 'fail' : 'pass';
+
+  return {
+    workflow,
+    status,
+    checked_at: checkedAt,
+    executable,
+    version,
+    commit,
+    missing_capabilities: missingCapabilities,
+    warnings,
+    capabilities,
+    evidence_summary: status === 'pass'
+      ? 'AWP workflow capabilities available; doctor is local-only and does not call GitHub or mutate target repos'
+      : `AWP workflow capabilities missing: ${missingCapabilities.join(', ')}`,
+  };
+}
+
+function parseWorkflow(value: string): string {
+  const normalized = value.trim().toLowerCase();
+  if (SUPPORTED_WORKFLOWS.has(normalized)) return normalized;
+  throw new Error(`Unsupported doctor workflow: ${value}. Expected awp.`);
+}
+
+function parseFormat(value: string): OutputFormat {
+  const normalized = value.trim().toLowerCase();
+  if (SUPPORTED_FORMATS.has(normalized)) return normalized as OutputFormat;
+  throw new Error(`Unsupported doctor format: ${value}. Expected text|json.`);
+}
+
+function runSpecHelp(args: string[]) {
+  return run([...doctorExecutableCommand(), ...args]);
+}
+
+function hasLongOption(output: string, optionName: string): boolean {
+  const escaped = optionName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`(?:^|\\s)--${escaped}(?:\\s|,|$)`, 'm').test(output);
+}
+
+function doctorExecutableCommand(): string[] {
+  if (process.env.SPEC_DOCTOR_SPEC_BIN) return [process.env.SPEC_DOCTOR_SPEC_BIN];
+  return [process.execPath, process.argv[1]];
+}
+
+function doctorExecutableLabel(): string {
+  return process.env.SPEC_DOCTOR_SPEC_BIN ?? `${process.execPath} ${process.argv[1]}`;
+}
+
+async function readPackageVersion(): Promise<string> {
+  try {
+    const packagePath = path.join(packageRoot(), 'package.json');
+    const parsed = JSON.parse(await fs.readFile(packagePath, 'utf8')) as { version?: string };
+    return parsed.version ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+async function readCommit(): Promise<string> {
+  if (process.env.SPEC_INJECTOR_COMMIT) return process.env.SPEC_INJECTOR_COMMIT;
+  const result = run(['git', 'rev-parse', '--short', 'HEAD'], { cwd: packageRoot() });
+  return result.exitCode === 0 ? result.stdout.trim() : 'unknown';
+}
+
+function packageRoot(): string {
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+}
+
+function printDoctorResult(result: DoctorResult, format: OutputFormat): void {
+  if (format === 'json') {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  console.log(`workflow=${result.workflow}`);
+  console.log(`status=${result.status}`);
+  console.log(`executable=${result.executable}`);
+  console.log(`version=${result.version}`);
+  console.log(`commit=${result.commit}`);
+  console.log(`missing_capabilities=${result.missing_capabilities.length > 0 ? result.missing_capabilities.join(',') : 'none'}`);
+  console.log(`warnings=${result.warnings.length > 0 ? result.warnings.join(' | ') : 'none'}`);
+  for (const capability of result.capabilities) {
+    console.log(`${capability.id}=${capability.status}`);
+  }
+  console.log(`evidence_summary=${result.evidence_summary}`);
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -60,7 +60,7 @@ async function runDoctor(workflow: string): Promise<DoctorResult> {
     },
     {
       id: 'workflow_check_phase_start_commit_merge',
-      status: /\bstart\|commit\|merge\b/.test(workflowOutput) ? 'pass' : 'fail',
+      status: hasWords(workflowOutput, ['start', 'commit', 'merge']) ? 'pass' : 'fail',
       required: true,
       evidence: 'spec workflow-check --help includes start|commit|merge',
     },
@@ -135,6 +135,10 @@ function hasLongOption(output: string, optionName: string): boolean {
   return new RegExp(`(?:^|\\s)--${escaped}(?:\\s|,|$)`, 'm').test(output);
 }
 
+function hasWords(output: string, words: string[]): boolean {
+  return words.every((word) => new RegExp(`\\b${word}\\b`, 'i').test(output));
+}
+
 function doctorExecutableCommand(): string[] {
   if (process.env.SPEC_DOCTOR_SPEC_BIN) return [process.env.SPEC_DOCTOR_SPEC_BIN];
   return [process.execPath, process.argv[1]];
@@ -156,8 +160,26 @@ async function readPackageVersion(): Promise<string> {
 
 async function readCommit(): Promise<string> {
   if (process.env.SPEC_INJECTOR_COMMIT) return process.env.SPEC_INJECTOR_COMMIT;
-  const result = run(['git', 'rev-parse', '--short', 'HEAD'], { cwd: packageRoot() });
+  const root = packageRoot();
+  const topLevel = run(['git', 'rev-parse', '--show-toplevel'], { cwd: root });
+  if (topLevel.exitCode !== 0) return 'unknown';
+
+  const [realRoot, realTopLevel] = await Promise.all([
+    realPathOrResolved(root),
+    realPathOrResolved(topLevel.stdout.trim()),
+  ]);
+  if (realRoot !== realTopLevel) return 'unknown';
+
+  const result = run(['git', 'rev-parse', '--short', 'HEAD'], { cwd: root });
   return result.exitCode === 0 ? result.stdout.trim() : 'unknown';
+}
+
+async function realPathOrResolved(value: string): Promise<string> {
+  try {
+    return await fs.realpath(value);
+  } catch {
+    return path.resolve(value);
+  }
 }
 
 function packageRoot(): string {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -144,6 +144,27 @@ Safety:
     await preflight(opts);
   });
 
+// doctor subcommand
+program
+  .command('doctor')
+  .description('Run local workflow capability readiness checks')
+  .option('--workflow <workflow>', 'Workflow capability set to check: awp (default: awp)')
+  .option('--format <format>', 'Output format: text or json (default: text)')
+  .addHelpText('after', `
+Checks:
+  - AWP workflow-check command and start|commit|merge phase support
+  - #242 workflow-check flags: --finding-disposition, --threshold-evidence, and --pr
+  - awp-review-check availability when present
+  - local package version and git commit metadata when available
+
+Safety:
+  Local-only capability check. Does not call GitHub, auto-install, auto-update, write files, or mutate target repos.
+`)
+  .action(async (opts: { workflow?: string; format?: string }) => {
+    const { doctor } = await import('./doctor.js');
+    await doctor(opts);
+  });
+
 // workflow-check subcommand
 program
   .command('workflow-check')

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import { classifyDomains, classifyDomainsWithEvidence } from '../dist/classifier/domain.js';
 import { config as runConfigCommand } from '../dist/cli/config.js';
@@ -645,6 +646,7 @@ test('spec --help lists deterministic CLI purpose and available commands', async
   assert.match(result.stdout, /\bplan\b/);
   assert.match(result.stdout, /\bconfig\b/);
   assert.match(result.stdout, /\bclean\b/);
+  assert.match(result.stdout, /\bdoctor\b/);
   assert.match(result.stdout, /\bworkflow-check\b/);
   assert.match(result.stdout, /\bevidence-check\b/);
   assert.match(result.stdout, /\blabel-audit\b/);
@@ -723,6 +725,13 @@ test('spec plan/config/clean help describe AI-facing usage and safety constraint
   assert.match(workflowCheckHelp.stdout, /stdout/i);
   assert.match(workflowCheckHelp.stdout, /does not edit GitHub/i);
 
+  const doctorHelp = await runSpec(['doctor', '--help']);
+  assert.equal(doctorHelp.code, 0, doctorHelp.stderr);
+  assert.match(doctorHelp.stdout, /workflow capability readiness/i);
+  assert.match(doctorHelp.stdout, /--workflow <workflow>/);
+  assert.match(doctorHelp.stdout, /awp/i);
+  assert.match(doctorHelp.stdout, /local-only/i);
+
   const labelAuditHelp = await runSpec(['label-audit', '--help']);
   assert.equal(labelAuditHelp.code, 0, labelAuditHelp.stderr);
   assert.match(labelAuditHelp.stdout, /label and milestone metadata audit/i);
@@ -730,6 +739,130 @@ test('spec plan/config/clean help describe AI-facing usage and safety constraint
   assert.match(labelAuditHelp.stdout, /reports only/i);
   assert.match(labelAuditHelp.stdout, /does not create, rename, delete, or mutate/i);
 });
+
+test('spec doctor reports current AWP workflow capabilities as JSON', async () => {
+  const result = await runSpec(['doctor', '--workflow', 'awp', '--format', 'json']);
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(result.stderr, '');
+  const parsed = JSON.parse(result.stdout) as {
+    workflow: string;
+    status: string;
+    version: string;
+    missing_capabilities: string[];
+    warnings: string[];
+    capabilities: Array<{ id: string; status: string; evidence: string }>;
+  };
+  assert.equal(parsed.workflow, 'awp');
+  assert.equal(parsed.status, 'pass');
+  assert.equal(parsed.version, '0.1.0');
+  assert.deepEqual(parsed.missing_capabilities, []);
+  assert.deepEqual(parsed.warnings, []);
+  for (const id of [
+    'workflow_check_command',
+    'workflow_check_phase_start_commit_merge',
+    'workflow_check_finding_disposition',
+    'workflow_check_threshold_evidence',
+    'workflow_check_pr_readback',
+    'awp_review_check_command',
+  ]) {
+    assert.equal(parsed.capabilities.find((capability) => capability.id === id)?.status, 'pass', id);
+  }
+});
+
+test('spec doctor text output is concise and local-only', async () => {
+  const result = await runSpec(['doctor', '--workflow', 'awp']);
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /workflow=awp/);
+  assert.match(result.stdout, /status=pass/);
+  assert.match(result.stdout, /workflow_check_pr_readback=pass/);
+  assert.match(result.stdout, /does not call GitHub/i);
+  assert.doesNotMatch(result.stdout, /https:\/\/api\.github\.com/i);
+});
+
+test('spec doctor fails when workflow-check is missing from installed spec', async (t) => {
+  const fakeSpec = await writeFakeSpec(t, {
+    rootHelp: 'Usage: spec\\nCommands:\\n  plan\\n  validate\\n  awp-review-check\\n',
+    workflowHelpExitCode: 1,
+    workflowHelp: 'error: unknown command workflow-check\\n',
+    awpReviewHelp: 'Usage: spec awp-review-check\\n',
+  });
+
+  const result = await runSpec(['doctor', '--workflow', 'awp', '--format', 'json'], {
+    env: { ...process.env, SPEC_DOCTOR_SPEC_BIN: fakeSpec },
+  });
+
+  assert.notEqual(result.code, 0);
+  const parsed = JSON.parse(result.stdout) as { status: string; missing_capabilities: string[]; capabilities: Array<{ id: string; status: string }> };
+  assert.equal(parsed.status, 'fail');
+  assert.ok(parsed.missing_capabilities.includes('workflow_check_command'));
+  assert.equal(parsed.capabilities.find((capability) => capability.id === 'workflow_check_command')?.status, 'fail');
+});
+
+test('spec doctor fails when installed workflow-check lacks #242 AWP flags', async (t) => {
+  const fakeSpec = await writeFakeSpec(t, {
+    rootHelp: 'Usage: spec\\nCommands:\\n  workflow-check\\n  awp-review-check\\n',
+    workflowHelp: [
+      'Usage: spec workflow-check',
+      '--phase <phase>',
+      'Workflow phase: start|commit|merge',
+      '--pr-body <path>',
+      '--routing-evidence <path>',
+    ].join('\\n'),
+    awpReviewHelp: 'Usage: spec awp-review-check\\n',
+  });
+
+  const result = await runSpec(['doctor', '--workflow', 'awp', '--format', 'json'], {
+    env: { ...process.env, SPEC_DOCTOR_SPEC_BIN: fakeSpec },
+  });
+
+  assert.notEqual(result.code, 0);
+  const parsed = JSON.parse(result.stdout) as { status: string; missing_capabilities: string[] };
+  assert.equal(parsed.status, 'fail');
+  assert.ok(parsed.missing_capabilities.includes('workflow_check_finding_disposition'));
+  assert.ok(parsed.missing_capabilities.includes('workflow_check_threshold_evidence'));
+  assert.ok(parsed.missing_capabilities.includes('workflow_check_pr_readback'));
+});
+
+async function writeFakeSpec(
+  t: { after(fn: () => void | Promise<void>): void },
+  options: {
+    rootHelp: string;
+    workflowHelp: string;
+    workflowHelpExitCode?: number;
+    awpReviewHelp: string;
+    awpReviewHelpExitCode?: number;
+  }
+): Promise<string> {
+  const binDir = await fs.mkdtemp(path.join(os.tmpdir(), 'spec-injector-doctor-fake-'));
+  t.after(async () => {
+    await fs.rm(binDir, { recursive: true, force: true });
+  });
+  const fakeSpec = path.join(binDir, 'spec');
+  await fs.writeFile(fakeSpec, `#!/usr/bin/env node
+const args = process.argv.slice(2);
+const rootHelp = ${JSON.stringify(options.rootHelp)};
+const workflowHelp = ${JSON.stringify(options.workflowHelp)};
+const awpReviewHelp = ${JSON.stringify(options.awpReviewHelp)};
+if (args.length === 0 || (args.length === 1 && args[0] === '--help')) {
+  process.stdout.write(rootHelp);
+  process.exit(0);
+}
+if (args[0] === 'workflow-check' && args[1] === '--help') {
+  process.stdout.write(workflowHelp);
+  process.exit(${options.workflowHelpExitCode ?? 0});
+}
+if (args[0] === 'awp-review-check' && args[1] === '--help') {
+  process.stdout.write(awpReviewHelp);
+  process.exit(${options.awpReviewHelpExitCode ?? 0});
+}
+process.stderr.write('unknown fake spec invocation: ' + args.join(' '));
+process.exit(1);
+`, 'utf8');
+  await fs.chmod(fakeSpec, 0o755);
+  return fakeSpec;
+}
 
 test('spec workflow-check rejects invalid phases before touching repo state', async () => {
   const result = await runSpec(['workflow-check', '--repo', repoRoot, '--phase', 'review']);

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -753,9 +753,10 @@ test('spec doctor reports current AWP workflow capabilities as JSON', async () =
     warnings: string[];
     capabilities: Array<{ id: string; status: string; evidence: string }>;
   };
+  const packageJson = JSON.parse(await fs.readFile(path.join(repoRoot, 'package.json'), 'utf8')) as { version: string };
   assert.equal(parsed.workflow, 'awp');
   assert.equal(parsed.status, 'pass');
-  assert.equal(parsed.version, '0.1.0');
+  assert.equal(parsed.version, packageJson.version);
   assert.deepEqual(parsed.missing_capabilities, []);
   assert.deepEqual(parsed.warnings, []);
   for (const id of [
@@ -779,6 +780,55 @@ test('spec doctor text output is concise and local-only', async () => {
   assert.match(result.stdout, /workflow_check_pr_readback=pass/);
   assert.match(result.stdout, /does not call GitHub/i);
   assert.doesNotMatch(result.stdout, /https:\/\/api\.github\.com/i);
+});
+
+test('spec doctor accepts workflow-check phase tokens with non-pipe separators', async (t) => {
+  const fakeSpec = await writeFakeSpec(t, {
+    rootHelp: 'Usage: spec\\nCommands:\\n  workflow-check\\n  awp-review-check\\n',
+    workflowHelp: [
+      'Usage: spec workflow-check',
+      '--phase <phase>',
+      'Supported phases: start, commit, merge',
+      '--finding-disposition <path>',
+      '--threshold-evidence <path>',
+      '--pr <number-or-url>',
+    ].join('\\n'),
+    awpReviewHelp: 'Usage: spec awp-review-check\\n',
+  });
+
+  const result = await runSpec(['doctor', '--workflow', 'awp', '--format', 'json'], {
+    env: { ...process.env, SPEC_DOCTOR_SPEC_BIN: fakeSpec },
+  });
+
+  assert.equal(result.code, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout) as { status: string; capabilities: Array<{ id: string; status: string }> };
+  assert.equal(parsed.status, 'pass');
+  assert.equal(parsed.capabilities.find((capability) => capability.id === 'workflow_check_phase_start_commit_merge')?.status, 'pass');
+});
+
+test('spec doctor does not report target repo HEAD when installed package root is nested in another git repo', async (t) => {
+  const targetRepo = await createTempRepo(t, 'spec-injector-doctor-installed-');
+  await writeRepoFiles(targetRepo, { 'README.md': 'target repo\\n' });
+  await initCleanGitRepo(targetRepo);
+  const targetHead = (await runCommand('git', ['rev-parse', '--short', 'HEAD'], targetRepo)).stdout.trim();
+  const packageDir = path.join(targetRepo, 'node_modules', 'spec-injector');
+  await fs.mkdir(packageDir, { recursive: true });
+  await fs.cp(path.join(repoRoot, 'dist'), path.join(packageDir, 'dist'), { recursive: true });
+  await fs.symlink(path.join(repoRoot, 'node_modules'), path.join(packageDir, 'node_modules'), 'dir');
+  const packageJson = JSON.parse(await fs.readFile(path.join(repoRoot, 'package.json'), 'utf8')) as { version: string };
+  await fs.writeFile(path.join(packageDir, 'package.json'), `${JSON.stringify({ version: packageJson.version }, null, 2)}\n`, 'utf8');
+
+  const result = await runCommand(process.execPath, [
+    path.join(packageDir, 'dist', 'cli', 'index.js'),
+    'doctor',
+    '--workflow', 'awp',
+    '--format', 'json',
+  ], targetRepo);
+  const parsed = JSON.parse(result.stdout) as { commit: string; status: string };
+
+  assert.equal(parsed.status, 'pass');
+  assert.equal(parsed.commit, 'unknown');
+  assert.notEqual(parsed.commit, targetHead);
 });
 
 test('spec doctor fails when workflow-check is missing from installed spec', async (t) => {
@@ -842,9 +892,9 @@ async function writeFakeSpec(
   const fakeSpec = path.join(binDir, 'spec');
   await fs.writeFile(fakeSpec, `#!/usr/bin/env node
 const args = process.argv.slice(2);
-const rootHelp = ${JSON.stringify(options.rootHelp)};
-const workflowHelp = ${JSON.stringify(options.workflowHelp)};
-const awpReviewHelp = ${JSON.stringify(options.awpReviewHelp)};
+const rootHelp = ${JSON.stringify(options.rootHelp.replaceAll('\\n', '\n'))};
+const workflowHelp = ${JSON.stringify(options.workflowHelp.replaceAll('\\n', '\n'))};
+const awpReviewHelp = ${JSON.stringify(options.awpReviewHelp.replaceAll('\\n', '\n'))};
 if (args.length === 0 || (args.length === 1 && args[0] === '--help')) {
   process.stdout.write(rootHelp);
   process.exit(0);

--- a/tests/hybrid-awp-routing-policy.test.ts
+++ b/tests/hybrid-awp-routing-policy.test.ts
@@ -70,3 +70,30 @@ test('target repo adoption contract remains linked from workflow docs', async ()
   assert.match(contract, /does not mutate downstream repos/i);
   assert.match(workflow, /\[target repo adoption contract\]\(target-repo-adoption-contract\.md\)/);
 });
+
+test('AI bootstrap install contract remains linked from workflow docs and README', async () => {
+  const contractPath = path.join(repoRoot, 'docs', 'ai-bootstrap-install-contract.md');
+  const workflowPath = path.join(repoRoot, 'docs', 'workflow.md');
+  const readmePath = path.join(repoRoot, 'README.md');
+  const englishReadmePath = path.join(repoRoot, 'README.en.md');
+
+  const [contract, workflow, readme, englishReadme] = await Promise.all([
+    fs.readFile(contractPath, 'utf8'),
+    fs.readFile(workflowPath, 'utf8'),
+    fs.readFile(readmePath, 'utf8'),
+    fs.readFile(englishReadmePath, 'utf8'),
+  ]);
+
+  assert.match(contract, /AI Bootstrap Install Contract/);
+  assert.match(contract, /https:\/\/github\.com\/Erick52106\/spec-injector/);
+  assert.match(contract, /SPEC_INJECTOR_DIR/);
+  assert.match(contract, /node "\$SPEC_INJECTOR_DIR\/dist\/cli\/index\.js"/);
+  assert.match(contract, /command -v spec/);
+  assert.match(contract, /spec doctor --workflow awp --format json/);
+  assert.match(contract, /Do not commit `.spec-injector\/out\/`/);
+  assert.match(contract, /tachigo/i);
+  assert.match(contract, /tachiya/i);
+  assert.match(workflow, /\[AI bootstrap install contract\]\(ai-bootstrap-install-contract\.md\)/);
+  assert.match(readme, /\[AI bootstrap install contract\]\(docs\/ai-bootstrap-install-contract\.md\)/);
+  assert.match(englishReadme, /\[AI bootstrap install contract\]\(docs\/ai-bootstrap-install-contract\.md\)/);
+});

--- a/tests/hybrid-awp-routing-policy.test.ts
+++ b/tests/hybrid-awp-routing-policy.test.ts
@@ -89,6 +89,10 @@ test('AI bootstrap install contract remains linked from workflow docs and README
   assert.match(contract, /SPEC_INJECTOR_DIR/);
   assert.match(contract, /node "\$SPEC_INJECTOR_DIR\/dist\/cli\/index\.js"/);
   assert.match(contract, /command -v spec/);
+  assert.match(contract, /spec workflow-check --help/);
+  assert.match(contract, /--finding-disposition/);
+  assert.match(contract, /--threshold-evidence/);
+  assert.match(contract, /--pr(?!-body)\b/);
   assert.match(contract, /spec doctor --workflow awp --format json/);
   assert.match(contract, /Do not commit `.spec-injector\/out\/`/);
   assert.match(contract, /tachigo/i);

--- a/tests/hybrid-awp-routing-policy.test.ts
+++ b/tests/hybrid-awp-routing-policy.test.ts
@@ -92,7 +92,7 @@ test('AI bootstrap install contract remains linked from workflow docs and README
   assert.match(contract, /spec workflow-check --help/);
   assert.match(contract, /--finding-disposition/);
   assert.match(contract, /--threshold-evidence/);
-  assert.match(contract, /--pr(?!-body)\b/);
+  assert.match(contract, /--pr(?!-)\b/);
   assert.match(contract, /spec doctor --workflow awp --format json/);
   assert.match(contract, /Do not commit `.spec-injector\/out\/`/);
   assert.match(contract, /tachigo/i);


### PR DESCRIPTION
Closes #243
Closes #244

## Summary
- 新增 `spec doctor --workflow awp` / `--format json`，用 local-only capability check 驗證 AWP workflow 所需 CLI surface。
- 新增 AI bootstrap install contract docs，說明 canonical repo、capability-first check、`SPEC_INJECTOR_DIR` local runner fallback、stdout-only/local-only boundaries。
- 從 README / workflow docs 連到 bootstrap contract，並補 CLI/docs regression tests。

## Tests / validation
- `pnpm build && node --test --test-name-pattern "doctor|bootstrap install" tests/cli.integration.test.ts tests/hybrid-awp-routing-policy.test.ts`
- `pnpm test`
- `pnpm build`
- `git diff --check`
- Manual smoke: `node bin/spec.js doctor --workflow awp`
- Manual smoke: `node bin/spec.js doctor --workflow awp --format json`

## Implementation Evidence
- Source of truth: #243, #244
- Depends on PR: none (#242 already merged before this PR was opened)
- Branch: `codex/awp-doctor-243-244`
- Commit hash: `ed48b957a6ececaee47b5e283abcc1b6f0e1e0ca`
- Issue #243 evidence comment URL: https://github.com/Erick52106/spec-injector/issues/243#issuecomment-4444603619
- Issue #244 evidence comment URL: https://github.com/Erick52106/spec-injector/issues/244#issuecomment-4444604841

## Scope guard / non-goals confirmation
- 不做 downstream repo mutation，也不修改 tachigo / tachiya。
- 不做 GitHub mutation inside `spec doctor`；doctor only inspects local CLI help/build metadata.
- 不做 auto-install/update/global install requirement。
- 不做 daemon、hosted control plane、dashboard、auto-merge、auto-comment 或 hidden LLM wrapper。
- 不自動寫 target repo output file；docs 明確維持 stdout/local-runner fallback contract。
- 不 commit `.spec-injector/`、generated task packages、private context 或 local doctor output。

## Review closeout / final merge gate evidence
- Ready for review, non-draft PR.
- Latest head SHA after review fixes: `ed48b957a6ececaee47b5e283abcc1b6f0e1e0ca`.
- Review findings disposition: adopted CodeRabbit phase-token separator tolerance; adopted Codex nested-package commit metadata guard; adopted test version consistency; adopted bootstrap contract flag assertions; adopted stricter standalone `--pr` assertion.
- Merge closeout readback: `mergeStateStatus=CLEAN`, `build=SUCCESS`, `CodeRabbit=SUCCESS`, review threads `3 total / 0 unresolved`, linked issues #243/#244 present.
- `spec workflow-check --phase merge --pr 245 --head-sha ed48b957a6ececaee47b5e283abcc1b6f0e1e0ca --format json` was attempted as a local-only readback and failed with `missing_fields=["config"]` because this repo has no `.spec-injector/` config yet; no repo config was written.
- Final merge remains pending explicit human merge authorization.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a local "doctor" CLI command to validate workflow capabilities with text or JSON output and workflow selection.

* **Documentation**
  * Added an "AI bootstrap install contract" guiding downstream entrypoints and a local-runner fallback.
  * Updated README/quickstart and workflow notes to reference the new capability-check command and the install contract.

* **Tests**
  * Added integration and routing-policy tests covering the doctor command, outputs, failure modes, and contract linkage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Erick52106/spec-injector/pull/245)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



