### PR TITLE
feat(plan): detect Markdown link issue paths

### DIFF
--- a/src/docs/finder.ts
+++ b/src/docs/finder.ts
@@ -201,6 +201,12 @@ function collectExplicitPathCandidates(body: string): string[] {
     if (normalized) candidates.push({ index: match.index ?? 0, path: normalized });
   }
 
+  for (const match of body.matchAll(/\[([^\]\n]+)\]\([^\)\n]+\)/g)) {
+    if (match.index !== undefined && body[match.index - 1] === '!') continue;
+    const normalized = normalizeExplicitPathCandidate(match[1]);
+    if (normalized) candidates.push({ index: match.index ?? 0, path: normalized });
+  }
+
   let offset = 0;
   for (const line of body.split('\n')) {
     const normalized = normalizeBulletPathCandidate(line);

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -5875,6 +5875,42 @@ test('spec plan includes issue-mentioned source file paths in prompt and full ou
   assert.match(fullResult.stdout, /sources:\s*3/);
 });
 
+test('spec plan treats Markdown link labels as issue-mentioned repo paths', async (t) => {
+  const fixture = await createExplicitPathPlanFixture(t, {
+    issueNumber: 268,
+    title: 'Extract Markdown link issue-mentioned repo paths',
+    bodyLines: [
+      'Relevant linked references:',
+      '- [apps/dashboard/src/providers/dataProvider.ts](https://github.com/example/repo/blob/main/apps/dashboard/src/providers/dataProvider.ts)',
+      '- [docs/architecture.md](docs/architecture.md)',
+      '- [external API](https://example.com/src/external-api.ts)',
+      '- [docs/architecture.md#anchor](docs/architecture.md#anchor)',
+    ],
+    repoFiles: {
+      'apps/dashboard/src/providers/dataProvider.ts': 'export const provider = "MARKDOWN_LINK_SOURCE_SENTINEL";\n',
+      'docs/architecture.md': '# Architecture\n\nMARKDOWN_LINK_DOC_SENTINEL\n',
+    },
+  });
+
+  const promptResult = await runSpec(['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run', '--format', 'prompt'], { env: fixture.env });
+  const fullResult = await runSpec(['plan', fixture.issueUrl, '--repo', fixture.repoDir, '--dry-run'], { env: fixture.env });
+
+  assert.equal(promptResult.code, 0, promptResult.stderr);
+  assert.equal(fullResult.code, 0, fullResult.stderr);
+
+  const promptIssueDocs = sectionBetween(promptResult.stdout, '### Issue-Mentioned Docs', '### Issue-Mentioned Source Files');
+  const promptIssueSources = sectionBetween(promptResult.stdout, '### Issue-Mentioned Source Files', '### Auto-Discovered Docs');
+
+  assert.match(promptIssueDocs, /`docs\/architecture\.md` — issue-mentioned; mentioned in issue/);
+  assert.match(promptIssueSources, /`apps\/dashboard\/src\/providers\/dataProvider\.ts` — issue-mentioned; mentioned in issue/);
+  assert.doesNotMatch(promptResult.stdout, /src\/external-api\.ts/);
+  assert.doesNotMatch(promptResult.stdout, /docs\/architecture\.md#anchor/);
+  assert.match(fullResult.stdout, /### docs\/architecture\.md\n\n_source: issue-mentioned; mentioned in issue_/);
+  assert.match(fullResult.stdout, /MARKDOWN_LINK_DOC_SENTINEL/);
+  assert.match(fullResult.stdout, /### apps\/dashboard\/src\/providers\/dataProvider\.ts\n\n_source: issue-mentioned; mentioned in issue_/);
+  assert.match(fullResult.stdout, /MARKDOWN_LINK_SOURCE_SENTINEL/);
+});
+
 test('spec plan includes issue-mentioned docs and de-dupes with always_read', async (t) => {
   const fixture = await createExplicitPathPlanFixture(t, {
     issueNumber: 81,


### PR DESCRIPTION
Closes #268

## Summary

- 讓 `spec plan` 從 Markdown link label 擷取 repo-relative file path，並標示為 issue-mentioned reference。
- 保留既有 normalization 安全邊界，不從 external URL target、anchor、absolute path 或 traversal path 產生 repo reference。
- 加 regression 覆蓋 Markdown link docs/source 進入 prompt/full output。

## Scope

- Touches explicit issue-mentioned path extraction in `src/docs/finder.ts`.
- Adds CLI integration coverage in `tests/cli.integration.test.ts`.

## Tests / validation

- `pnpm build && node --test --test-name-pattern "Markdown link" tests/cli.integration.test.ts`：pass（1 pass / 0 fail）
- `node --test --test-name-pattern "issue-mentioned|Markdown link|ignores URLs" tests/cli.integration.test.ts`：pass（8 pass / 0 fail）
- `pnpm build && node --test tests/cli.integration.test.ts`：pass（219 pass / 0 fail）
- `pnpm test`：pass（270 tests；268 pass / 2 skip / 0 fail）
- `pnpm build`：pass
- `git diff --check`：pass

## Spec gate evidence

- spec gate status: pass
- spec evidence ref: https://github.com/Erick52106/spec-injector/issues/268#issuecomment-4529744128
- routing evidence status: pass
- routing evidence ref: https://github.com/Erick52106/spec-injector/issues/268#issuecomment-4529744128
- finding disposition status: pass

## Implementation Evidence

- issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/268#issuecomment-4529744128
- commit: c019ad691c260a9bf8584816d716e5343b85fecb
- AWP routing: Hybrid AWP with Explicit Fallback Gate
- worker dispatch evidence:
  - Gauss (`019e5b6c-a6d8-76d3-8bfd-2dfd1b4de4e6`) read-only scan recommended this Layer 1 precision issue.
  - Noether (`019e5b6d-1c3b-7b80-894a-c6b45121b99b`) read-only scan recommended a separate maintainability candidate, intentionally not mixed into this PR.
  - Anscombe (`019e5b72-5ef5-7e42-a4d4-723138fb2101`) read-only AWP review approved the diff with no adopted fixes.

## Review closeout / final merge gate evidence

- CodeRabbit walkthrough: reviewed; no actionable inline findings.
- CodeRabbit Docstring Coverage warning: not adopted / noise. This repo is not docstring-gated, existing style does not require docstrings for small internal helpers, and adding docstring-only churn would be outside #268.
- Review threads: 0 unresolved.
- Checks: build pass; CodeRabbit pass.

## Final merge gate

- latest head SHA: c019ad691c260a9bf8584816d716e5343b85fecb
- ready_to_merge: yes

## Non-goals

- No `spec workflow-check` / frozen AWP baseline changes.
- No CLI flag or output schema changes.
- No hosted control plane, daemon, dashboard, auto-merge, auto-comment, or downstream repo mutation.
- No target repo generated output or private context committed.

## Scope guard confirmation

All code changes are limited to the source issue scope and referenced files.