### PR TITLE
docs(dogfood): add third brownfield evidence gate

### DIFF
--- a/docs/dogfood.md
+++ b/docs/dogfood.md
@@ -8,6 +8,11 @@ Dogfood 不等於直接實作 target repo issue。它是一種觀察與校準流
 
 AWP / `spec workflow-check` target PR outcome 的跨 repo 回收欄位，請見 [AWP Dogfood Outcome Ledger](awp-dogfood-outcome-ledger.md)。該 ledger 用於累積 3-5 張真實 PR outcome 後再調整核心 AWP baseline；它不是 merge approval，也不要求 target repo PR body 塞完整 metrics。
 
+## Reports
+
+- [Hono 2026-05-14 third brownfield dogfood](dogfood/hono-2026-05-14.md): read-only WARN evidence for `honojs/hono#4916`, with strong issue-mentioned source capture but caveated auto-discovery / classifier precision.
+- [Vitest 2026-05-09 second brownfield dogfood](dogfood/vitest-2026-05-09.md): read-only WARN evidence for `vitest-dev/vitest#10280`, with monorepo/path-shape caveats.
+
 ## What Dogfood Checks
 
 Dogfood report 應觀察：

--- a/docs/dogfood/hono-2026-05-14.md
+++ b/docs/dogfood/hono-2026-05-14.md
@@ -6,7 +6,7 @@
 
 - 以陌生的 non-`tachigo` / non-`tachiya` / non-`storefront` / non-`spec-injector` 公開 repo 驗證 `spec plan` 在一般 TypeScript framework repo 的 deterministic issue-to-context usefulness。
 - 記錄 source precision、diagnostics quality、classifier behavior、path friction、README claim impact 與 Layer 3 / Layer 4 relation。
-- 補齊 #222 要求的第三個 read-only brownfield evidence gate；這不是 runtime implementation issue，也不代表 4.7 全部 gate 已完成。
+- 補齊 #223 定義、#222 要求的第三個 read-only brownfield evidence gate；這不是 runtime implementation issue，也不代表 4.7 全部 gate 已完成。
 
 ## Target
 

--- a/docs/dogfood/hono-2026-05-14.md
+++ b/docs/dogfood/hono-2026-05-14.md
@@ -6,7 +6,7 @@
 
 - 以陌生的 non-`tachigo` / non-`tachiya` / non-`storefront` / non-`spec-injector` 公開 repo 驗證 `spec plan` 在一般 TypeScript framework repo 的 deterministic issue-to-context usefulness。
 - 記錄 source precision、diagnostics quality、classifier behavior、path friction、README claim impact 與 Layer 3 / Layer 4 relation。
-- 補齊 #223 定義、#222 要求的第三個 read-only brownfield evidence gate；這不是 runtime implementation issue，也不代表 4.7 全部 gate 已完成。
+- 補齊 #223 定義的第三個 read-only brownfield evidence gate；這不是 runtime implementation issue，也不代表 4.7 全部 gate 已完成。
 
 ## Target
 

--- a/docs/dogfood/hono-2026-05-14.md
+++ b/docs/dogfood/hono-2026-05-14.md
@@ -1,0 +1,241 @@
+# Hono Brownfield Dogfood Report (Read-Only)
+
+> 第三個 brownfield dogfood。僅執行 read-only `spec plan` 驗證，不修改 target repo、不建立 `.spec-injector/`、不做 target repo implementation。
+
+## Goal
+
+- 以陌生的 non-`tachigo` / non-`tachiya` / non-`storefront` / non-`spec-injector` 公開 repo 驗證 `spec plan` 在一般 TypeScript framework repo 的 deterministic issue-to-context usefulness。
+- 記錄 source precision、diagnostics quality、classifier behavior、path friction、README claim impact 與 Layer 3 / Layer 4 relation。
+- 補齊 #222 要求的第三個 read-only brownfield evidence gate；這不是 runtime implementation issue，也不代表 4.7 全部 gate 已完成。
+
+## Target
+
+- Name: `honojs/hono`
+- URL: https://github.com/honojs/hono
+- Branch / ref tested: `main`
+- Commit / HEAD under test: `16c4e3885f51376cb6cbddc80eeae0202cd86234`
+- Target issue / request source: https://github.com/honojs/hono/issues/4916
+- Target repo status before run: clean
+- Target repo status after run: clean
+- Reproducibility note: this report is tied to the pinned target commit above, not a floating `main` reference.
+
+## Target Selection Rationale
+
+- Public OSS repo with no private or sensitive source requirement.
+- Not `spec-injector`, `tachigo`, `tachiya`, or `storefront`.
+- Different from the prior Vitest monorepo dogfood: Hono is a TypeScript web framework repo with a compact source tree and a cookie helper bug, not a package-export/workspace issue.
+- The target issue contains explicit source references, giving a useful precision/recall check:
+  - `src/utils/cookie.ts`
+  - `src/helper/cookie/index.ts`
+- The issue is implementation-shaped but can be evaluated read-only; no target repo branch, commit, PR, or test execution is required.
+
+## Safety Checklist
+
+- [x] Target repo remains read-only.
+- [x] Did not run `spec init` in target repo.
+- [x] Did not create `.spec-injector/` in target repo.
+- [x] Did not create a target repo branch.
+- [x] Did not create a target repo commit.
+- [x] Did not create a target repo PR.
+- [x] Did not modify target repo files.
+- [x] Did not run target repo cleanup / reset / stash / clean.
+- [x] Used an external config path outside the target repo.
+- [x] Captured command, exit code, stdout/stderr summary, and diagnostics.
+- [x] Report avoids long source excerpts and only records safe file references / summaries.
+
+## Commands Run
+
+### Target repo preflight
+
+- `git clone --depth 1 https://github.com/honojs/hono /tmp/spec-injector-dogfood-hono-20260513`
+- `git -C /tmp/spec-injector-dogfood-hono-20260513 rev-parse HEAD`
+  - output: `16c4e3885f51376cb6cbddc80eeae0202cd86234`
+- `git -C /tmp/spec-injector-dogfood-hono-20260513 status --short --branch`
+  - output: `## main...origin/main`
+- `test ! -e /tmp/spec-injector-dogfood-hono-20260513/.spec-injector`
+
+### External config
+
+- External config path: `/tmp/spec-hono-targeted-20260514.json`
+- Config strategy:
+  - temporary external v2 config snapshot
+  - derived from safe read-only inspection of Hono root files and source layout
+  - kept outside target repo
+  - no config copied into target repo
+- Config SHA-256: `366062cb15212f99c3fa136217ba1159d8eca58c8b6b8b2cdf9dcef942793505`
+
+### Dogfood run
+
+```bash
+node bin/spec.js plan https://github.com/honojs/hono/issues/4916 \
+  --repo /tmp/spec-injector-dogfood-hono-20260513 \
+  --config /tmp/spec-hono-targeted-20260514.json \
+  --dry-run \
+  --format prompt \
+  --verbose \
+  > /tmp/spec-hono-plan-20260514.stdout \
+  2> /tmp/spec-hono-plan-20260514.stderr
+```
+
+- cwd: `spec-injector` worktree for #223
+- exit code: `0`
+- stdout lines: `89`
+- stderr lines: `0`
+- stdout SHA-256: `669d178a0382c99814eac4dd2310ddae0678ad802fa422094a0648ff47b2290a`
+- stderr SHA-256: `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
+
+### Target repo readback
+
+- `git -C /tmp/spec-injector-dogfood-hono-20260513 status --short --branch`
+  - output: `## main...origin/main`
+- `test ! -e /tmp/spec-injector-dogfood-hono-20260513/.spec-injector`
+  - result: passed
+
+## Environment / Tool Versions
+
+- Node: `v24.15.0`
+- pnpm: `10.33.0`
+- OS / shell: macOS / `zsh`
+- Runtime env vars: none added for dogfood
+
+## Input Summary
+
+- Issue: `honojs/hono#4916`
+- Title: `bug: getCookie(c, name) and getCookie(c)[name] return different values for duplicate cookie names`
+- Issue language: English
+- Runtime mentioned by issue: Bun
+- Request summary:
+  - Duplicate cookie names such as `Cookie: a=first; a=last` produce inconsistent results.
+  - `getCookie(c)[a]` returns the last value.
+  - `getCookie(c, 'a')` returns the first value.
+  - The issue points at `parse(cookie, name?)` in `src/utils/cookie.ts` and the public helper paths in `src/helper/cookie/index.ts`.
+- Selected docs / source strategy:
+  - always-read: `README.md`, `docs/CONTRIBUTING.md`
+  - rule doc: `docs/MIGRATION.md`
+  - source root: `src`
+  - source cap: 10 files
+
+## Output Summary
+
+- `spec plan` fetched the issue successfully.
+- Detected domains: `api`, `frontend`, `database`.
+- Matched guardrail: `read-only-dogfood`.
+- Relevant file references included both issue-mentioned source files:
+  - `src/utils/cookie.ts`
+  - `src/helper/cookie/index.ts`
+- Auto-discovered one directly useful test file:
+  - `src/helper/cookie/index.test.ts`
+- Auto-discovered several weaker source candidates, such as request/middleware/DOM-related files.
+- Missing files: none.
+- Read-failed diagnostics: none.
+- Truncation metadata was visible on auto-discovered source snippets.
+
+## Source Reference Precision
+
+- True positives:
+  - The two issue-mentioned source files were correctly captured as issue-mentioned references.
+  - `src/helper/cookie/index.test.ts` was auto-discovered and is plausibly useful for implementation planning.
+- False positives:
+  - `src/request.ts`, cache/static/language/method-override middleware, route helper, `src/hono-base.ts`, and DOM JSX tests are weakly related to the cookie duplicate-name behavior.
+  - `docs/CODE_OF_CONDUCT.md` was discovered because the issue text contains common terms, but it does not help the implementation plan.
+- False negatives:
+  - `src/utils/cookie.test.ts` was not surfaced even though it is a strong validation candidate for `parse(cookie, name?)`.
+  - The output did not explicitly rank why `src/helper/cookie/index.test.ts` appeared but `src/utils/cookie.test.ts` did not.
+- Precision / recall summary:
+  - Issue-mentioned reference precision is strong.
+  - Auto-discovery recall for tests is partial.
+  - Source ranking still overweights generic HTTP/request/DOM/index tokens in framework repos.
+
+## Diagnostics Quality
+
+- Good:
+  - No missing or read-failed files were silently hidden.
+  - Source truncation metadata was explicit.
+  - The output preserved the read-only guardrail in the prompt.
+- Caveats:
+  - No diagnostic explains why `src/utils/cookie.test.ts` was omitted.
+  - The source ranking explanation is still implicit; a downstream AI can see selected files, but not the score reasons.
+  - Since no read failure occurred, this run does not add new evidence about unreadable path handling.
+
+## Classifier Assessment
+
+- True positive:
+  - `api` is appropriate because the issue includes request/response and HTTP cookie behavior.
+- False positives / weak signals:
+  - `frontend` came from generic words such as `form` and DOM-side comparison text; this is not a frontend implementation issue.
+  - `database` came from `index`, which is only part of file names / object indexing and not a database concern.
+- False negatives:
+  - There is no cookie/http-helper specific domain, so the classifier cannot express this more precise target.
+- #206 relation:
+  - This target is English and does not provide Traditional Chinese classifier evidence.
+  - It does not unblock #206.
+
+## Monorepo / Path-Shape Friction
+
+- Hono is not a heavy workspace-style monorepo in the same way as the Vitest dogfood target, so path-shape friction was lower.
+- The explicit issue paths resolved cleanly relative to repo root.
+- The main friction is ranking within a broad `src` tree, not package-root aliasing or directory input ambiguity.
+- This supports keeping monorepo/path warnings as caveated README language rather than claiming a complete resolver.
+
+## README Claim Impact
+
+- Supported:
+  - `spec plan --dry-run --format prompt --verbose` can produce useful bounded planning context for a real brownfield repo without writing output files.
+  - External config snapshot dogfood remains practical and safe.
+  - Issue-mentioned source refs are valuable and can be captured deterministically.
+- Caveated:
+  - Auto-discovery is not high-precision enough to claim production-ready source ranking for every brownfield repo.
+  - Classifier output remains helpful but can be noisy on generic web-framework terms.
+  - Dogfood evidence remains WARN / caveated, not unconditional PASS.
+- Not supported:
+  - No claim that `spec-injector` can autonomously fix target repos.
+  - No claim that Layer 3 / Layer 4 runtime exists.
+  - No claim that #206 has shipped or is justified by this run.
+
+## Layer 3 Relation
+
+- This run supports Layer 3 protocol vocabulary around:
+  - `dogfood-report`
+  - `external-config-snapshot`
+  - `issue-mentioned-source`
+  - `auto-discovered-source`
+  - `classifier-noise`
+  - `target-repo-safety-readback`
+- It does not justify implementing a protocol runtime by itself.
+- It suggests future catalog fields should separate issue-mentioned refs from auto-discovered refs and capture test-file recall separately.
+
+## Layer 4 Relation
+
+- This run provides visual/status-friendly evidence categories, such as read-only safety, output usefulness, classifier caveat, and target repo mutation readback.
+- It does not justify companion/status runtime, daemon behavior, dashboard, or autonomous remediation.
+- If Layer 4 later presents dogfood status, it should show WARN / caveated evidence, not a green all-clear.
+
+## Verdict
+
+- Verdict: `WARN`
+- Rationale:
+  - The run was safe, read-only, reproducible, and useful.
+  - Explicit source refs were captured correctly.
+  - Auto-discovery found one useful test file but missed another important test file and included several weakly related source files.
+  - Classifier output included meaningful `api` signal plus noisy `frontend` / `database` signals.
+- 4.7 readiness impact:
+  - Raises confidence that the current read-only dogfood workflow is safe and useful across another public target.
+  - Preserves the caveat that 4.7 still needs written decisions for #206, Layer 3, Layer 4, and README/visual overclaim gates.
+  - Does not lower confidence, but also does not convert dogfood evidence into unconditional PASS.
+
+## Follow-Up Recommendations
+
+- Do not open a Hono target repo PR from this report.
+- Do not implement #206 from this report; no zh-TW evidence was observed.
+- Candidate repo-local follow-up, if prioritized later:
+  - Improve or document source ranking so sibling test files like `src/utils/cookie.test.ts` are easier to surface when an issue names `src/utils/cookie.ts`.
+  - Consider classifier calibration for generic `index` and DOM comparison wording to reduce `database` / `frontend` false positives.
+  - Add dogfood-report vocabulary to future Layer 3 catalog work without turning dogfood reports into runtime authority.
+
+## Scope Boundary
+
+- This dogfood run did not implement the target repo issue.
+- No target repo code was modified.
+- No target repo generated output was written.
+- No target repo branch, commit, PR, cleanup, stash, reset, or checkout was performed.
+- This report is workflow evidence only; it is not merge approval and not a target repo implementation plan.

--- a/tests/hybrid-awp-routing-policy.test.ts
+++ b/tests/hybrid-awp-routing-policy.test.ts
@@ -133,6 +133,28 @@ test('AWP dogfood outcome ledger remains linked from dogfood docs and README', a
   assert.match(englishReadme, /\[docs\/awp-dogfood-outcome-ledger\.md\]\(docs\/awp-dogfood-outcome-ledger\.md\)/);
 });
 
+test('third brownfield dogfood report remains indexed with safety and caveat evidence', async () => {
+  const dogfoodIndexPath = path.join(repoRoot, 'docs', 'dogfood.md');
+  const reportPath = path.join(repoRoot, 'docs', 'dogfood', 'hono-2026-05-14.md');
+
+  const [dogfoodIndex, report] = await Promise.all([
+    fs.readFile(dogfoodIndexPath, 'utf8'),
+    fs.readFile(reportPath, 'utf8'),
+  ]);
+
+  assert.match(dogfoodIndex, /\[Hono 2026-05-14 third brownfield dogfood\]\(dogfood\/hono-2026-05-14\.md\)/);
+  assert.match(report, /honojs\/hono/);
+  assert.match(report, /16c4e3885f51376cb6cbddc80eeae0202cd86234/);
+  assert.match(report, /https:\/\/github\.com\/honojs\/hono\/issues\/4916/);
+  assert.match(report, /Did not create `\.spec-injector\/` in target repo/);
+  assert.match(report, /src\/utils\/cookie\.ts/);
+  assert.match(report, /src\/helper\/cookie\/index\.ts/);
+  assert.match(report, /src\/utils\/cookie\.test\.ts/);
+  assert.match(report, /Verdict: `WARN`/);
+  assert.match(report, /does not unblock #206/);
+  assert.match(report, /No target repo code was modified/);
+});
+
 test('optional AWP delegation evidence manifest remains linked from policy docs and README', async () => {
   const manifestPath = path.join(repoRoot, 'docs', 'awp-delegation-evidence-manifest.md');
   const policyPath = path.join(repoRoot, 'docs', 'hybrid-awp-routing-policy.md');


### PR DESCRIPTION
Closes #223

## Summary

- Adds the third read-only brownfield dogfood report for `honojs/hono#4916`, pinned to target commit `16c4e3885f51376cb6cbddc80eeae0202cd86234`.
- Records the external-config `spec plan --dry-run --format prompt --verbose` run, stdout/stderr summary, target repo safety readback, source precision, diagnostics quality, classifier caveats, README claim impact, and Layer 3 / Layer 4 relation.
- Indexes the report from `docs/dogfood.md` and adds a regression test that the report remains linked with safety/verdict evidence.

## Tests / validation

- `node --test --test-name-pattern "third brownfield dogfood|AWP dogfood outcome" tests/hybrid-awp-routing-policy.test.ts`
- `pnpm test`
- `pnpm build`
- `git diff --check`

## Implementation Evidence

- commit: `03e4d6f7851888ae996d2b8c62e83d51624edcfe`
- issue evidence comment: https://github.com/Erick52106/spec-injector/issues/223#issuecomment-4445559701

## Review finding disposition

- CodeRabbit traceability finding: adopted. The report now anchors the third gate sentence to #223 only.

## Scope guard / non-goals confirmation

- Did not modify README.
- Did not implement runtime changes.
- Did not implement #206.
- Did not unpark #149.
- Did not implement Layer 3 protocol runtime.
- Did not implement Layer 4 companion/status runtime.
- Did not mutate the Hono target repo.
- Did not create target repo branch / commit / PR.
- Did not run `spec init` in the target repo.
- Did not create `.spec-injector/` in the target repo.
- Did not claim 4.8+ or unconditional 4.7 readiness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a dogfood reports section documenting tool validation findings.
  * Added a Hono brownfield validation report with run details, environment metadata, findings, caveats, and WARN verdict with follow-up recommendations.

* **Tests**
  * Added a test to ensure dogfood reports are indexed and contain expected evidence and safety guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Erick52106/spec-injector/pull/254)

<!-- review_stack_entry_end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Erick52106/spec-injector/pull/254)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->