### PR TITLE
fix(workflow-check): harden PR checks readback

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -96,6 +96,8 @@ CodeRabbit / Codex auto review findings 只能作為 auxiliary signals。`spec e
 
 Thread-level limitation：`spec evidence-check` 目前只做 read-only 輔助檢核，不會完整 enforce GitHub review thread / conversation closeout。它可提醒 PR body / evidence / HEAD / validation / findings shape，但不能保證每條 CodeRabbit / Codex / human thread 都已關閉。`PASS` 僅表示輔助欄位滿足程度，不是 merge approval。該 checker 不能 auto-comment、auto-resolve、auto-merge、auto-close，也不會 mutate GitHub issue / PR metadata；最終 thread-level closeout 必須由 human 逐條確認與接手。
 
+`spec workflow-check --phase merge --pr <number-or-url>` 可做 local-only merge closeout readback。它會讀取 PR body、draft state、review metadata、`gh pr checks` summary 與 review threads，並把無法可靠判斷的 GitHub / `gh` output drift 回報成 `manual` fallback，而不是把工具層 schema mismatch 誤判成 PR 本身不可 merge。若 checks readback 回傳缺欄位、未知 enum、或只有無法歸類的 status shape，controller 應以 PR 頁面、`gh pr checks`、Actions UI、review thread readback 補人工 evidence；不得因 manual fallback 自動 merge，也不得讓 checker auto-comment、auto-resolve 或 mutate GitHub。
+
 ## Worktree naming
 
 建議命名：

--- a/src/cli/workflow-check.ts
+++ b/src/cli/workflow-check.ts
@@ -683,7 +683,7 @@ async function runMergeCloseoutPhase(
     '--repo',
     context.repo,
     '--json',
-    'name,state,bucket,link,conclusion',
+    'name,state,bucket,link,startedAt,completedAt',
   ]);
   const threadsRead = readReviewThreads(context.prRef, context.repo);
 
@@ -717,7 +717,9 @@ async function runMergeCloseoutPhase(
     readWarnings.push(threadsRead.error);
   }
 
-  const checksStatus = checksRead.error ? 'manual' : summarizeChecksStatus(checks);
+  const checksSummary = checksRead.error ? { status: 'manual' as WorkflowStatus, warnings: [] } : summarizeChecks(checks);
+  readWarnings.push(...checksSummary.warnings);
+  const checksStatus = checksSummary.status;
   const unresolvedCount = threadsRead.value === null
     ? null
     : threadsRead.value.filter((thread) => thread.isResolved !== true).length;
@@ -741,7 +743,7 @@ async function runMergeCloseoutPhase(
       ? 'fail'
       : 'manual';
 
-  if (checksStatus === 'fail') missingFields.push('checks_status');
+  if (checksStatus !== 'pass') missingFields.push('checks_status');
   if (sourceIssueEvidenceStatus !== 'pass') missingFields.push('source_issue_evidence');
   if (specGateStatus !== 'pass') missingFields.push('spec_gate_status');
   if (routingEvidenceStatus !== 'pass') missingFields.push('routing_evidence_status');
@@ -1524,10 +1526,44 @@ function manualCloseout(missingFields: string[], warnings: string[]): CloseoutRe
 }
 
 function summarizeChecksStatus(checks: Array<Record<string, unknown>>): WorkflowStatus {
-  if (checks.length === 0) return 'manual';
-  if (checks.some((check) => /fail|failure|cancel|timed_out|action_required/i.test(`${check.bucket ?? ''} ${check.conclusion ?? ''} ${check.state ?? ''}`))) return 'fail';
-  if (checks.some((check) => /pending|queued|in_progress|waiting|requested/i.test(`${check.bucket ?? ''} ${check.conclusion ?? ''} ${check.state ?? ''}`))) return 'manual';
-  return 'pass';
+  return summarizeChecks(checks).status;
+}
+
+function summarizeChecks(checks: Array<Record<string, unknown>>): { status: WorkflowStatus; warnings: string[] } {
+  if (checks.length === 0) return { status: 'manual', warnings: ['checks_status manual fallback: no checks were returned.'] };
+  const warnings: string[] = [];
+  let hasManual = false;
+
+  for (const check of checks) {
+    const statusText = checkStatusText(check);
+    if (/fail|failure|cancel|cancelled|timed_out|action_required|startup_failure/i.test(statusText)) {
+      return { status: 'fail', warnings };
+    }
+    if (/pending|queued|in_progress|waiting|requested/i.test(statusText)) {
+      hasManual = true;
+      warnings.push(`checks_status manual fallback: ${checkName(check)} is not complete (${statusText || 'unknown status'}).`);
+      continue;
+    }
+    if (!/\b(?:pass|passed|success|successful|completed|skipped|neutral)\b/i.test(statusText)) {
+      hasManual = true;
+      warnings.push(`checks_status manual fallback: ${checkName(check)} did not include a recognized status field.`);
+    }
+  }
+
+  return { status: hasManual ? 'manual' : 'pass', warnings };
+}
+
+function checkStatusText(check: Record<string, unknown>): string {
+  return [
+    check.bucket,
+    check.conclusion,
+    check.state,
+    check.status,
+  ].map((value) => String(value ?? '').trim()).filter(Boolean).join(' ');
+}
+
+function checkName(check: Record<string, unknown>): string {
+  return String(check.name ?? check.context ?? 'unnamed check');
 }
 
 function summarizeNamedAutomationStatus(

--- a/src/cli/workflow-check.ts
+++ b/src/cli/workflow-check.ts
@@ -1544,7 +1544,7 @@ function summarizeChecks(checks: Array<Record<string, unknown>>): { status: Work
       warnings.push(`checks_status manual fallback: ${checkName(check)} is not complete (${statusText || 'unknown status'}).`);
       continue;
     }
-    if (!/\b(?:pass|passed|success|successful|completed|skipped|neutral)\b/i.test(statusText)) {
+    if (!/\b(?:pass|passed|success|successful|skipped|skipping|neutral)\b/i.test(statusText)) {
       hasManual = true;
       warnings.push(`checks_status manual fallback: ${checkName(check)} did not include a recognized status field.`);
     }

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -2346,6 +2346,8 @@ test('spec workflow-check merge closeout treats alternate queued check status as
   assert.equal(parsed.checks_status, 'manual');
   assert.equal(parsed.ready_to_merge, 'manual');
   assert.ok((parsed.missing_fields as string[]).includes('checks_status'));
+  assert.match((parsed.warnings as string[]).join('\n'), /manual fallback/i);
+  assert.match((parsed.warnings as string[]).join('\n'), /build/i);
   const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
   assertNoGhMutationCommands(ghLog);
 });
@@ -2379,7 +2381,7 @@ test('spec workflow-check merge closeout reports manual fallback for checks miss
     reviews: [{ author: { login: 'chatgpt-codex-connector' }, body: 'No actionable findings.', state: 'COMMENTED' }],
     reviewThreads: [],
     checks: [
-      { name: 'build' },
+      { name: 'build', state: 'COMPLETED' },
       { name: 'CodeRabbit', state: 'SUCCESS', bucket: 'pass' },
     ],
   });
@@ -2399,6 +2401,8 @@ test('spec workflow-check merge closeout reports manual fallback for checks miss
   assert.ok((parsed.missing_fields as string[]).includes('checks_status'));
   assert.match((parsed.warnings as string[]).join('\n'), /manual fallback/i);
   assert.match((parsed.warnings as string[]).join('\n'), /build/i);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
 });
 
 test('spec workflow-check merge closeout omits unknown review thread counts', async (t) => {

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -2245,6 +2245,162 @@ test('spec workflow-check merge closeout returns manual when mocked gh readback 
   assertNoGhMutationCommands(ghLog);
 });
 
+test('spec workflow-check merge closeout does not request drift-prone conclusion check fields', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-closeout-no-conclusion-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+  const headSha = 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+  const fixture = await createEvidenceCheckFixture(t, {
+    issueNumber: 247,
+    headSha,
+    forbiddenChecksJsonFields: ['conclusion'],
+    prBody: [
+      'Closes #247',
+      '',
+      '## Spec gate evidence',
+      '- spec gate status: pass',
+      '- spec evidence ref: https://github.com/Erick52106/spec-injector/issues/247#issuecomment-1001',
+      '- routing evidence status: pass',
+      '- routing evidence ref: workflow-check:start:247',
+      '- finding disposition status: pass',
+      '',
+      '## Implementation Evidence',
+      '- Issue evidence: https://github.com/Erick52106/spec-injector/issues/247#issuecomment-1001',
+      `- Commit: ${headSha}`,
+      '',
+      '## Final merge gate',
+      `- latest head SHA: ${headSha}`,
+      '- ready_to_merge: yes',
+    ].join('\n'),
+    reviews: [{ author: { login: 'chatgpt-codex-connector' }, body: 'No actionable findings.', state: 'COMMENTED' }],
+    reviewThreads: [],
+    checks: [
+      { name: 'build', state: 'COMPLETED', bucket: 'pass', completedAt: '2026-05-13T19:56:36Z' },
+      { name: 'CodeRabbit', state: 'SUCCESS', bucket: 'pass', completedAt: '0001-01-01T00:00:00Z' },
+    ],
+  });
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'merge',
+    '--pr', `https://github.com/${fixture.repo}/pull/${fixture.prNumber}`,
+    '--format', 'json',
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.status, 'pass');
+  assert.equal(parsed.checks_status, 'pass');
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assert.match(ghLog, /pr checks/);
+  assert.doesNotMatch(ghLog, /conclusion/);
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec workflow-check merge closeout treats alternate queued check status as manual fallback', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-closeout-status-queued-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+  const headSha = 'ffffffffffffffffffffffffffffffffffffffff';
+  const fixture = await createEvidenceCheckFixture(t, {
+    issueNumber: 247,
+    headSha,
+    prBody: [
+      'Closes #247',
+      '',
+      '## Spec gate evidence',
+      '- spec gate status: pass',
+      '- spec evidence ref: https://github.com/Erick52106/spec-injector/issues/247#issuecomment-1001',
+      '- routing evidence status: pass',
+      '- routing evidence ref: workflow-check:start:247',
+      '- finding disposition status: pass',
+      '',
+      '## Implementation Evidence',
+      '- Issue evidence: https://github.com/Erick52106/spec-injector/issues/247#issuecomment-1001',
+      `- Commit: ${headSha}`,
+      '',
+      '## Final merge gate',
+      `- latest head SHA: ${headSha}`,
+      '- ready_to_merge: yes',
+    ].join('\n'),
+    reviews: [{ author: { login: 'chatgpt-codex-connector' }, body: 'No actionable findings.', state: 'COMMENTED' }],
+    reviewThreads: [],
+    checks: [
+      { name: 'build', status: 'queued' },
+      { name: 'CodeRabbit', state: 'SUCCESS', bucket: 'pass' },
+    ],
+  });
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'merge',
+    '--pr', `https://github.com/${fixture.repo}/pull/${fixture.prNumber}`,
+    '--format', 'json',
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.status, 'manual');
+  assert.equal(parsed.checks_status, 'manual');
+  assert.equal(parsed.ready_to_merge, 'manual');
+  assert.ok((parsed.missing_fields as string[]).includes('checks_status'));
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec workflow-check merge closeout reports manual fallback for checks missing status fields', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-closeout-checks-unknown-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+  const headSha = '1212121212121212121212121212121212121212';
+  const fixture = await createEvidenceCheckFixture(t, {
+    issueNumber: 247,
+    headSha,
+    prBody: [
+      'Closes #247',
+      '',
+      '## Spec gate evidence',
+      '- spec gate status: pass',
+      '- spec evidence ref: https://github.com/Erick52106/spec-injector/issues/247#issuecomment-1001',
+      '- routing evidence status: pass',
+      '- routing evidence ref: workflow-check:start:247',
+      '- finding disposition status: pass',
+      '',
+      '## Implementation Evidence',
+      '- Issue evidence: https://github.com/Erick52106/spec-injector/issues/247#issuecomment-1001',
+      `- Commit: ${headSha}`,
+      '',
+      '## Final merge gate',
+      `- latest head SHA: ${headSha}`,
+      '- ready_to_merge: yes',
+    ].join('\n'),
+    reviews: [{ author: { login: 'chatgpt-codex-connector' }, body: 'No actionable findings.', state: 'COMMENTED' }],
+    reviewThreads: [],
+    checks: [
+      { name: 'build' },
+      { name: 'CodeRabbit', state: 'SUCCESS', bucket: 'pass' },
+    ],
+  });
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'merge',
+    '--pr', `https://github.com/${fixture.repo}/pull/${fixture.prNumber}`,
+    '--format', 'json',
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.status, 'manual');
+  assert.equal(parsed.checks_status, 'manual');
+  assert.ok((parsed.missing_fields as string[]).includes('checks_status'));
+  assert.match((parsed.warnings as string[]).join('\n'), /manual fallback/i);
+  assert.match((parsed.warnings as string[]).join('\n'), /build/i);
+});
+
 test('spec workflow-check merge closeout omits unknown review thread counts', async (t) => {
   const repoDir = await createTempRepo(t, 'spec-injector-workflow-closeout-no-repo-');
   await writeConfig(repoDir, { version: 2, guardrails: [] });

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -50,10 +50,11 @@ type EvidenceCheckFixtureOptions = {
   headSha?: string;
   expectedPrRef?: string;
   isDraft?: boolean;
-  checks?: Array<{ name: string; state?: string; conclusion?: string; bucket?: string }>;
+  checks?: Array<{ name: string; state?: string; conclusion?: string; bucket?: string; status?: string; completedAt?: string; startedAt?: string }>;
   checksCommand?: { exitCode?: number; stdout?: string; stderr?: string };
   reviews?: Array<{ author?: { login?: string }; body?: string; state?: string; submittedAt?: string }>;
   reviewThreads?: Array<{ isResolved?: boolean; isOutdated?: boolean }>;
+  forbiddenChecksJsonFields?: string[];
 };
 
 type LabelAuditFixture = {
@@ -323,6 +324,7 @@ export async function createEvidenceCheckFixture(
     ],
     reviewThreads: options.reviewThreads ?? [],
     checksCommand: options.checksCommand,
+    forbiddenChecksJsonFields: options.forbiddenChecksJsonFields,
     expectedPrRef: options.expectedPrRef ?? String(prNumber),
   });
 
@@ -535,6 +537,7 @@ async function createFakeEvidenceGh(
     checks: Array<Record<string, unknown>>;
     reviewThreads?: Array<Record<string, unknown>>;
     checksCommand?: { exitCode?: number; stdout?: string; stderr?: string };
+    forbiddenChecksJsonFields?: string[];
     expectedPrRef: string;
   }
 ): Promise<{
@@ -592,6 +595,14 @@ if (args[0] === 'pr' && args[1] === 'checks') {
   if (args[2] !== payload.expectedPrRef) {
     console.error('Unexpected checks PR ref: ' + args[2]);
     process.exit(1);
+  }
+  const jsonFlagIndex = args.indexOf('--json');
+  const requestedFields = String(args[jsonFlagIndex + 1] ?? '').split(',').map((value) => value.trim()).filter(Boolean);
+  for (const forbiddenField of payload.forbiddenChecksJsonFields ?? []) {
+    if (requestedFields.includes(forbiddenField)) {
+      console.error('Unsupported checks json field requested: ' + forbiddenField);
+      process.exit(1);
+    }
   }
   if (payload.checksCommand) {
     if (payload.checksCommand.stdout !== undefined) {


### PR DESCRIPTION
Closes #247

## Summary

- 強化 `spec workflow-check --phase merge --pr` 的 read-only `gh pr checks` readback，避免 `gh` JSON 欄位漂移變成未處理的工具層 blocker。
- 不再向 `gh pr checks` 要求容易漂移的 `conclusion` 欄位；若舊 fixture 或既有 output 帶有 `conclusion`，仍會被分類器理解。
- Queued、缺少 status 欄位、未知 status shape，或只有 `state: COMPLETED` 但沒有 conclusive status 的 checks，會回報明確 `manual` fallback 與 warnings，不會假裝 ready，也不會直接炸掉。
- 補上 mocked `gh` regression 與 workflow docs，說明 AWP controller 遇到 manual fallback 時該做人工 readback。

## Tests / validation

- `pnpm build && node --test --test-name-pattern "merge closeout|gh schema|checks" tests/cli.integration.test.ts`
- `pnpm test`
- `pnpm build`
- `git diff --check`

## Implementation Evidence

- Source of truth: #247
- Commit: `66d2fff`
- Issue evidence comment: https://github.com/Erick52106/spec-injector/issues/247#issuecomment-4445303243
- Review finding disposition: adopted Codex P1 completed-only checks fallback; adopted CodeRabbit warning/non-mutation test nits.
- Dogfood note: `spec workflow-check --repo . --phase commit --format json` currently returns `fail` with `missing_fields=["config"]` because this repo worktree has no `.spec-injector/config.json`; this is recorded as a spec-injector repo adoption gap, not treated as passing evidence.

## Scope guard / non-goals

- No GitHub mutation behavior added to `workflow-check`.
- No review thread resolve/comment/merge behavior added.
- No target repo Scope Police parser added.
- No hosted control plane, daemon, dashboard, or auto-merge behavior added.

## Review closeout / final merge gate evidence

- Latest head: `66d2fff806d9ed01fe8173ddd25bb4cba91e63d1`
- Draft: no
- Merge state: `CLEAN`
- Checks: build pass, CodeRabbit pass
- Review threads: 1 total, 0 unresolved; Codex P1 thread resolved after adopted fix in `66d2fff`
- Ready to merge: yes, with exact-head merge guard
