### PR TITLE
feat(classifier): add minimal zh-TW keyword support

### DIFF
--- a/docs/classifier.md
+++ b/docs/classifier.md
@@ -20,6 +20,18 @@ Classifier 不是 LLM、不是 architecture reviewer，也不是最終決策者�
 
 目前沒有 repo-local custom domains runtime，也沒有 hidden LLM / API / local model classifier。
 
+## Traditional Chinese Keyword Surface
+
+Classifier 也包含一小組 evidence-driven Traditional Chinese keyword surface，用來覆蓋常見 workflow / issue wording，例如：
+
+- `auth`: `登入`、`登出`、`授權`、`權限`、`憑證`、`密碼`
+- `database`: `資料庫`、`資料表`、`欄位`、`查詢`、`遷移`
+- `frontend`: `前端`、`使用者介面`、`畫面`、`元件`、`表單`
+- `backend` / `api`: `後端`、`伺服器`、`服務`、`端點`、`路由`、`請求`、`回應`
+- `docs` / `ci` / `i18n`: `說明文件`、`操作指南`、`持續整合`、`建置步驟`、`多語系`、`翻譯`
+
+這些 keywords 仍是 deterministic token / phrase boundary matching，不做斷詞、語意推論、LLM classifier、RAG 或 custom domain expansion。繁中 workflow metadata，例如「請用繁體中文回覆」或 PR evidence closeout wording，不應單獨觸發 runtime domains。
+
 ## What Counts As Evidence
 
 Classifier evidence 是 deterministic signal，不是 model reasoning。常見 evidence 來源包含：

--- a/docs/classifier.md
+++ b/docs/classifier.md
@@ -27,7 +27,7 @@ Classifier 也包含一小組 evidence-driven Traditional Chinese keyword surfac
 - `auth`: `登入`、`登出`、`授權`、`權限`、`憑證`、`密碼`
 - `database`: `資料庫`、`資料表`、`欄位`、`查詢`、`遷移`
 - `frontend`: `前端`、`使用者介面`、`畫面`、`元件`、`表單`
-- `backend` / `api`: `後端`、`伺服器`、`服務`、`端點`、`路由`、`請求`、`回應`
+- `backend` / `api`: `後端`、`伺服器`、`後端服務`、`端點`、`路由`、`請求`、`回應`
 - `docs` / `ci` / `i18n`: `說明文件`、`操作指南`、`持續整合`、`建置步驟`、`多語系`、`翻譯`
 
 這些 keywords 仍是 deterministic token / phrase boundary matching，不做斷詞、語意推論、LLM classifier、RAG 或 custom domain expansion。繁中 workflow metadata，例如「請用繁體中文回覆」或 PR evidence closeout wording，不應單獨觸發 runtime domains。

--- a/src/classifier/domain.ts
+++ b/src/classifier/domain.ts
@@ -22,20 +22,20 @@ export interface DomainClassificationResult {
 }
 
 const DOMAIN_KEYWORDS: Record<string, string[]> = {
-  frontend: ['frontend', 'ui', 'component', 'client component', 'server action', 'add-to-cart', 'form action', 'pdp', 'render', 'css', 'style', 'react', 'vue', 'angular', 'svelte', 'button', 'form', 'page', 'layout', 'responsive', 'animation', 'dom', 'html', 'tailwind', 'visual', 'design'],
-  backend: ['server', 'service', 'handler', 'controller', 'middleware', 'worker', 'daemon', 'queue', 'job', 'cron', 'scheduler', 'grpc', 'rpc'],
-  api: ['api', 'endpoint', 'rest', 'graphql', 'http', 'route', 'swagger', 'openapi', 'webhook', 'request', 'response'],
-  auth: ['auth', 'authentication', 'authorization', 'authorize', 'authorized', 'login', 'logout', 'token', 'jwt', 'oauth', 'session', 'password', 'credential', 'permission', 'role', 'access', 'signup', 'register'],
-  database: ['database', 'db', 'sql', 'query', 'queries', 'migration', 'schema', 'table', 'column', 'model', 'data model', 'orm', 'repository layer', 'persistence', 'persisted', 'record storage', 'postgres', 'postgresql', 'mysql', 'sqlite', 'mongo', 'redis', 'index', 'prisma', 'drizzle', 'gorm'],
+  frontend: ['frontend', 'ui', 'component', 'client component', 'server action', 'add-to-cart', 'form action', 'pdp', 'render', 'css', 'style', 'react', 'vue', 'angular', 'svelte', 'button', 'form', 'page', 'layout', 'responsive', 'animation', 'dom', 'html', 'tailwind', 'visual', 'design', '前端', '使用者介面', '畫面', '元件', '表單', '樣式', '版面', '響應式'],
+  backend: ['server', 'service', 'handler', 'controller', 'middleware', 'worker', 'daemon', 'queue', 'job', 'cron', 'scheduler', 'grpc', 'rpc', '後端', '伺服器', '服務', '處理器', '控制器', '中介層', '排程'],
+  api: ['api', 'endpoint', 'rest', 'graphql', 'http', 'route', 'swagger', 'openapi', 'webhook', 'request', 'response', '端點', '路由', '請求', '回應', '介接'],
+  auth: ['auth', 'authentication', 'authorization', 'authorize', 'authorized', 'login', 'logout', 'token', 'jwt', 'oauth', 'session', 'password', 'credential', 'permission', 'role', 'access', 'signup', 'register', '登入', '登出', '授權', '權限', '角色', '憑證', '密碼', '權杖', '存取控制'],
+  database: ['database', 'db', 'sql', 'query', 'queries', 'migration', 'schema', 'table', 'column', 'model', 'data model', 'orm', 'repository layer', 'persistence', 'persisted', 'record storage', 'postgres', 'postgresql', 'mysql', 'sqlite', 'mongo', 'redis', 'index', 'prisma', 'drizzle', 'gorm', '資料庫', '資料表', '欄位', '查詢', '遷移', '結構描述', '索引', '持久化'],
   infra: ['infra', 'deploy', 'docker', 'kubernetes', 'k8s', 'terraform', 'helm', 'nginx', 'network', 'devops', 'provision', 'cloud', 'vm', 'container'],
   'cloud-storage': ['s3', 'gcs', 'storage', 'bucket', 'upload', 'download', 'blob', 'cdn', 'file upload', 'asset', 'object storage'],
   blockchain: ['blockchain', 'on-chain', 'transaction hash', 'tx hash', 'block height', 'contract address', 'token transfer', 'gas', 'nonce', 'ethereum', 'evm', 'solana', 'polygon', 'web3', 'nft', 'defi', 'ledger', 'consensus', 'miner'],
   'smart-contract': ['smart contract', 'contract address', 'solidity', 'abi', 'evm', 'vyper', 'bytecode', 'deploy contract'],
   wallet: ['wallet', 'connect wallet', 'wallet address', 'private key', 'public key', 'address', 'signature', 'signing', 'transaction hash', 'tx hash', 'token transfer', 'on-chain', 'send', 'receive', 'balance', 'seed phrase', 'mnemonic'],
-  i18n: ['i18n', 'l10n', 'locale', 'translation', 'lang', 'language', 'localize', 'multilang'],
+  i18n: ['i18n', 'l10n', 'locale', 'translation', 'lang', 'language', 'localize', 'multilang', '多語系', '翻譯', '在地化', '語系', '語言切換'],
   testing: ['.spec.ts', '.spec.tsx', '.spec.js', '.spec.jsx', '.spec.mts', '.spec.mjs', '.spec.cts', '.spec.cjs', '.test.ts', '.test.tsx', '.test.js', '.test.jsx', '.test.mts', '.test.mjs', '.test.cts', '.test.cjs', 'test', 'unit', 'integration', 'e2e', 'mock', 'stub', 'coverage', 'jest', 'vitest', 'playwright', 'cypress', 'assert', 'fixture'],
-  docs: ['docs', 'documentation', 'readme', 'guide', 'changelog', 'wiki', 'jsdoc', 'typedoc'],
-  ci: ['ci', 'cd', 'pipeline', 'workflow', 'github action', 'jenkins', 'travis', 'circleci', 'build step', 'artifact', 'badge'],
+  docs: ['docs', 'documentation', 'readme', 'guide', 'changelog', 'wiki', 'jsdoc', 'typedoc', '文件', '說明文件', '操作指南', '變更紀錄'],
+  ci: ['ci', 'cd', 'pipeline', 'workflow', 'github action', 'jenkins', 'travis', 'circleci', 'build step', 'artifact', 'badge', '持續整合', '部署流程', '建置步驟', '建置失敗'],
   tooling: ['lint', 'eslint', 'prettier', 'config', 'setup', 'cli', 'script', 'generator', 'plugin', 'package manager', 'npm', 'yarn', 'pnpm', 'bun'],
 };
 

--- a/src/classifier/domain.ts
+++ b/src/classifier/domain.ts
@@ -23,7 +23,7 @@ export interface DomainClassificationResult {
 
 const DOMAIN_KEYWORDS: Record<string, string[]> = {
   frontend: ['frontend', 'ui', 'component', 'client component', 'server action', 'add-to-cart', 'form action', 'pdp', 'render', 'css', 'style', 'react', 'vue', 'angular', 'svelte', 'button', 'form', 'page', 'layout', 'responsive', 'animation', 'dom', 'html', 'tailwind', 'visual', 'design', '前端', '使用者介面', '畫面', '元件', '表單', '樣式', '版面', '響應式'],
-  backend: ['server', 'service', 'handler', 'controller', 'middleware', 'worker', 'daemon', 'queue', 'job', 'cron', 'scheduler', 'grpc', 'rpc', '後端', '伺服器', '服務', '處理器', '控制器', '中介層', '排程'],
+  backend: ['server', 'service', 'handler', 'controller', 'middleware', 'worker', 'daemon', 'queue', 'job', 'cron', 'scheduler', 'grpc', 'rpc', '後端', '伺服器', '後端服務', '處理器', '控制器', '中介層', '排程'],
   api: ['api', 'endpoint', 'rest', 'graphql', 'http', 'route', 'swagger', 'openapi', 'webhook', 'request', 'response', '端點', '路由', '請求', '回應', '介接'],
   auth: ['auth', 'authentication', 'authorization', 'authorize', 'authorized', 'login', 'logout', 'token', 'jwt', 'oauth', 'session', 'password', 'credential', 'permission', 'role', 'access', 'signup', 'register', '登入', '登出', '授權', '權限', '角色', '憑證', '密碼', '權杖', '存取控制'],
   database: ['database', 'db', 'sql', 'query', 'queries', 'migration', 'schema', 'table', 'column', 'model', 'data model', 'orm', 'repository layer', 'persistence', 'persisted', 'record storage', 'postgres', 'postgresql', 'mysql', 'sqlite', 'mongo', 'redis', 'index', 'prisma', 'drizzle', 'gorm', '資料庫', '資料表', '欄位', '查詢', '遷移', '結構描述', '索引', '持久化'],

--- a/tests/classifier/domain.test.ts
+++ b/tests/classifier/domain.test.ts
@@ -510,6 +510,20 @@ test('zh-TW generic model and file wording does not imply database', () => {
   assert.ok(!result.domains.includes('database'), `Expected database to be absent from ${result.domains.join(', ')}`);
 });
 
+test('zh-TW generic service wording does not imply backend', () => {
+  const result = classifyDomainsWithEvidence(issue({
+    title: '更新客服服務品質與服務條款文件',
+    body: [
+      '這是產品文案和支援流程調整。',
+      '沒有 runtime 程式碼或部署設定變更。',
+    ].join('\n'),
+    labels: ['docs'],
+  }));
+
+  assert.ok(result.domains.includes('docs'), `Expected docs in ${result.domains.join(', ')}`);
+  assert.ok(!result.domains.includes('backend'), `Expected backend to be absent from ${result.domains.join(', ')}`);
+});
+
 test('classification evidence and rejected reasons keep deterministic shape and ordering', () => {
   const sampleIssue = issue({
     title: 'Dashboard endpoint route transaction review',

--- a/tests/classifier/domain.test.ts
+++ b/tests/classifier/domain.test.ts
@@ -420,6 +420,96 @@ test('dogfood-shaped add-to-cart issue keeps frontend signal without database or
   assert.ok(!result.evidence.some((e) => e.domain === 'tooling'), `Expected no tooling evidence, got ${JSON.stringify(result.evidence)}`);
 });
 
+test('zh-TW auth database docs and ci keywords classify with deterministic evidence', () => {
+  const result = classifyDomainsWithEvidence(issue({
+    title: '補齊登入權限與資料庫遷移文件',
+    body: [
+      '新增說明文件，記錄資料表欄位和查詢行為。',
+      '修正 GitHub Actions 持續整合的建置步驟。',
+      '登入、授權、角色和憑證行為都要保留。',
+    ].join('\n'),
+    labels: [],
+  }));
+
+  assert.ok(result.domains.includes('auth'), `Expected auth in ${result.domains.join(', ')}`);
+  assert.ok(result.domains.includes('database'), `Expected database in ${result.domains.join(', ')}`);
+  assert.ok(result.domains.includes('docs'), `Expected docs in ${result.domains.join(', ')}`);
+  assert.ok(result.domains.includes('ci'), `Expected ci in ${result.domains.join(', ')}`);
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'auth' && e.term === '登入' && e.source === 'title'
+  ));
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'database' && e.term === '資料庫' && e.source === 'title'
+  ));
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'docs' && e.term === '說明文件' && e.source === 'body'
+  ));
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'ci' && e.term === '持續整合' && e.source === 'body'
+  ));
+});
+
+test('zh-TW frontend backend api and i18n keywords classify without semantic matching', () => {
+  const result = classifyDomainsWithEvidence(issue({
+    title: '前端畫面串接後端端點與多語系翻譯',
+    body: [
+      '使用者介面元件需要呼叫後端服務的路由。',
+      '請求與回應格式要穩定，語系切換和在地化文案也要保留。',
+    ].join('\n'),
+    labels: [],
+  }));
+
+  assert.ok(result.domains.includes('frontend'), `Expected frontend in ${result.domains.join(', ')}`);
+  assert.ok(result.domains.includes('backend'), `Expected backend in ${result.domains.join(', ')}`);
+  assert.ok(result.domains.includes('api'), `Expected api in ${result.domains.join(', ')}`);
+  assert.ok(result.domains.includes('i18n'), `Expected i18n in ${result.domains.join(', ')}`);
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'frontend' && e.term === '前端' && e.source === 'title'
+  ));
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'backend' && e.term === '後端' && e.source === 'title'
+  ));
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'api' && e.term === '端點' && e.source === 'title'
+  ));
+  assert.ok(result.evidence.some((e) =>
+    e.domain === 'i18n' && e.term === '多語系' && e.source === 'title'
+  ));
+});
+
+test('zh-TW workflow metadata stays out of runtime domains without explicit signals', () => {
+  const result = classifyDomainsWithEvidence(issue({
+    title: '整理 PR body 與 issue evidence comment',
+    body: [
+      '請使用繁體中文回覆，保留 commands、file paths 和 raw output。',
+      '更新 closeout 紀錄並確認 reviewers 已讀回最新狀態。',
+      '這是流程紀錄，不是功能修正。',
+    ].join('\n'),
+    labels: ['area:workflow'],
+  }));
+
+  assert.ok(!result.domains.includes('auth'), `Expected auth to be absent from ${result.domains.join(', ')}`);
+  assert.ok(!result.domains.includes('database'), `Expected database to be absent from ${result.domains.join(', ')}`);
+  assert.ok(!result.domains.includes('frontend'), `Expected frontend to be absent from ${result.domains.join(', ')}`);
+  assert.ok(!result.domains.includes('backend'), `Expected backend to be absent from ${result.domains.join(', ')}`);
+  assert.ok(!result.domains.includes('api'), `Expected api to be absent from ${result.domains.join(', ')}`);
+  assert.ok(!result.domains.includes('i18n'), `Expected i18n to be absent from ${result.domains.join(', ')}`);
+});
+
+test('zh-TW generic model and file wording does not imply database', () => {
+  const result = classifyDomainsWithEvidence(issue({
+    title: '整理 AI 模型回覆文件',
+    body: [
+      '調整本機檔案說明，只處理提示文字和工作紀錄。',
+      '模型這個詞指的是 AI 回覆設定，不是產品資料設計。',
+    ].join('\n'),
+    labels: ['docs'],
+  }));
+
+  assert.ok(result.domains.includes('docs'), `Expected docs in ${result.domains.join(', ')}`);
+  assert.ok(!result.domains.includes('database'), `Expected database to be absent from ${result.domains.join(', ')}`);
+});
+
 test('classification evidence and rejected reasons keep deterministic shape and ordering', () => {
   const sampleIssue = issue({
     title: 'Dashboard endpoint route transaction review',


### PR DESCRIPTION
Closes #206

## Summary

- Add a minimal Traditional Chinese keyword surface for high-frequency classifier domains: auth, database, frontend, backend, api, docs, ci, and i18n.
- Add deterministic regression coverage for zh-TW true positives and false positives.
- Adopt review feedback by tightening broad backend `服務` matching to `後端服務` plus a generic service wording false-positive test.
- Document that zh-TW support remains keyword-boundary based and does not add segmentation, LLM, semantic matching, or taxonomy expansion.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm build && node --test tests/classifier/domain.test.ts`
- `pnpm test`
- `pnpm build`
- `git diff --check`
- `node bin/spec.js preflight --repo . --expected-branch codex/zh-tw-classifier-206 --expected-worktree-root /Users/erickwang/dev/spec-injector-worktrees` returned fail because the main repo has existing `.worktrees/` dirtiness and local `main` is behind origin/main; current dedicated worktree was clean.
- `node bin/spec.js workflow-check --repo . --phase commit --format json` returned fail because this repo does not currently have a `.spec-injector/` config; recorded as dogfood caveat, not pass evidence.

## Implementation Evidence

- Commit: `6754704a4c61d6d25dad6cb08c4053fa375d708c`
- Issue evidence comment: https://github.com/Erick52106/spec-injector/issues/206#issuecomment-4445727597

## Review Finding Assessment

- Adopted: Codex review finding about broad zh-TW `服務` backend matching. Fix: use narrower `後端服務` keyword and add false-positive coverage for `客服服務品質` / `服務條款` docs wording.

## Scope Guard

This PR stays inside #206 classifier/docs/tests scope.

## Non-goals

This PR does not add segmentation / jieba, an LLM classifier, semantic matching, RAG, custom domain expansion, domain taxonomy changes, evidence format changes, or non-deterministic classifier behavior. It does not mutate target repos or unpark #149.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced domain classifier with expanded keyword support for Traditional Chinese, improving detection across frontend, backend, API, authentication, database, and CI/CD domains.

* **Documentation**
  * Added documentation explaining Traditional Chinese keyword coverage for the classifier.

* **Tests**
  * Added multilingual test cases validating domain classification accuracy for Chinese-language content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Erick52106/spec-injector/pull/256)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->