### PR TITLE
fix(workflow): allow PR closeout without local config

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -196,7 +196,7 @@ Notes:
 
 - `start`: validates repo config. With `--issue`, it performs a dry-run bounded context check through `spec plan --dry-run --format prompt --verbose` without writing a task package. If the issue has an AWP / Codex autonomous routing signal, it also emits a deterministic Hybrid AWP routing plan; if no autonomous signal is present, routing fields are `n/a` and ordinary workflows do not fail.
 - `commit`: checks staged files for `.spec-injector/`, generated task packages / spec output, and private context artifacts. With `--pr-body`, it also checks for spec gate status/ref or manual fallback evidence. With `--routing-evidence`, it checks local PR body routing status/ref, delegation log, Spark / ops evidence, 5.4 worker evidence, and explicit fallback quality.
-- `merge`: checks a local PR body for final merge gate evidence, spec gate status/ref, and latest HEAD SHA. With `--head-sha`, stale or mismatched evidence fails. With `--routing-evidence`, stale start-gate routing evidence or routing/PR-body mismatch fails.
+- `merge`: checks a local PR body for final merge gate evidence, spec gate status/ref, and latest HEAD SHA. With `--head-sha`, stale or mismatched evidence fails. With `--routing-evidence`, stale start-gate routing evidence or routing/PR-body mismatch fails. With `--pr`, merge closeout readback can continue without local `.spec-injector/config.json`; missing local config is reported as a warning while GitHub PR body / checks / reviews are read.
 
 ## Optional live gh smoke test
 

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Notes:
 
 - `start`: validates repo config. With `--issue`, it performs a dry-run bounded context check through `spec plan --dry-run --format prompt --verbose` without writing a task package. If the issue has an AWP / Codex autonomous routing signal, it also emits a deterministic Hybrid AWP routing plan; if no autonomous signal is present, routing fields are `n/a` and ordinary workflows do not fail.
 - `commit`: checks staged files for `.spec-injector/`, generated task packages / spec output, and private context artifacts. With `--pr-body`, it also checks for spec gate status/ref or manual fallback evidence. With `--routing-evidence`, it checks local PR body routing status/ref, delegation log, Spark / ops evidence, 5.4 worker evidence, and explicit fallback quality.
-- `merge`: checks a local PR body for final merge gate evidence, spec gate status/ref, and latest HEAD SHA. With `--head-sha`, stale or mismatched evidence fails. With `--routing-evidence`, stale start-gate routing evidence or routing/PR-body mismatch fails.
+- `merge`: checks a local PR body for final merge gate evidence, spec gate status/ref, and latest HEAD SHA. With `--head-sha`, stale or mismatched evidence fails. With `--routing-evidence`, stale start-gate routing evidence or routing/PR-body mismatch fails. With `--pr`, merge closeout readback can continue without local `.spec-injector/config.json`; missing local config is reported as a warning while GitHub PR body / checks / reviews are read.
 
 ## Optional live gh smoke test
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -111,7 +111,7 @@ CodeRabbit / Codex auto review findings 只能作為 auxiliary signals。`spec e
 
 Thread-level limitation：`spec evidence-check` 目前只做 read-only 輔助檢核，不會完整 enforce GitHub review thread / conversation closeout。它可提醒 PR body / evidence / HEAD / validation / findings shape，但不能保證每條 CodeRabbit / Codex / human thread 都已關閉。`PASS` 僅表示輔助欄位滿足程度，不是 merge approval。該 checker 不能 auto-comment、auto-resolve、auto-merge、auto-close，也不會 mutate GitHub issue / PR metadata；最終 thread-level closeout 必須由 human 逐條確認與接手。
 
-`spec workflow-check --phase merge --pr <number-or-url>` 可做 local-only merge closeout readback。它會讀取 PR body、draft state、review metadata、`gh pr checks` summary 與 review threads，並把無法可靠判斷的 GitHub / `gh` output drift 回報成 `manual` fallback，而不是把工具層 schema mismatch 誤判成 PR 本身不可 merge。若 checks readback 回傳缺欄位、未知 enum、或只有無法歸類的 status shape，controller 應以 PR 頁面、`gh pr checks`、Actions UI、review thread readback 補人工 evidence；不得因 manual fallback 自動 merge，也不得讓 checker auto-comment、auto-resolve 或 mutate GitHub。
+`spec workflow-check --phase merge --pr <number-or-url>` 可做 local-only merge closeout readback。它會讀取 PR body、draft state、review metadata、`gh pr checks` summary 與 review threads，並把無法可靠判斷的 GitHub / `gh` output drift 回報成 `manual` fallback，而不是把工具層 schema mismatch 誤判成 PR 本身不可 merge。這個 `--pr` readback path 不依賴 target repo `.spec-injector/config.json`；若 local config 不存在，checker 會保留 warning 並繼續 readback，避免 repo-local closeout 被 config bootstrap 狀態誤擋。`start` / `commit` phase 仍需要 local config。若 checks readback 回傳缺欄位、未知 enum、或只有無法歸類的 status shape，controller 應以 PR 頁面、`gh pr checks`、Actions UI、review thread readback 補人工 evidence；不得因 manual fallback 自動 merge，也不得讓 checker auto-comment、auto-resolve 或 mutate GitHub。
 
 ## Worktree naming
 

--- a/src/cli/workflow-check.ts
+++ b/src/cli/workflow-check.ts
@@ -210,7 +210,6 @@ export async function workflowCheck(opts: WorkflowCheckOptions): Promise<void> {
 
   try {
     ensureRepoPath(repoPath);
-    config = await loadConfig(repoPath);
   } catch (err) {
     const result = buildResult({
       phase,
@@ -225,9 +224,33 @@ export async function workflowCheck(opts: WorkflowCheckOptions): Promise<void> {
     process.exit(1);
   }
 
+  try {
+    config = await loadConfig(repoPath);
+  } catch (err) {
+    if (isMergePrCloseout(phase, opts)) {
+      warnings.push(`Local config unavailable; merge --pr closeout continued with readback-only evidence: ${(err as Error).message}`);
+    } else {
+      const result = buildResult({
+        phase,
+        repoPath,
+        checkedAt,
+        status: 'fail',
+        missingFields: ['config'],
+        warnings,
+        evidenceSummary: `workflow-check could not validate repo config: ${(err as Error).message}`,
+      });
+      printResult(result, format);
+      process.exit(1);
+    }
+  }
+
   const result = await runPhase(phase, repoPath, config, opts, checkedAt, warnings);
   printResult(result, format);
   if (result.status === 'fail') process.exit(1);
+}
+
+function isMergePrCloseout(phase: WorkflowPhase, opts: WorkflowCheckOptions): boolean {
+  return phase === 'merge' && Boolean(opts.pr);
 }
 
 function parsePhase(value: string): WorkflowPhase {
@@ -243,13 +266,29 @@ function parseFormat(value: string): OutputFormat {
 async function runPhase(
   phase: WorkflowPhase,
   repoPath: string,
-  config: Config,
+  config: Config | null,
   opts: WorkflowCheckOptions,
   checkedAt: string,
   warnings: string[]
 ): Promise<WorkflowCheckResult> {
   if (phase === 'start') {
     return runStartPhase(repoPath, opts, checkedAt, warnings);
+  }
+
+  if (isMergePrCloseout(phase, opts)) {
+    return runMergeCloseoutPhase(repoPath, opts, checkedAt, warnings);
+  }
+
+  if (!config) {
+    return buildResult({
+      phase,
+      repoPath,
+      checkedAt,
+      status: 'fail',
+      missingFields: ['config'],
+      warnings,
+      evidenceSummary: 'workflow-check could not validate repo config',
+    });
   }
 
   const staged = readStagedPaths(repoPath, config);

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -2258,6 +2258,102 @@ test('spec workflow-check merge phase collects closeout readback evidence with m
   assertNoGhMutationCommands(ghLog);
 });
 
+test('spec workflow-check merge closeout with --pr does not require local config', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-closeout-no-config-');
+  await fs.writeFile(path.join(repoDir, 'README.md'), '# fixture\n', 'utf8');
+  await initCleanGitRepo(repoDir);
+  const headSha = 'abababababababababababababababababababab';
+  const fixture = await createEvidenceCheckFixture(t, {
+    issueNumber: 263,
+    headSha,
+    prBody: [
+      'Closes #263',
+      '',
+      '## Summary',
+      'Closeout readback evidence without local config.',
+      '',
+      '## Scope',
+      'Read-only closeout evidence collection.',
+      '',
+      '## Non-goals',
+      'No mutation.',
+      '',
+      '## Spec gate evidence',
+      '- spec gate status: pass',
+      '- spec evidence ref: https://github.com/Erick52106/spec-injector/issues/263#issuecomment-1001',
+      '- routing evidence status: pass',
+      '- routing evidence ref: workflow-check:start:263',
+      '- finding disposition status: pass',
+      '',
+      '## Implementation Evidence',
+      '- Issue evidence: https://github.com/Erick52106/spec-injector/issues/263#issuecomment-1001',
+      `- Commit: ${headSha}`,
+      '',
+      '## Validation',
+      '- `pnpm test`',
+      '',
+      '## Final merge gate',
+      `- latest head SHA: ${headSha}`,
+      '- ready_to_merge: yes',
+    ].join('\n'),
+    reviews: [{ author: { login: 'chatgpt-codex-connector' }, body: 'No actionable findings.', state: 'COMMENTED' }],
+    reviewThreads: [],
+    checks: [
+      { name: 'build', state: 'COMPLETED', conclusion: 'SUCCESS', bucket: 'pass' },
+      { name: 'CodeRabbit', state: 'SUCCESS', conclusion: 'SUCCESS', bucket: 'pass' },
+    ],
+  });
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'merge',
+    '--pr', `https://github.com/${fixture.repo}/pull/${fixture.prNumber}`,
+    '--format', 'json',
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.status, 'pass');
+  assert.equal(parsed.closeout_readback_status, 'pass');
+  assert.equal(parsed.ready_to_merge, 'yes');
+  assert.match((parsed.warnings as string[]).join('\n'), /local config/i);
+  assert.doesNotMatch((parsed.missing_fields as string[]).join('\n'), /config/);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assert.match(ghLog, /pr view/);
+  assert.match(ghLog, /pr checks/);
+  assert.match(ghLog, /api graphql/);
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec workflow-check still requires local config outside merge --pr closeout', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-no-config-phases-');
+  await fs.writeFile(path.join(repoDir, 'README.md'), '# fixture\n', 'utf8');
+  await initCleanGitRepo(repoDir);
+
+  const startResult = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'start',
+    '--format', 'json',
+  ]);
+  assert.notEqual(startResult.code, 0);
+  const parsedStart = JSON.parse(startResult.stdout) as Record<string, unknown>;
+  assert.equal(parsedStart.status, 'fail');
+  assert.deepEqual(parsedStart.missing_fields, ['config']);
+
+  const commitResult = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'commit',
+    '--format', 'json',
+  ]);
+  assert.notEqual(commitResult.code, 0);
+  const parsedCommit = JSON.parse(commitResult.stdout) as Record<string, unknown>;
+  assert.equal(parsedCommit.status, 'fail');
+  assert.deepEqual(parsedCommit.missing_fields, ['config']);
+});
+
 test('spec workflow-check merge closeout fails when PR body readback is not ready to merge', async (t) => {
   const repoDir = await createTempRepo(t, 'spec-injector-workflow-closeout-not-ready-');
   await writeConfig(repoDir, { version: 2, guardrails: [] });


### PR DESCRIPTION
Closes #263

## Summary

- 讓 `spec workflow-check --phase merge --pr ...` 在 local `.spec-injector/config.json` 缺失時繼續做 PR readback，並把 config 缺失保留為 warning。
- 保持 `start` / `commit` 以及 non-`--pr` merge path 的 config validation fail 行為。
- 更新 README / workflow docs，說明 `merge --pr` readback 不依賴 target repo config。

## Tests / validation

- pnpm build
- pnpm build && node --test --test-name-pattern "merge closeout with --pr does not require local config" tests/cli.integration.test.ts（RED 後 GREEN）
- node --test --test-name-pattern "local config" tests/cli.integration.test.ts
- pnpm test
- git diff --check
- dogfood: `node dist/cli/index.js workflow-check --repo "$PWD" --phase merge --pr 262 --format json` continued PR readback with local config warning; failure moved to PR-body contract fields, not config.

## Spec gate evidence

- spec gate status: pass
- spec evidence ref: https://github.com/Erick52106/spec-injector/issues/263#issuecomment-4529498152
- routing evidence status: pass
- routing evidence ref: workflow-check:start:issue-263
- finding disposition status: pass

## Implementation Evidence

- issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/263#issuecomment-4529498152
- commit hash: 2a41d322b6a7bee31e7bdf05b9ed338ac3311348

## Review finding disposition

- noise / not applicable: CodeRabbit rate-limit summary comment did not include actionable findings.
- noise / not applicable: no Codex review findings were posted for this head at closeout readback time.

## AWP routing evidence

- routing_mode: hybrid_awp
- routing_task_class: product_behavior
- worker dispatch: completed
- worker evidence: Euler explored runtime patch point; Bacon explored mocked-gh regression test strategy.
- controller_role: scope, architecture, review, merge_gate
- controller_fallback: denied for implementation until worker exploration completed.
- controller_fallback_reason: runtime behavior change touches workflow-check merge gate semantics, so worker exploration was required before implementation.
- delegation_outcome: completed

## Scope guard

- Source issue: #263。
- 修改範圍限於 `workflow-check` merge `--pr` config fallback、regression tests、README/workflow docs。

## Non-goals

- 不新增 CLI flag。
- 不改 JSON contract 欄位名稱或 status enum。
- 不讓 checker mutate GitHub。
- 不要求 downstream Scope Police parse full evidence。
- 不新增 `.spec-injector/` config、generated output 或 private context。
- 不做 daemon / hosted control plane / auto-comment / auto-merge。

## Final merge gate

- latest head SHA: 2a41d322b6a7bee31e7bdf05b9ed338ac3311348
- ready_to_merge: yes

## Dogfood caveats

- Main worktree 仍有既有 untracked `.worktrees/` 且本地 main behind origin；本 PR 在 external dedicated worktree from latest `origin/main` 實作，沒有 stash / clean / reset main。