### PR TITLE
chore(workflow): ignore local worktree directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@ dist/
 *.js.map
 
 # Local worktree and scratch directories
-.worktrees/
-worktrees/
-spec-injector-worktrees/
+/.worktrees/
+/worktrees/
+/spec-injector-worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 node_modules/
 dist/
 *.js.map
+
+# Local worktree and scratch directories
+.worktrees/
+worktrees/
+spec-injector-worktrees/

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -121,6 +121,8 @@ Thread-level limitation：`spec evidence-check` 目前只做 read-only 輔助檢
 - worktree path: `issue-<number>-<slug>`
 - branch name: `<type>/<issue-number>-<slug>`
 
+Repo-local worktree scratch directories（例如 `.worktrees/`、`worktrees/`、`spec-injector-worktrees/`）已被 ignore，避免本機容器變成 commit candidate。除非任務另有要求，canonical shared parent 仍是 `../spec-injector-worktrees`。不要 commit local worktree contents。
+
 Examples:
 
 - `docs/123-agent-worktree-workflow`

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -121,7 +121,7 @@ Thread-level limitation：`spec evidence-check` 目前只做 read-only 輔助檢
 - worktree path: `issue-<number>-<slug>`
 - branch name: `<type>/<issue-number>-<slug>`
 
-Repo-local worktree scratch directories（例如 `.worktrees/`、`worktrees/`、`spec-injector-worktrees/`）已被 ignore，避免本機容器變成 commit candidate。除非任務另有要求，canonical shared parent 仍是 `../spec-injector-worktrees`。不要 commit local worktree contents。
+Repo-local worktree scratch directories（例如 repo root 的 `.worktrees/`、`worktrees/`、`spec-injector-worktrees/`）已被 root-anchored ignore，避免本機容器變成 commit candidate，也避免隱藏 nested docs / fixtures。除非任務另有要求，canonical shared parent 仍是 `../spec-injector-worktrees`。不要 commit local worktree contents。
 
 Examples:
 

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -42,6 +42,22 @@ import {
 
 const UNREPLACED_TEMPLATE_PLACEHOLDER_PATTERN = /\{\{\s*[A-Za-z_][A-Za-z0-9_]*\s*\}\}|__[A-Z][A-Z0-9_]*__/;
 
+test('repo ignore policy keeps local worktree scratch directories untracked', async () => {
+  const gitignorePath = path.join(repoRoot, '.gitignore');
+  const workflowPath = path.join(repoRoot, 'docs', 'workflow.md');
+
+  const [gitignore, workflow] = await Promise.all([
+    fs.readFile(gitignorePath, 'utf8'),
+    fs.readFile(workflowPath, 'utf8'),
+  ]);
+
+  assert.match(gitignore, /^\.worktrees\/$/m);
+  assert.match(gitignore, /^worktrees\/$/m);
+  assert.match(gitignore, /^spec-injector-worktrees\/$/m);
+  assert.match(workflow, /Repo-local worktree scratch directories/);
+  assert.match(workflow, /不要 commit local worktree contents/);
+});
+
 async function captureConsoleOutput(fn: () => Promise<void>): Promise<{ stdout: string; stderr: string }> {
   const originalLog = console.log;
   const originalError = console.error;

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -51,9 +51,9 @@ test('repo ignore policy keeps local worktree scratch directories untracked', as
     fs.readFile(workflowPath, 'utf8'),
   ]);
 
-  assert.match(gitignore, /^\.worktrees\/$/m);
-  assert.match(gitignore, /^worktrees\/$/m);
-  assert.match(gitignore, /^spec-injector-worktrees\/$/m);
+  assert.match(gitignore, /^\/\.worktrees\/$/m);
+  assert.match(gitignore, /^\/worktrees\/$/m);
+  assert.match(gitignore, /^\/spec-injector-worktrees\/$/m);
   assert.match(workflow, /Repo-local worktree scratch directories/);
   assert.match(workflow, /不要 commit local worktree contents/);
 });


### PR DESCRIPTION
Closes #265

## Summary

- Add root-anchored repo-local ignore rules for `/.worktrees/`, `/worktrees/`, and `/spec-injector-worktrees/` scratch directories.
- Document that repo-local worktree scratch directories are ignored without hiding nested docs / fixtures.
- Add a regression test that protects the ignore policy and workflow doc note.

## Scope

- Root ignore policy for local worktree scratch directories.
- Workflow docs note for local scratch directories and commit boundaries.
- Regression coverage for the ignore policy.

## Non-goals

- Did not delete local `.worktrees/`.
- Did not clean branch / worktree.
- Did not change CLI behavior.
- Did not add generated output, private context, or `.spec-injector/` artifact.
- Did not touch downstream repos.

## Spec gate evidence

- spec gate status: pass
- spec evidence ref: https://github.com/Erick52106/spec-injector/issues/265#issuecomment-4529522466

## Delegation Execution Log

- routing evidence status: pass
- routing evidence ref: https://github.com/Erick52106/spec-injector/issues/265#issuecomment-4529522466
- delegation_outcome: completed
- worker_5_4 evidence: Chandrasekhar read-only exploration completed before implementation.
- controller_fallback: denied
- controller_fallback_reason: worker check completed; controller fallback was not used for implementation

## Finding disposition evidence

- finding disposition status: pass
- finding disposition ref: Codex P2 adopted in bc59ce37dd57e1fada42cde9dcd41958ace44777; CodeRabbit rate-limit comment classified noise / not applicable

## Tests / validation

- RED: `node --test --test-name-pattern "repo ignore policy" tests/cli.integration.test.ts` failed before implementation because `.worktrees/` was not ignored.
- `git check-ignore -v .worktrees/foo worktrees/foo spec-injector-worktrees/foo`
- `sh -c 'if git check-ignore -q docs/worktrees/foo; then printf "nested docs/worktrees/foo is unexpectedly ignored\\n"; exit 1; else printf "nested docs/worktrees/foo is not ignored\\n"; fi'`
- `node --test --test-name-pattern "repo ignore policy" tests/cli.integration.test.ts`
- `pnpm test` (268 tests: 266 pass, 2 skipped)
- `pnpm build`
- `git diff --check`

## Implementation Evidence

- Source of truth: #265
- AWP routing: `hybrid_awp`, task class `small_docs_template_test`
- Issue evidence comment: https://github.com/Erick52106/spec-injector/issues/265#issuecomment-4529522466
- Commit: bc59ce37dd57e1fada42cde9dcd41958ace44777

## Final merge gate

- latest head SHA: bc59ce37dd57e1fada42cde9dcd41958ace44777
- ready_to_merge: yes
