### PR TITLE
docs(dogfood): add AWP outcome ledger

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -385,6 +385,7 @@ These directions should get separate issues, tests, and corresponding docs updat
 - Workflow: [docs/workflow.md](docs/workflow.md)
 - Validation matrix and quality gates: [docs/validation.md](docs/validation.md)
 - Dogfood: [docs/dogfood.md](docs/dogfood.md)
+- AWP dogfood outcome ledger: [docs/awp-dogfood-outcome-ledger.md](docs/awp-dogfood-outcome-ledger.md)
 - Install / release strategy: [docs/release.md](docs/release.md)
 - AI workflow guides: [docs/workflows/README.md](docs/workflows/README.md)
 - Issue / PR conventions: [docs/conventions.md](docs/conventions.md)

--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ Important fields:
 - Workflow: [docs/workflow.md](docs/workflow.md)
 - Validation matrix and quality gates: [docs/validation.md](docs/validation.md)
 - Dogfood: [docs/dogfood.md](docs/dogfood.md)
+- AWP dogfood outcome ledger: [docs/awp-dogfood-outcome-ledger.md](docs/awp-dogfood-outcome-ledger.md)
 - Install / release strategy: [docs/release.md](docs/release.md)
 - AI workflow guides: [docs/workflows/README.md](docs/workflows/README.md)
 - Issue / PR conventions: [docs/conventions.md](docs/conventions.md)

--- a/docs/awp-dogfood-outcome-ledger.md
+++ b/docs/awp-dogfood-outcome-ledger.md
@@ -1,0 +1,134 @@
+# AWP Dogfood Outcome Ledger
+
+本文件定義 tachigo / tachiya 等 target repo 使用 AWP + `spec-injector` workflow 後，回收 PR outcome evidence 的最小紀錄 contract。
+
+目的不是把每張 target repo PR 變成 metrics report，也不是把 dogfood ledger 當成 merge approval。它只用來累積真實 PR 樣本，讓下一輪 workflow baseline 調整有 evidence，而不是被單一 PR 的小摩擦牽著走。
+
+## When To Record
+
+只在同時滿足以下條件時記錄：
+
+- PR 是 AWP / autonomous-worker-profile 流程，或明確使用 `spec workflow-check` 作為 start / commit / merge evidence。
+- PR 已完成一輪 review closeout，或因 workflow blocker 停在可描述的狀態。
+- 紀錄位置在 `spec-injector` 端或 target repo 已核可的 ledger / issue comment；不要把完整 metrics 塞進每張 target repo PR body。
+
+非 AWP PR 不需要填這份 ledger。普通 manual PR 可以只保留原 repo 的 PR evidence。
+
+## Sample Threshold
+
+在調整核心 AWP baseline 前，應先累積至少 3-5 張 target repo PR outcome sample。
+
+未達樣本門檻前：
+
+- P0 blocker 可以立刻修。
+- P1 / P2 workflow friction 應先進 follow-up ledger 或 bounded issue。
+- 單一 PR 的 nitpick、局部 CI noise、或 reviewer preference 不應直接改核心 baseline。
+- 如果樣本都來自同一 repo、同一 issue type、或同一人為操作模式，應標記 sample bias，不要當成跨 repo 結論。
+
+## Minimal Fields
+
+每筆 outcome sample 應保留下列欄位：
+
+```markdown
+## AWP dogfood outcome sample
+
+- Target repo:
+- Target issue:
+- Target PR:
+- PR head SHA:
+- Workflow date:
+- Workflow mode: hybrid_awp / strict_awp / controller_fallback / manual
+- `spec-injector` version or commit:
+- `spec workflow-check` evidence refs:
+  - start:
+  - commit:
+  - merge:
+- Worker routing:
+  - expected worker split:
+  - actual worker split:
+  - missed worker: yes / no / unclear
+  - over-delegated worker: yes / no / unclear
+  - explicit fallback used: yes / no
+- Gate outcomes:
+  - workflow-check caught real issue: yes / no / unclear
+  - workflow-check false positive: yes / no / unclear
+  - workflow-check false negative: yes / no / unclear
+  - CI false positive / false negative:
+  - Scope Police false positive / false negative:
+- Review loop:
+  - review rounds:
+  - actionable findings count:
+  - adopted findings:
+  - not-adopted findings with rationale:
+  - main rework reason:
+- Friction classification:
+  - infra complexity:
+  - workflow-created friction:
+  - model/tool limitation:
+  - human policy ambiguity:
+- Severity:
+  - P0 must-fix:
+  - follow-up ledger only:
+- Final outcome:
+  - merged / closed / blocked / superseded:
+  - merge commit or blocker ref:
+```
+
+`status/ref` evidence is enough. Downstream Scope Police should not parse full `spec plan` output, task packages, or private AWP ledgers.
+
+## Friction Classification
+
+Outcome analysis must separate the source of friction:
+
+| Classification | Meaning | Example |
+| --- | --- | --- |
+| Infra complexity | Target repo or CI is inherently complex. | flaky external service, monorepo package boundary, required generated file mismatch |
+| Workflow-created friction | AWP / `spec-injector` policy caused extra work. | worker split required when direct controller fix was enough |
+| Model/tool limitation | Agent, `gh`, or local tool output was incomplete or unstable. | `gh pr checks` schema drift causing manual fallback |
+| Human policy ambiguity | Repo rule or review expectation was not precise enough. | unclear whether Scope Police should accept manual fallback wording |
+
+不要把所有問題都歸咎於模型，也不要把 target repo 本身的複雜度誤算成 workflow baseline failure。
+
+## P0 Must-Fix Signals
+
+下列情況可以在未達 3-5 sample threshold 前建立或處理 P0/P1 fix issue：
+
+- `spec workflow-check` 產生 false pass，導致 unsafe merge gate evidence。
+- 工具嘗試 GitHub mutation、target repo mutation、auto-merge、auto-comment、或寫入 private/generated output。
+- Evidence freshness 無法判斷，且 checker 仍回報 pass。
+- Downstream repo 被要求解析 full task package / private context 才能通過 Scope Police。
+- AWP routing 明顯漏派必要 worker，且造成 production-facing 或 merge-gate blocker。
+
+這些是 safety / correctness 問題，不需要等樣本數夠才修。
+
+## Follow-Up Ledger Signals
+
+下列情況通常先進 follow-up ledger，不直接改核心 baseline：
+
+- 單一 reviewer preference 或 wording nit。
+- 某 repo 的 CI / Scope Police local convention 尚未穩定。
+- Worker routing 有輕微 over-delegation，但沒有造成錯誤或重大延遲。
+- Manual fallback wording 可以更清楚，但沒有 false pass。
+- AWP ledgers 太長、太短、或欄位命名不順，但 downstream 仍能完成 closeout。
+
+這些可以累積 3-5 sample 後一起校準。
+
+## Baseline Change Gate
+
+提出 AWP baseline 變更前，應在 issue 或 PR body 中回答：
+
+- 已累積幾張 PR outcome sample？
+- 樣本分布在哪些 repo / issue type？
+- 觀測到的是 P0 safety issue，還是可累積的 workflow friction？
+- 變更是否會讓 downstream repo Scope Police 需要解析更多 evidence？
+- 是否能用 docs / template / checker warning 解決，而不用改 CLI behavior？
+
+若答案不足，先保留為 follow-up ledger，不修改核心 AWP baseline。
+
+## Non-Goals
+
+- 不要求每張 target repo PR body 填完整 metrics。
+- 不要求非 AWP PR 填 ledger。
+- 不把 ledger 當 merge approval。
+- 不在 target repo commit `.spec-injector/`、generated output、private context 或 local dogfood notes。
+- 不新增 hosted control plane、daemon、dashboard、auto-merge 或 auto-comment。

--- a/docs/dogfood.md
+++ b/docs/dogfood.md
@@ -6,6 +6,8 @@ Dogfood 是用 `spec-injector` 處理真實 target repo issue，以驗證 contex
 
 Dogfood 不等於直接實作 target repo issue。它是一種觀察與校準流程。
 
+AWP / `spec workflow-check` target PR outcome 的跨 repo 回收欄位，請見 [AWP Dogfood Outcome Ledger](awp-dogfood-outcome-ledger.md)。該 ledger 用於累積 3-5 張真實 PR outcome 後再調整核心 AWP baseline；它不是 merge approval，也不要求 target repo PR body 塞完整 metrics。
+
 ## What Dogfood Checks
 
 Dogfood report 應觀察：

--- a/tests/hybrid-awp-routing-policy.test.ts
+++ b/tests/hybrid-awp-routing-policy.test.ts
@@ -101,3 +101,34 @@ test('AI bootstrap install contract remains linked from workflow docs and README
   assert.match(readme, /\[AI bootstrap install contract\]\(docs\/ai-bootstrap-install-contract\.md\)/);
   assert.match(englishReadme, /\[AI bootstrap install contract\]\(docs\/ai-bootstrap-install-contract\.md\)/);
 });
+
+test('AWP dogfood outcome ledger remains linked from dogfood docs and README', async () => {
+  const ledgerPath = path.join(repoRoot, 'docs', 'awp-dogfood-outcome-ledger.md');
+  const dogfoodPath = path.join(repoRoot, 'docs', 'dogfood.md');
+  const readmePath = path.join(repoRoot, 'README.md');
+  const englishReadmePath = path.join(repoRoot, 'README.en.md');
+
+  const [ledger, dogfood, readme, englishReadme] = await Promise.all([
+    fs.readFile(ledgerPath, 'utf8'),
+    fs.readFile(dogfoodPath, 'utf8'),
+    fs.readFile(readmePath, 'utf8'),
+    fs.readFile(englishReadmePath, 'utf8'),
+  ]);
+
+  assert.match(ledger, /AWP Dogfood Outcome Ledger/);
+  assert.match(ledger, /至少 3-5/);
+  assert.match(ledger, /missed worker/i);
+  assert.match(ledger, /over-delegated worker/i);
+  assert.match(ledger, /workflow-check caught real issue/i);
+  assert.match(ledger, /Scope Police false positive/i);
+  assert.match(ledger, /review rounds/i);
+  assert.match(ledger, /main rework reason/i);
+  assert.match(ledger, /Workflow-created friction/);
+  assert.match(ledger, /P0 must-fix/i);
+  assert.match(ledger, /follow-up ledger/i);
+  assert.match(ledger, /Downstream Scope Police should not parse full `spec plan` output/);
+
+  assert.match(dogfood, /\[AWP Dogfood Outcome Ledger\]\(awp-dogfood-outcome-ledger\.md\)/);
+  assert.match(readme, /\[docs\/awp-dogfood-outcome-ledger\.md\]\(docs\/awp-dogfood-outcome-ledger\.md\)/);
+  assert.match(englishReadme, /\[docs\/awp-dogfood-outcome-ledger\.md\]\(docs\/awp-dogfood-outcome-ledger\.md\)/);
+});


### PR DESCRIPTION
Closes #249

## Summary

- 新增 `docs/awp-dogfood-outcome-ledger.md`，定義 AWP + `spec-injector` target PR outcome 的最小紀錄 contract。
- 明確要求核心 AWP baseline 調整前先累積 3-5 張 PR outcome sample；未達門檻時，除 P0 safety/correctness blocker 外只進 follow-up ledger。
- 覆蓋 #249 指定欄位：漏派/過度派 worker、`workflow-check` 是否擋到真問題、CI / Scope Police 誤判、review loop 次數、主要 rework reason、infra complexity vs workflow-created friction、P0 vs follow-up。
- 從 `docs/dogfood.md`、`README.md`、`README.en.md` 連到 ledger，避免把完整 metrics 塞進每張 target repo PR body。

## Tests / validation

- `pnpm build && node --test tests/hybrid-awp-routing-policy.test.ts`
- `pnpm test`
- `pnpm build`
- `git diff --check`

## Implementation Evidence

- Source of truth: #249
- Commit: `637c81e`
- Issue evidence comment: https://github.com/Erick52106/spec-injector/issues/249#issuecomment-4445391122

## Scope guard / non-goals

- No CLI/runtime behavior change.
- No target repo PR template / Scope Police change.
- No requirement for non-AWP PRs to fill this ledger.
- No hosted control plane, daemon, dashboard, auto-merge, or auto-comment.
- No target repo `.spec-injector/`, generated output, private context, or local ledger committed.

## Review closeout / final merge gate evidence

- Latest head: `637c81ed6dd9b209504cc6267a33b0343b575651`
- Draft: no
- Merge state: `CLEAN`
- Checks: build pass, CodeRabbit pass
- CodeRabbit: no actionable comments generated
- Review threads: 0 total, 0 unresolved
- Ready to merge: yes, with exact-head merge guard
