### PR TITLE
fix(config): reject invalid discovery limits

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -92,6 +92,13 @@ function requireStringArray(val: unknown, field: string): string[] {
   return val as string[];
 }
 
+function requireNonNegativeInteger(val: unknown, field: string): number {
+  if (typeof val !== 'number' || !Number.isInteger(val) || val < 0) {
+    throw new Error(`${field} must be a non-negative integer`);
+  }
+  return val;
+}
+
 function parseAndValidateConfig(text: string, filePath: string): SpecConfig {
   const raw = JSON.parse(text) as Record<string, unknown>;
 
@@ -139,8 +146,10 @@ function parseAndValidateConfig(text: string, filePath: string): SpecConfig {
       docs: d['docs'] !== undefined ? requireStringArray(d['docs'], 'discovery.docs') : undefined,
       source: d['source'] !== undefined ? requireStringArray(d['source'], 'discovery.source') : undefined,
       exclude: d['exclude'] !== undefined ? requireStringArray(d['exclude'], 'discovery.exclude') : undefined,
-      max_docs: typeof d['max_docs'] === 'number' ? d['max_docs'] : undefined,
-      max_source_files: typeof d['max_source_files'] === 'number' ? d['max_source_files'] : undefined,
+      max_docs: d['max_docs'] !== undefined ? requireNonNegativeInteger(d['max_docs'], 'discovery.max_docs') : undefined,
+      max_source_files: d['max_source_files'] !== undefined
+        ? requireNonNegativeInteger(d['max_source_files'], 'discovery.max_source_files')
+        : undefined,
     };
   }
 

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -4852,6 +4852,22 @@ test('spec validate rejects malformed discovery.exclude values', async (t) => {
   assertNoRawStackTrace(result);
 });
 
+test('spec validate rejects invalid discovery limit values', async (t) => {
+  const repoDir = await createTempRepo(t);
+  await writeConfig(repoDir, {
+    version: 2,
+    discovery: {
+      max_docs: '5',
+    },
+  });
+
+  const result = await runSpec(['validate', '--repo', repoDir]);
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stderr, /discovery\.max_docs must be a non-negative integer/i);
+  assertNoRawStackTrace(result);
+});
+
 test('spec validate rejects malformed guardrails values and missing required fields', async (t) => {
   const repoDir = await createTempRepo(t);
   await writeConfig(repoDir, {

--- a/tests/config/loader.test.ts
+++ b/tests/config/loader.test.ts
@@ -96,6 +96,49 @@ test('loadConfig reports invalid external config schema errors with config path'
   assert.deepEqual(await fs.readdir(targetRepo), []);
 });
 
+test('loadConfig rejects invalid discovery limit values clearly', async (t) => {
+  const targetRepo = await createTempDir(t, 'invalid-discovery-limit-target-repo');
+  const configPath = path.join(await createTempDir(t, 'invalid-discovery-limit-config'), 'config.json');
+
+  for (const [field, value] of [
+    ['max_docs', '5'],
+    ['max_docs', -1],
+    ['max_source_files', 1.5],
+  ] as const) {
+    await writeJson(configPath, {
+      version: 2,
+      discovery: {
+        [field]: value,
+      },
+    });
+
+    await assert.rejects(
+      () => loadConfig(targetRepo, { configPath }),
+      new RegExp(`Invalid config\\.json at .*config\\.json: discovery\\.${field} must be a non-negative integer`)
+    );
+  }
+
+  assert.deepEqual(await fs.readdir(targetRepo), []);
+});
+
+test('loadConfig preserves zero discovery limits', async (t) => {
+  const targetRepo = await createTempDir(t, 'zero-discovery-limit-target-repo');
+  const configPath = path.join(await createTempDir(t, 'zero-discovery-limit-config'), 'config.json');
+  await writeJson(configPath, {
+    version: 2,
+    discovery: {
+      max_docs: 0,
+      max_source_files: 0,
+    },
+  });
+
+  const config = await loadConfig(targetRepo, { configPath });
+
+  assert.equal(config.specConfig.discovery?.max_docs, 0);
+  assert.equal(config.specConfig.discovery?.max_source_files, 0);
+  assert.deepEqual(await fs.readdir(targetRepo), []);
+});
+
 test('loadConfig rejects legacy v1 rules files as non-current config', async (t) => {
   const targetRepo = await createTempDir(t, 'legacy-target-repo');
   const rulesPath = path.join(await createTempDir(t, 'legacy-config'), 'rules.json');


### PR DESCRIPTION
Closes #270

## Summary

- 明確驗證 `discovery.max_docs` 與 `discovery.max_source_files`。
- 拒絕字串、負數與非整數，避免 typo 被靜默當成預設值。
- 保留 `0` 作為有效非負整數，讓使用者可明確關閉該類 discovery。

## Scope

- Updates config schema validation in `src/config/loader.ts`.
- Adds loader regressions and a CLI `spec validate` regression.

## Tests / validation

- `pnpm build && node --test tests/config/loader.test.ts && node --test --test-name-pattern "invalid discovery limit" tests/cli.integration.test.ts`：pass（loader 6 pass；CLI 1 pass）
- `pnpm build && node --test tests/config/loader.test.ts tests/cli.integration.test.ts`：pass（226 pass / 0 fail）
- `pnpm test`：pass（273 tests；271 pass / 2 skip / 0 fail）
- `pnpm build`：pass
- `git diff --check`：pass

## Spec gate evidence

- spec gate status: pass
- spec evidence ref: https://github.com/Erick52106/spec-injector/issues/270#issuecomment-4529770342
- routing evidence status: pass
- routing evidence ref: https://github.com/Erick52106/spec-injector/issues/270#issuecomment-4529770342
- finding disposition status: pass

## Implementation Evidence

- issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/270#issuecomment-4529770342
- commit: f8c5d0cc7c7f3be1974238208aa0f850c8bd42c1
- AWP routing: Hybrid AWP with Explicit Fallback Gate
- worker dispatch evidence:
  - Gauss (`019e5b6c-a6d8-76d3-8bfd-2dfd1b4de4e6`) originally suggested this Layer 1 config hygiene candidate.
  - Hooke (`019e5b7d-4008-7f43-9c5b-181257ce7d23`) read-only AWP review approved the diff and confirmed `0` semantics remain valid.

## Review closeout / final merge gate evidence

- CodeRabbit status: pass / review skipped due rate limit; no actionable findings were posted.
- CodeRabbit rate-limit comment: not adopted / not applicable as a code finding; no requested code change.
- Review threads: 0 unresolved.
- Checks: build pass; CodeRabbit status pass.
- AWP worker review: Hooke approved the diff with no adopted fixes.

## Final merge gate

- latest head SHA: f8c5d0cc7c7f3be1974238208aa0f850c8bd42c1
- ready_to_merge: yes

## Non-goals

- No `spec plan` output schema changes.
- No discovery ranking / scoring / snippet changes.
- No `spec workflow-check` / frozen AWP baseline changes.
- No downstream repo or target repo config mutation.

## Scope guard confirmation

All code changes are limited to the source issue scope and referenced files.