### PR TITLE
docs(workflow): freeze AWP baseline gate

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -387,7 +387,7 @@ These directions should get separate issues, tests, and corresponding docs updat
 - Workflow: [docs/workflow.md](docs/workflow.md)
 - Validation matrix and quality gates: [docs/validation.md](docs/validation.md)
 - Dogfood: [docs/dogfood.md](docs/dogfood.md)
-- AWP dogfood outcome ledger: [docs/awp-dogfood-outcome-ledger.md](docs/awp-dogfood-outcome-ledger.md)
+- AWP dogfood outcome ledger and AWP baseline freeze: [docs/awp-dogfood-outcome-ledger.md](docs/awp-dogfood-outcome-ledger.md)
 - Optional AWP delegation evidence manifest: [docs/awp-delegation-evidence-manifest.md](docs/awp-delegation-evidence-manifest.md)
 - Install / release strategy: [docs/release.md](docs/release.md)
 - AI workflow guides: [docs/workflows/README.md](docs/workflows/README.md)

--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ Important fields:
 - Workflow: [docs/workflow.md](docs/workflow.md)
 - Validation matrix and quality gates: [docs/validation.md](docs/validation.md)
 - Dogfood: [docs/dogfood.md](docs/dogfood.md)
-- AWP dogfood outcome ledger: [docs/awp-dogfood-outcome-ledger.md](docs/awp-dogfood-outcome-ledger.md)
+- AWP dogfood outcome ledger and AWP baseline freeze: [docs/awp-dogfood-outcome-ledger.md](docs/awp-dogfood-outcome-ledger.md)
 - Optional AWP delegation evidence manifest: [docs/awp-delegation-evidence-manifest.md](docs/awp-delegation-evidence-manifest.md)
 - Install / release strategy: [docs/release.md](docs/release.md)
 - AI workflow guides: [docs/workflows/README.md](docs/workflows/README.md)

--- a/docs/awp-dogfood-outcome-ledger.md
+++ b/docs/awp-dogfood-outcome-ledger.md
@@ -22,7 +22,7 @@
 
 freeze status: active.
 
-#258 freezes the current AWP baseline after #246, #247, and #249. Until the ledger has 至少 5 張真實 AWP PR samples, do not change baseline AWP workflow fields, Worker Profiles tables, `spec workflow-check` CLI flags, JSON schema, exit-code semantics, target repo PR templates, target repo Scope Police rules, or target repo AWP AGENTS sections for non-P0 reasons.
+Issue #258 freezes the current AWP baseline after #246, #247, and #249. Until the ledger has 至少 5 張真實 AWP PR samples, do not change baseline AWP workflow fields, Worker Profiles tables, `spec workflow-check` CLI flags, JSON schema, exit-code semantics, target repo PR templates, target repo Scope Police rules, or target repo AWP AGENTS sections for non-P0 reasons.
 
 P0 break-glass can bypass the sample gate only when a safety or correctness issue would otherwise mislead merge closeout or block all acceptable workarounds. Ordinary naming preferences, PR body formatting, single-PR review nits, theoretical session security models, or one-off workflow friction should stay in the ledger or a bounded follow-up issue.
 

--- a/docs/awp-dogfood-outcome-ledger.md
+++ b/docs/awp-dogfood-outcome-ledger.md
@@ -18,6 +18,28 @@
 
 在調整核心 AWP baseline 前，應先累積至少 3-5 張 target repo PR outcome sample。
 
+## #258 Freeze Gate
+
+freeze status: active.
+
+#258 freezes the current AWP baseline after #246, #247, and #249. Until the ledger has 至少 5 張真實 AWP PR samples, do not change baseline AWP workflow fields, Worker Profiles tables, `spec workflow-check` CLI flags, JSON schema, exit-code semantics, target repo PR templates, target repo Scope Police rules, or target repo AWP AGENTS sections for non-P0 reasons.
+
+P0 break-glass can bypass the sample gate only when a safety or correctness issue would otherwise mislead merge closeout or block all acceptable workarounds. Ordinary naming preferences, PR body formatting, single-PR review nits, theoretical session security models, or one-off workflow friction should stay in the ledger or a bounded follow-up issue.
+
+Freeze re-evaluation should use ledger data, including:
+
+- `false_blocker_count`
+- `evidence_missing_count`
+- `review_round_count`
+- `ci_rerun_count`
+- `total_diff_lines`
+- repeated workflow friction across repo / issue type
+- any real evidence of forged or misleading session / delegation evidence
+
+Do not change `spec workflow-check` CLI flags, JSON schema, or exit-code meaning from this freeze issue.
+
+Do not implement `spec session`, `workflow-check --session`, hooks, HMAC, external witness, GitHub App bot witness, branch protection required checks, hosted control plane, daemon, dashboard, auto-comment, or auto-merge from this freeze issue. If future evidence supports a v0.2 session artifact, open a separate implementation issue with target repo thin wiring, rollback criteria, migration notes, and explicit non-goals.
+
 未達樣本門檻前：
 
 - P0 blocker 可以立刻修。

--- a/docs/dogfood.md
+++ b/docs/dogfood.md
@@ -6,7 +6,7 @@ Dogfood 是用 `spec-injector` 處理真實 target repo issue，以驗證 contex
 
 Dogfood 不等於直接實作 target repo issue。它是一種觀察與校準流程。
 
-AWP / `spec workflow-check` target PR outcome 的跨 repo 回收欄位，請見 [AWP Dogfood Outcome Ledger](awp-dogfood-outcome-ledger.md)。該 ledger 用於累積 3-5 張真實 PR outcome 後再調整核心 AWP baseline；它不是 merge approval，也不要求 target repo PR body 塞完整 metrics。
+AWP / `spec workflow-check` target PR outcome 的跨 repo 回收欄位與 #258 freeze gate，請見 [AWP Dogfood Outcome Ledger](awp-dogfood-outcome-ledger.md)。該 ledger 用於累積至少 5 張真實 PR outcome 後再調整核心 AWP baseline；它不是 merge approval，也不要求 target repo PR body 塞完整 metrics。
 
 ## Reports
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -14,6 +14,8 @@ Issue / PR label taxonomy、visual hierarchy、combination rules、migration sta
 
 Autonomous Worker Profiles / Codex autonomous PR work 的 start-gate routing source of truth 見 [Hybrid AWP routing policy](hybrid-awp-routing-policy.md)。該 policy 只適用於有明確 autonomous routing signal 的 workflow；一般 human PR 或非 autonomous work 不應因缺少 AWP routing evidence 而 fail。
 
+核心 AWP baseline 變更受 [AWP Dogfood Outcome Ledger](awp-dogfood-outcome-ledger.md) 的 #258 freeze gate 控制。未累積至少 5 張真實 AWP PR outcome sample 前，除 P0 break-glass 外，不新增 session / hook / enforcement surface，也不更改 `spec workflow-check` flags 或 schema。
+
 若 autonomous workflow 有 start-gate routing evidence，可在 commit / merge 階段用 local file 傳入 `spec workflow-check --routing-evidence <path>`。該檢查只讀本地 PR body 與本地 routing JSON，驗證 status/ref、delegation log、Spark / ops evidence、5.4 worker evidence、explicit fallback reason 與 merge HEAD freshness；它不讀取或修改 GitHub remote state，也不要求 downstream Scope Police 解析完整 routing plan。
 
 Autonomous review follow-up 的 batching、freshness、duplicate collapse、root-cause escalation、patch budget 與 final closeout ledger source of truth 見 [AWP review triage gates](awp-review-triage-gates.md)。可用 `spec awp-review-check --repo . --evidence <path>` 檢查 local JSON evidence；該 checker 不讀寫 GitHub、不 resolve review threads、不 auto-fix、不 merge，也不要求 downstream Scope Police 解析完整 ledger。

--- a/tests/hybrid-awp-routing-policy.test.ts
+++ b/tests/hybrid-awp-routing-policy.test.ts
@@ -206,6 +206,42 @@ test('AWP dogfood outcome ledger remains linked from dogfood docs and README', a
   assert.match(englishReadme, /\[docs\/awp-dogfood-outcome-ledger\.md\]\(docs\/awp-dogfood-outcome-ledger\.md\)/);
 });
 
+test('AWP baseline freeze gate remains linked and design-only', async () => {
+  const ledgerPath = path.join(repoRoot, 'docs', 'awp-dogfood-outcome-ledger.md');
+  const dogfoodPath = path.join(repoRoot, 'docs', 'dogfood.md');
+  const workflowPath = path.join(repoRoot, 'docs', 'workflow.md');
+  const readmePath = path.join(repoRoot, 'README.md');
+  const englishReadmePath = path.join(repoRoot, 'README.en.md');
+
+  const [ledger, dogfood, workflow, readme, englishReadme] = await Promise.all([
+    fs.readFile(ledgerPath, 'utf8'),
+    fs.readFile(dogfoodPath, 'utf8'),
+    fs.readFile(workflowPath, 'utf8'),
+    fs.readFile(readmePath, 'utf8'),
+    fs.readFile(englishReadmePath, 'utf8'),
+  ]);
+
+  assert.match(ledger, /#258 freeze gate/i);
+  assert.match(ledger, /freeze status: active/i);
+  assert.match(ledger, /至少 5 張真實 AWP PR/);
+  assert.match(ledger, /false_blocker_count/);
+  assert.match(ledger, /evidence_missing_count/);
+  assert.match(ledger, /review_round_count/);
+  assert.match(ledger, /ci_rerun_count/);
+  assert.match(ledger, /total_diff_lines/);
+  assert.match(ledger, /P0 break-glass/i);
+  assert.match(ledger, /Do not implement `spec session`/);
+  assert.match(ledger, /Do not change `spec workflow-check` CLI flags/);
+  assert.match(ledger, /#246/);
+  assert.match(ledger, /#247/);
+  assert.match(ledger, /#249/);
+
+  assert.match(dogfood, /#258 freeze gate/i);
+  assert.match(workflow, /#258 freeze gate/i);
+  assert.match(readme, /AWP baseline freeze/i);
+  assert.match(englishReadme, /AWP baseline freeze/i);
+});
+
 test('third brownfield dogfood report remains indexed with safety and caveat evidence', async () => {
   const dogfoodIndexPath = path.join(repoRoot, 'docs', 'dogfood.md');
   const reportPath = path.join(repoRoot, 'docs', 'dogfood', 'hono-2026-05-14.md');


### PR DESCRIPTION
Closes #258

## Summary

- Record the #258 AWP baseline freeze gate in the existing dogfood outcome ledger instead of adding a new workflow surface.
- Point workflow, dogfood docs, and README doc maps at the freeze gate.
- Add a docs regression test that protects the freeze gate, sample threshold, P0 break-glass, and design-only non-goals.

## Scope

- AWP dogfood outcome ledger freeze gate.
- Workflow/dogfood/README links to the existing ledger.
- Docs-only regression coverage.

## Non-goals

- Did not implement `spec session`.
- Did not add `workflow-check --session`.
- Did not change `spec workflow-check` CLI flags, JSON schema, or exit-code meaning.
- Did not change tachigo / tachiya PR templates, Scope Police rules, or AGENTS sections.
- Did not add hooks, HMAC, external witness, branch protection checks, hosted control plane, daemon, dashboard, auto-comment, or auto-merge.

## Spec gate evidence

- spec gate status: pass
- spec evidence ref: https://github.com/Erick52106/spec-injector/issues/258#issuecomment-4529552404

## Delegation Execution Log

- routing evidence status: pass
- routing evidence ref: https://github.com/Erick52106/spec-injector/issues/258#issuecomment-4529552404
- delegation_outcome: completed
- worker_5_4 evidence: Fermat read-only exploration completed before implementation and recommended reusing the existing dogfood ledger instead of adding a new docs surface.
- controller_fallback: denied
- controller_fallback_reason: worker check completed; controller fallback was not used for implementation

## Finding disposition evidence

- finding disposition status: pass
- finding disposition ref: CodeRabbit nit adopted in ddb8e602e24723ed0455accb950d035b415c7ef1

## Tests / validation

- RED: `node --test --test-name-pattern "AWP baseline freeze" tests/hybrid-awp-routing-policy.test.ts` failed before implementation because the #258 freeze gate was not documented.
- `node --test --test-name-pattern "AWP baseline freeze" tests/hybrid-awp-routing-policy.test.ts`
- `node --test tests/hybrid-awp-routing-policy.test.ts`
- `pnpm build`
- `pnpm test` (269 tests: 267 pass, 2 skipped)
- `git diff --check`

## Implementation Evidence

- Source of truth: #258
- AWP routing: `hybrid_awp`, task class `design_docs_regression`
- Issue evidence comment: https://github.com/Erick52106/spec-injector/issues/258#issuecomment-4529552404
- Commit: ddb8e602e24723ed0455accb950d035b415c7ef1

## Final merge gate

- latest head SHA: ddb8e602e24723ed0455accb950d035b415c7ef1
- ready_to_merge: yes
