### PR TITLE
docs(workflow): design optional AWP delegation manifest

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -386,6 +386,7 @@ These directions should get separate issues, tests, and corresponding docs updat
 - Validation matrix and quality gates: [docs/validation.md](docs/validation.md)
 - Dogfood: [docs/dogfood.md](docs/dogfood.md)
 - AWP dogfood outcome ledger: [docs/awp-dogfood-outcome-ledger.md](docs/awp-dogfood-outcome-ledger.md)
+- Optional AWP delegation evidence manifest: [docs/awp-delegation-evidence-manifest.md](docs/awp-delegation-evidence-manifest.md)
 - Install / release strategy: [docs/release.md](docs/release.md)
 - AI workflow guides: [docs/workflows/README.md](docs/workflows/README.md)
 - Issue / PR conventions: [docs/conventions.md](docs/conventions.md)

--- a/README.md
+++ b/README.md
@@ -384,6 +384,7 @@ Important fields:
 - Validation matrix and quality gates: [docs/validation.md](docs/validation.md)
 - Dogfood: [docs/dogfood.md](docs/dogfood.md)
 - AWP dogfood outcome ledger: [docs/awp-dogfood-outcome-ledger.md](docs/awp-dogfood-outcome-ledger.md)
+- Optional AWP delegation evidence manifest: [docs/awp-delegation-evidence-manifest.md](docs/awp-delegation-evidence-manifest.md)
 - Install / release strategy: [docs/release.md](docs/release.md)
 - AI workflow guides: [docs/workflows/README.md](docs/workflows/README.md)
 - Issue / PR conventions: [docs/conventions.md](docs/conventions.md)

--- a/docs/awp-delegation-evidence-manifest.md
+++ b/docs/awp-delegation-evidence-manifest.md
@@ -1,0 +1,167 @@
+# Optional AWP Delegation Evidence Manifest
+
+This document defines a design-only, optional manifest for recording delegation evidence in Autonomous Worker Profiles (AWP) workflows.
+
+The manifest can help a controller audit whether a worker profile was assigned, what scope it owned, what it returned, and why controller fallback was used. It is not a worker runtime, not a hosted control plane, and not proof that a subagent truly executed. It is local evidence shape that `spec workflow-check` may read in a future implementation issue.
+
+## Applicability
+
+The manifest applies only when a workflow has an explicit AWP / Hybrid AWP / autonomous PR signal.
+
+Non-AWP users and ordinary human PRs must not be required to provide this manifest. If no autonomous signal is present, future checker behavior should report `skipped`, `manual`, or `n/a` for delegation-manifest checks rather than failing a normal PR.
+
+## Minimal Schema
+
+The first schema should be small enough for a controller, wrapper, or target repo script to produce without storing private transcripts.
+
+```json
+{
+  "schema_version": 1,
+  "manifest_id": "awp-delegation:<stable-id>",
+  "repo": "owner/name or local repo path",
+  "issue_ref": "https://github.com/owner/repo/issues/123",
+  "pr_ref": "https://github.com/owner/repo/pull/456",
+  "head_sha": "40-character-sha",
+  "created_at": "2026-05-13T00:00:00Z",
+  "autonomous_signal": "present",
+  "routing_evidence_ref": "workflow-check:start:<id>",
+  "controller": {
+    "role": "scope|architecture|review|merge_gate|fallback_executor",
+    "fallback_used": false,
+    "fallback_reason": "n/a"
+  },
+  "workers": [
+    {
+      "worker_id": "worker-1",
+      "profile": "spark|ops_readback|implementation_5_4|review_5_5|custom",
+      "model": "gpt-5.4",
+      "reasoning": "low|medium|high|xhigh|unknown",
+      "assigned_scope": [
+        "docs/foo.md",
+        "tests/foo.test.ts"
+      ],
+      "forbidden_scope": [
+        "src/runtime/**"
+      ],
+      "task_summary": "short bounded assignment",
+      "result_summary": "short result or blocker summary",
+      "evidence_ref": "PR comment, local path, or issue comment URL",
+      "closeout_status": "completed|blocked|superseded|not_started",
+      "blocker_reason": "n/a"
+    }
+  ]
+}
+```
+
+Required top-level fields:
+
+- `schema_version`
+- `manifest_id`
+- `repo`
+- `head_sha`
+- `created_at`
+- `autonomous_signal`
+- `routing_evidence_ref`
+- `controller.role`
+- `controller.fallback_used`
+- `controller.fallback_reason`
+- `workers`
+
+Each worker entry should include:
+
+- `worker_id`
+- `profile`
+- `model`
+- `reasoning`
+- `assigned_scope`
+- `result_summary`
+- `evidence_ref`
+- `closeout_status`
+
+`assigned_scope` should be paths, modules, or bounded responsibilities. It should not contain private transcript text or full model logs.
+
+## Producer Options
+
+The manifest may be produced by one of three actors:
+
+| Producer | Good fit | Risk |
+| --- | --- | --- |
+| AI controller manual entry | Works in any local environment and preserves human-readable judgment. | Self-reported; easy to forget fields or overstate delegation. |
+| Agent wrapper / local runner | Can record worker profile, model, reasoning, and closeout consistently. | Wrapper-specific; must not become a required runtime or hidden control plane. |
+| Target repo local script | Can normalize repo-specific worker evidence into a stable JSON shape. | Target repo maintenance burden; must not force Scope Police to parse full private evidence. |
+
+All producer modes are optional. The target repo may keep only a `status/ref` in the PR body and store richer evidence in an approved local or issue-comment location.
+
+## Future `workflow-check` Boundary
+
+A future `spec workflow-check` implementation may read this manifest as an explicit local input, for example:
+
+```bash
+spec workflow-check --repo . --phase commit --delegation-manifest /tmp/awp-delegation.json
+spec workflow-check --repo . --phase merge --delegation-manifest /tmp/awp-delegation.json --head-sha <sha>
+```
+
+If implemented, the checker should only validate shape and readback consistency:
+
+- valid JSON
+- supported `schema_version`
+- required fields present
+- `autonomous_signal=present` only affects autonomous workflows
+- `head_sha` matches current or provided head SHA
+- worker `closeout_status` is not `not_started` for required workers
+- controller fallback has an explicit reason when `fallback_used=true`
+- assigned scope is bounded and does not claim forbidden/private paths
+
+The checker must not:
+
+- spawn, close, or manage subagents
+- call model providers
+- read private session transcripts
+- mutate GitHub issues, PRs, labels, comments, reviews, or threads
+- write task packages, manifests, or output files by default
+- require downstream Scope Police to parse the full manifest
+- treat manifest pass as human merge approval
+
+## Trust Boundary
+
+The manifest improves auditability but cannot prove all runtime facts.
+
+It can improve confidence that:
+
+- routing evidence has a concrete worker assignment record
+- controller fallback was explicit
+- assigned scope and closeout status are reviewable
+- worker evidence can be compared with PR body `status/ref` fields
+- missing or stale worker evidence can produce `manual` or `fail` instead of silent pass
+
+It still cannot prove:
+
+- a model actually executed the work
+- the worker used the claimed model or reasoning effort
+- private context was not seen by another process
+- the result summary is semantically correct
+- the controller did not rewrite worker output
+- the PR is safe to merge without human review
+
+For this reason, the manifest should be evidence for review, not an authority layer.
+
+## Implementation Decision
+
+This issue defines the design and trust boundary only. It should not add runtime schema validation, new CLI flags, config schema changes, or target repo enforcement.
+
+If the team wants runtime support, open a separate implementation issue for:
+
+- CLI flag design
+- JSON validation behavior
+- fixture coverage
+- interaction with `--routing-evidence`, `--finding-disposition`, and `--threshold-evidence`
+- target repo compatibility expectations for tachigo / tachiya
+
+## Non-Goals
+
+- Do not turn `spec-injector` into a subagent runtime or orchestration platform.
+- Do not require `spec-injector` to spawn, monitor, or close subagents.
+- Do not commit private session transcripts into target repos.
+- Do not require target repos to commit `.spec-injector/` output.
+- Do not require non-AWP users to adopt this manifest.
+- Do not make this manifest a merge approval gate by itself.

--- a/docs/hybrid-awp-routing-policy.md
+++ b/docs/hybrid-awp-routing-policy.md
@@ -87,6 +87,8 @@ spec workflow-check --repo . --phase merge --pr-body /tmp/pr.md --routing-eviden
 
 The routing evidence file is local input only. The CLI does not fetch or mutate GitHub to resolve routing evidence refs.
 
+If a workflow needs stronger auditability for whether delegation actually occurred, use the design-only [optional AWP delegation evidence manifest](awp-delegation-evidence-manifest.md). That manifest records worker profile, model, reasoning, assigned scope, result summary, closeout status, and controller fallback reason as local evidence shape. It remains optional, does not apply to non-AWP PRs, and does not make `spec-injector` spawn or orchestrate workers.
+
 ## Non-goals
 
 This policy does not:

--- a/tests/hybrid-awp-routing-policy.test.ts
+++ b/tests/hybrid-awp-routing-policy.test.ts
@@ -132,3 +132,38 @@ test('AWP dogfood outcome ledger remains linked from dogfood docs and README', a
   assert.match(readme, /\[docs\/awp-dogfood-outcome-ledger\.md\]\(docs\/awp-dogfood-outcome-ledger\.md\)/);
   assert.match(englishReadme, /\[docs\/awp-dogfood-outcome-ledger\.md\]\(docs\/awp-dogfood-outcome-ledger\.md\)/);
 });
+
+test('optional AWP delegation evidence manifest remains linked from policy docs and README', async () => {
+  const manifestPath = path.join(repoRoot, 'docs', 'awp-delegation-evidence-manifest.md');
+  const policyPath = path.join(repoRoot, 'docs', 'hybrid-awp-routing-policy.md');
+  const readmePath = path.join(repoRoot, 'README.md');
+  const englishReadmePath = path.join(repoRoot, 'README.en.md');
+
+  const [manifest, policy, readme, englishReadme] = await Promise.all([
+    fs.readFile(manifestPath, 'utf8'),
+    fs.readFile(policyPath, 'utf8'),
+    fs.readFile(readmePath, 'utf8'),
+    fs.readFile(englishReadmePath, 'utf8'),
+  ]);
+
+  assert.match(manifest, /Optional AWP Delegation Evidence Manifest/);
+  assert.match(manifest, /worker profile/i);
+  assert.match(manifest, /model/i);
+  assert.match(manifest, /reasoning/i);
+  assert.match(manifest, /assigned_scope/);
+  assert.match(manifest, /result_summary/);
+  assert.match(manifest, /closeout_status/);
+  assert.match(manifest, /fallback_reason/);
+  assert.match(manifest, /AI controller manual entry/);
+  assert.match(manifest, /Agent wrapper \/ local runner/);
+  assert.match(manifest, /Target repo local script/);
+  assert.match(manifest, /only validate shape and readback consistency/i);
+  assert.match(manifest, /must not:\n\n- spawn, close, or manage subagents/);
+  assert.match(manifest, /cannot prove/);
+  assert.match(manifest, /separate implementation issue/);
+  assert.match(manifest, /Do not require non-AWP users to adopt this manifest/);
+
+  assert.match(policy, /\[optional AWP delegation evidence manifest\]\(awp-delegation-evidence-manifest\.md\)/);
+  assert.match(readme, /\[docs\/awp-delegation-evidence-manifest\.md\]\(docs\/awp-delegation-evidence-manifest\.md\)/);
+  assert.match(englishReadme, /\[docs\/awp-delegation-evidence-manifest\.md\]\(docs\/awp-delegation-evidence-manifest\.md\)/);
+});

--- a/tests/hybrid-awp-routing-policy.test.ts
+++ b/tests/hybrid-awp-routing-policy.test.ts
@@ -158,7 +158,7 @@ test('optional AWP delegation evidence manifest remains linked from policy docs 
   assert.match(manifest, /Agent wrapper \/ local runner/);
   assert.match(manifest, /Target repo local script/);
   assert.match(manifest, /only validate shape and readback consistency/i);
-  assert.match(manifest, /must not:\n\n- spawn, close, or manage subagents/);
+  assert.match(manifest, /must not:\s*\n\s*-\s*spawn, close, or manage subagents/i);
   assert.match(manifest, /cannot prove/);
   assert.match(manifest, /separate implementation issue/);
   assert.match(manifest, /Do not require non-AWP users to adopt this manifest/);


### PR DESCRIPTION
Closes #248

## Summary

- 新增 `docs/awp-delegation-evidence-manifest.md`，定義 optional delegation evidence manifest 的最小 schema 與 trust boundary。
- Schema 覆蓋 worker profile、model、reasoning、assigned scope、result summary、closeout status、controller fallback reason。
- 評估三種 producer：AI controller manual entry、agent wrapper / local runner、target repo local script。
- 明確規定未來 `workflow-check` 若實作也只做 local schema/readback consistency，不做 subagent orchestration。
- 明確說明 non-AWP / ordinary human PR 不受此 manifest gate 影響。

## Tests / validation

- `pnpm install --frozen-lockfile`
- `pnpm build && node --test tests/hybrid-awp-routing-policy.test.ts`
- `pnpm test`
- `pnpm build`
- `git diff --check`

## Implementation Evidence

- Source of truth: #248
- Commit: `a7287ec`
- Issue evidence comment: https://github.com/Erick52106/spec-injector/issues/248#issuecomment-4445426312
- Review finding disposition: adopted CodeRabbit whitespace-tolerant assertion nit.

## Scope guard / non-goals

- Design-only docs and link regression.
- No CLI flag or runtime schema validation added.
- No config schema change.
- No subagent spawn / close / orchestration behavior.
- No private transcript or `.spec-injector/` output committed to target repos.
- No downstream Scope Police parser requirement.

## Review closeout / final merge gate evidence

- Latest head: `a7287ecad6352bd9df38912803808d241c444c8d`
- Draft: no
- Merge state: `CLEAN`
- Checks: build pass, CodeRabbit pass
- Review finding disposition: CodeRabbit nit adopted in `a7287ec`
- Review threads: 0 total, 0 unresolved
- Ready to merge: yes, with exact-head merge guard
