### PR TITLE
docs(workflow): require AWP dispatch evidence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,21 @@ Code/docs implementation 不得直接在 main repo worktree 進行。
 
 Metadata-only 任務可以不用 dedicated worktree，但不得假設 main repo 可以被任意切換或清理。若 metadata-only 任務遇到 dirty repo，停下回報。
 
+## AWP / autonomous routing signal
+
+若 user prompt、source issue、task package 或 repo-local instruction 明確要求 AWP / Autonomous Worker Profiles / autonomous worker routing，該要求是 Hybrid AWP routing signal。
+
+在任何 code/docs implementation 前，controller 必須先完成 start-gate routing decision：
+
+- 實際 dispatch worker / subagent 做 bounded exploration、implementation slice 或 readback，並在 evidence 中記錄 assigned scope 與 outcome。
+- 或記錄 controller-direct fallback，且包含明確 bounded `controller_fallback_reason` 與 `delegation_outcome=skipped|unavailable|fell_through`。
+
+AWP evidence 至少應在 source issue、PR body、implementation evidence comment 或 closeout 中保留 `routing_mode`、`routing_task_class`、`controller_fallback`、`controller_fallback_reason` 與 `delegation_outcome`。
+
+repo-native workflow compliance 不等於 AWP delegation evidence。完成 ordinary issue-first / worktree-first / PR evidence closeout 仍不得被宣稱為 AWP，除非同時有 worker dispatch 或明確 controller-direct fallback evidence。
+
+AWP routing 不改變本 repo 的產品邊界：不得把 worker runtime、daemon、hosted control plane、dashboard、auto-comment、auto-merge、hidden LLM wrapper 或 target repo mutation 塞進 CLI core。
+
 ## Scope discipline
 
 - 只處理指定 issue。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,10 +39,12 @@ Metadata-only 任務可以不用 dedicated worktree，但不得假設 main repo 
 
 若 user prompt、source issue、task package 或 repo-local instruction 明確要求 AWP / Autonomous Worker Profiles / autonomous worker routing，該要求是 Hybrid AWP routing signal。
 
-在任何 code/docs implementation 前，controller 必須先完成 start-gate routing decision：
+偵測 AWP signal 可以發生在 issue triage / prompt reading 階段；但 worker dispatch、implementation slice 或 controller-direct fallback evidence 必須在 Mandatory startup rules 完成、dedicated worktree clean 之後，且在任何 code/docs implementation 前完成。
+
+controller 必須先完成 start-gate routing decision：
 
 - 實際 dispatch worker / subagent 做 bounded exploration、implementation slice 或 readback，並在 evidence 中記錄 assigned scope 與 outcome。
-- 或記錄 controller-direct fallback，且包含明確 bounded `controller_fallback_reason` 與 `delegation_outcome=skipped|unavailable|fell_through`。
+- 或記錄 controller-direct fallback，且包含明確 bounded `controller_fallback_reason` 與 `delegation_outcome=skipped|unavailable`。
 
 AWP evidence 至少應在 source issue、PR body、implementation evidence comment 或 closeout 中保留 `routing_mode`、`routing_task_class`、`controller_fallback`、`controller_fallback_reason` 與 `delegation_outcome`。
 

--- a/README.en.md
+++ b/README.en.md
@@ -241,6 +241,8 @@ spec plan <issue-number-or-url> --repo . --dry-run --format prompt --verbose
 
 The AI should then use that prompt output to draft an implementation plan. Human approval remains the gate before any repo files are modified.
 
+AWP-signaled workflow differs from the ordinary issue-to-PR path. If a prompt, source issue, or repo instruction explicitly asks for AWP / Autonomous Worker Profiles / autonomous worker routing, the controller must first follow the [Hybrid AWP routing policy](docs/hybrid-awp-routing-policy.md) and record either worker dispatch evidence or a controller-direct fallback reason. The ordinary issue-to-PR workflow does not prove worker dispatch by itself.
+
 Some teams may expose a repo-level `/spec-plan <issue>` shorthand in Claude Code or another AI tool. That shorthand is workflow glue, not a `spec-injector` runtime command. The actual CLI command remains `spec plan`.
 
 See [docs/workflow.md](docs/workflow.md), [docs/workflows/README.md](docs/workflows/README.md), [docs/workflows/codex.md](docs/workflows/codex.md), and [docs/workflows/claude-code.md](docs/workflows/claude-code.md).

--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ spec plan <issue-number-or-url> --repo . --dry-run --format prompt --verbose
 
 The AI should then use that prompt output to draft an implementation plan. Human approval remains the gate before any repo files are modified.
 
+AWP-signaled workflow differs from the ordinary issue-to-PR path. If a prompt, source issue, or repo instruction explicitly asks for AWP / Autonomous Worker Profiles / autonomous worker routing, the controller must first follow the [Hybrid AWP routing policy](docs/hybrid-awp-routing-policy.md) and record either worker dispatch evidence or a controller-direct fallback reason. The ordinary issue-to-PR workflow does not prove worker dispatch by itself.
+
 Some teams may expose a repo-level `/spec-plan <issue>` shorthand in Claude Code or another AI tool. That shorthand is workflow glue, not a `spec-injector` runtime command. The actual CLI command remains `spec plan`.
 
 See [docs/workflow.md](docs/workflow.md), [docs/workflows/README.md](docs/workflows/README.md), [docs/workflows/codex.md](docs/workflows/codex.md), and [docs/workflows/claude-code.md](docs/workflows/claude-code.md).

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -94,6 +94,19 @@ Claude Code 優先負責 planning / review 類工作：
 
 `spec-injector` 只產出 handoff artifact。Branch、commit、PR、evidence comment、review、merge 與 cleanup 是 surrounding workflow，不是 CLI core 自動執行的 runtime behavior。
 
+## AWP controller / worker handoff
+
+當 human、source issue 或 repo instruction 明確要求 AWP / Autonomous Worker Profiles / autonomous worker routing 時，standard handoff flow 前要先做 AWP start-gate handoff。repo-native workflow compliance is not delegation proof：issue-first、dedicated worktree、validation、PR body、implementation evidence comment 與 merge closeout 只能證明一般 repo workflow，不代表真的發生 worker routing。
+
+AWP controller 必須在 implementation 前二選一：
+
+- `dispatch worker`：派出 bounded worker / subagent 做 exploration、implementation slice 或 readback，並保存 assigned scope、result summary、closeout status 與 `delegation_outcome=completed|fell_through`。
+- `controller-direct fallback`：不派 worker，但在 issue / PR / closeout evidence 中明確記錄 `controller_fallback=allowed`、bounded `controller_fallback_reason` 與 `delegation_outcome=skipped|unavailable`。
+
+Controller 保留 scope、architecture、review 與 merge-gate responsibility。Worker output 是 input，不是 approval；controller 必須獨立 readback diff、tests、GitHub state 與 review findings，才能進入 PR / merge closeout。
+
+這個 handoff 不讓 `spec-injector` 變成 agent orchestrator。它只要求 repo-local AWP work 誠實記錄「有派工」或「明確 fallback」，不得把 ordinary controller-only run 包裝成 AWP。
+
 ## Planning vs implementation
 
 Read-only planning 適用於：

--- a/docs/hybrid-awp-routing-policy.md
+++ b/docs/hybrid-awp-routing-policy.md
@@ -18,6 +18,8 @@ Absence of autonomous routing signal must not fail ordinary human PRs or non-aut
 
 Downstream Scope Police workflows should not enforce AWP routing sections for general human PRs.
 
+For repo-local `spec-injector` work, repo-native issue/worktree/evidence compliance does not prove AWP delegation occurred. When an AWP signal is present, closeout evidence needs either worker dispatch or an explicit controller-direct fallback so reviewers can distinguish actual AWP execution from an ordinary controller-only issue-to-PR workflow.
+
 ## Start gate
 
 Routing is decided at the start gate, before implementation starts and before the controller commits to a plan. The start gate should classify the task, decide which worker class is required, and record the controller's retained role.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -32,7 +32,7 @@ Future companion / workflow observability status vocabulary 見 [status-event-sc
 
 ## Autonomous / AWP start-gate overlay
 
-若 user prompt、source issue、task package 或 repo-local instruction 明確要求 AWP、Autonomous Worker Profiles、autonomous worker routing 或等價 worker-routing contract，controller 必須把它視為 `autonomous routing signal`。這個 overlay 發生在 standard startup sequence 與 implementation plan 之前，也就是 before implementation；它不取代 issue-first、worktree-first、validation、PR evidence 或 review closeout。
+若 user prompt、source issue、task package 或 repo-local instruction 明確要求 AWP、Autonomous Worker Profiles、autonomous worker routing 或等價 worker-routing contract，controller 必須把它視為 `autonomous routing signal`。Signal detection 可以發生在 prompt reading / issue triage 階段；但 worker dispatch、implementation slice 或 controller-direct fallback evidence 必須 after startup safety checks，也就是完成 main repo status check、dedicated worktree 建立與 worktree clean readback 之後，且 before implementation。這個 overlay 不取代 issue-first、worktree-first、validation、PR evidence 或 review closeout。
 
 有 AWP signal 時，implementation 前必須先留下 start-gate evidence：
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -30,6 +30,19 @@ Future companion / workflow observability status vocabulary 見 [status-event-sc
 
 相鄰工具與 roadmap 邊界請見 [docs/positioning.md](positioning.md)。多 agent / Codex / Claude Code / ChatGPT / other agents 的分工與 handoff patterns 請見 [docs/agent-handoff.md](agent-handoff.md)。
 
+## Autonomous / AWP start-gate overlay
+
+若 user prompt、source issue、task package 或 repo-local instruction 明確要求 AWP、Autonomous Worker Profiles、autonomous worker routing 或等價 worker-routing contract，controller 必須把它視為 `autonomous routing signal`。這個 overlay 發生在 standard startup sequence 與 implementation plan 之前，也就是 before implementation；它不取代 issue-first、worktree-first、validation、PR evidence 或 review closeout。
+
+有 AWP signal 時，implementation 前必須先留下 start-gate evidence：
+
+- `worker dispatch`：controller 實際派出 bounded worker / subagent 做 exploration、implementation slice 或 readback，並記錄 assigned scope、result summary 與 `delegation_outcome=completed|fell_through`。
+- `controller-direct fallback`：controller 不派 worker，但明確記錄 `controller_fallback=allowed`、bounded `controller_fallback_reason` 與 `delegation_outcome=skipped|unavailable`。
+
+AWP closeout 應在 source issue、PR body、implementation evidence comment 或 merge closeout 中能讀回 routing mode、task class、controller fallback decision、fallback reason 與 `delegation_outcome`。repo-native workflow compliance、`spec plan`、dedicated worktree、validation、PR body evidence 與 issue closeout 只證明一般 repo workflow；它們本身不是 AWP delegation evidence。
+
+沒有 autonomous routing signal 的 ordinary human PR / non-AWP AI work 不需要 worker dispatch 或 controller-direct fallback evidence，相關欄位可維持 `n/a`、`manual` 或 `skipped`。
+
 ## Worktree-first workflow
 
 Main repo 是 control plane，應保持 clean / synced。Code/docs implementation 不直接在 main repo worktree 做。

--- a/tests/hybrid-awp-routing-policy.test.ts
+++ b/tests/hybrid-awp-routing-policy.test.ts
@@ -4,6 +4,48 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { repoRoot } from './helpers/cli.ts';
 
+test('repo-local AWP instructions require dispatch or explicit fallback evidence before implementation', async () => {
+  const agentsPath = path.join(repoRoot, 'AGENTS.md');
+  const workflowPath = path.join(repoRoot, 'docs', 'workflow.md');
+  const handoffPath = path.join(repoRoot, 'docs', 'agent-handoff.md');
+  const policyPath = path.join(repoRoot, 'docs', 'hybrid-awp-routing-policy.md');
+  const readmePath = path.join(repoRoot, 'README.md');
+  const englishReadmePath = path.join(repoRoot, 'README.en.md');
+
+  const [agents, workflow, handoff, policy, readme, englishReadme] = await Promise.all([
+    fs.readFile(agentsPath, 'utf8'),
+    fs.readFile(workflowPath, 'utf8'),
+    fs.readFile(handoffPath, 'utf8'),
+    fs.readFile(policyPath, 'utf8'),
+    fs.readFile(readmePath, 'utf8'),
+    fs.readFile(englishReadmePath, 'utf8'),
+  ]);
+
+  assert.match(agents, /AWP \/ autonomous routing signal/);
+  assert.match(agents, /controller_fallback_reason/);
+  assert.match(agents, /delegation_outcome/);
+  assert.match(agents, /repo-native workflow compliance 不等於 AWP delegation evidence/);
+
+  assert.match(workflow, /Autonomous \/ AWP start-gate overlay/);
+  assert.match(workflow, /before implementation/);
+  assert.match(workflow, /worker dispatch/);
+  assert.match(workflow, /controller-direct fallback/);
+  assert.match(workflow, /delegation_outcome/);
+
+  assert.match(handoff, /AWP controller \/ worker handoff/);
+  assert.match(handoff, /repo-native workflow compliance is not delegation proof/);
+  assert.match(handoff, /dispatch worker/);
+  assert.match(handoff, /controller-direct fallback/);
+
+  assert.match(policy, /repo-native issue\/worktree\/evidence compliance does not prove AWP delegation occurred/);
+  assert.match(policy, /worker dispatch or an explicit controller-direct fallback/);
+
+  assert.match(readme, /AWP-signaled workflow/);
+  assert.match(readme, /ordinary issue-to-PR workflow does not prove worker dispatch/);
+  assert.match(englishReadme, /AWP-signaled workflow/);
+  assert.match(englishReadme, /ordinary issue-to-PR workflow does not prove worker dispatch/);
+});
+
 test('Hybrid AWP routing policy remains linked from workflow-check docs', async () => {
   const policyPath = path.join(repoRoot, 'docs', 'hybrid-awp-routing-policy.md');
   const readmePath = path.join(repoRoot, 'README.md');

--- a/tests/hybrid-awp-routing-policy.test.ts
+++ b/tests/hybrid-awp-routing-policy.test.ts
@@ -27,6 +27,7 @@ test('repo-local AWP instructions require dispatch or explicit fallback evidence
   assert.match(agents, /repo-native workflow compliance 不等於 AWP delegation evidence/);
 
   assert.match(workflow, /Autonomous \/ AWP start-gate overlay/);
+  assert.match(workflow, /after startup safety checks/);
   assert.match(workflow, /before implementation/);
   assert.match(workflow, /worker dispatch/);
   assert.match(workflow, /controller-direct fallback/);
@@ -39,6 +40,8 @@ test('repo-local AWP instructions require dispatch or explicit fallback evidence
 
   assert.match(policy, /repo-native issue\/worktree\/evidence compliance does not prove AWP delegation occurred/);
   assert.match(policy, /worker dispatch or an explicit controller-direct fallback/);
+
+  assert.doesNotMatch(agents, /controller-direct fallback[\s\S]{0,200}fell_through/);
 
   assert.match(readme, /AWP-signaled workflow/);
   assert.match(readme, /ordinary issue-to-PR workflow does not prove worker dispatch/);


### PR DESCRIPTION
Closes #261

## Summary

- 在 AGENTS / workflow / handoff 文件新增 AWP signal 的 start-gate overlay：startup safety checks 完成且 dedicated worktree clean 之後、implementation 前，必須有 worker dispatch 或明確 controller-direct fallback evidence。
- 在 Hybrid AWP policy 與 README / README.en 補明 ordinary issue-to-PR workflow 不等於 worker dispatch proof。
- 新增 regression test 鎖住 repo-local AWP 入口文件契約，並防止 controller-direct fallback 誤用 `fell_through`。

## Tests / validation

- pnpm build
- node --test --test-name-pattern "repo-local AWP" tests/hybrid-awp-routing-policy.test.ts（RED 後 GREEN）
- node --test tests/hybrid-awp-routing-policy.test.ts
- pnpm test
- git diff --check

## Implementation Evidence

- issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/261#issuecomment-4529406394
- commit hash: 10b649bc75c981b1cda9379abeb7c496d0cf5256

## Review finding disposition

- adopted: Codex P1 startup ordering finding；修正為 signal detection 可早於 startup，但 worker dispatch / implementation slice / fallback evidence 必須 after startup safety checks 且 before implementation。
- adopted: Codex P2 fallback outcome finding；controller-direct fallback 只允許 `skipped|unavailable`，`fell_through` 保留給實際 dispatch 後未完成的 worker outcome。

## AWP routing evidence

- routing_mode: hybrid_awp
- routing_task_class: workflow_policy
- worker dispatch: completed
- worker evidence: Pasteur explored docs/workflow gaps; Pauli explored CLI/test feasibility and flagged runtime-manifest work as out of #258/#261 scope.
- controller_role: scope, architecture, review, merge_gate
- controller_fallback: denied for implementation; controller retained final policy/edit/review gate after worker exploration.
- controller_fallback_reason: user explicitly requested AWP and prior runs exposed missing worker/fallback evidence, so worker exploration was required before implementation.
- delegation_outcome: completed

## Scope guard

- Source issue: #261。
- 修改範圍限於 repo-local AWP entrypoint docs / policy docs / README pointers / regression test。

## Non-goals

- 不修改 CLI flags、JSON schema、exit semantics 或 runtime worker orchestration。
- 不新增 hosted control plane、daemon、dashboard、auto-comment、auto-merge 或 hidden LLM wrapper。
- 不修改 tachigo / tachiya template、Scope Police、CI 或 AGENTS。
- 不寫 `.spec-injector/`、generated output、private context 或 dogfood scratch file。

## Dogfood caveats

- `spec preflight` 在本 worktree 回報 FAIL，原因是 main worktree 既有 dirty / behind 與目前 implementation worktree 有未提交修改；未自動 stash / clean / reset。
- `spec workflow-check --repo "$PWD" --phase commit --format json` 回報 FAIL，原因是本 repo 目前沒有 `.spec-injector/` config；未執行 `spec init` 以避免新增 repo 檔案。