### PR TITLE
docs(workflow): align AWP sample threshold wording

### DIFF
--- a/docs/awp-dogfood-outcome-ledger.md
+++ b/docs/awp-dogfood-outcome-ledger.md
@@ -16,7 +16,7 @@
 
 ## Sample Threshold
 
-在調整核心 AWP baseline 前，應先累積至少 3-5 張 target repo PR outcome sample。
+在調整核心 AWP baseline 前，應先累積至少 5 張 target repo PR outcome sample。
 
 ## #258 Freeze Gate
 
@@ -113,7 +113,7 @@ Outcome analysis must separate the source of friction:
 
 ## P0 Must-Fix Signals
 
-下列情況可以在未達 3-5 sample threshold 前建立或處理 P0/P1 fix issue：
+下列情況可以在未達至少 5 張 sample threshold 前建立或處理 P0/P1 fix issue：
 
 - `spec workflow-check` 產生 false pass，導致 unsafe merge gate evidence。
 - 工具嘗試 GitHub mutation、target repo mutation、auto-merge、auto-comment、或寫入 private/generated output。
@@ -133,7 +133,7 @@ Outcome analysis must separate the source of friction:
 - Manual fallback wording 可以更清楚，但沒有 false pass。
 - AWP ledgers 太長、太短、或欄位命名不順，但 downstream 仍能完成 closeout。
 
-這些可以累積 3-5 sample 後一起校準。
+這些可以累積至少 5 張 sample 後一起校準。
 
 ## Baseline Change Gate
 

--- a/tests/hybrid-awp-routing-policy.test.ts
+++ b/tests/hybrid-awp-routing-policy.test.ts
@@ -189,7 +189,8 @@ test('AWP dogfood outcome ledger remains linked from dogfood docs and README', a
   ]);
 
   assert.match(ledger, /AWP Dogfood Outcome Ledger/);
-  assert.match(ledger, /至少 3-5/);
+  assert.match(ledger, /至少 5 張 target repo PR outcome sample/);
+  assert.doesNotMatch(ledger, /3-5 sample|3-5 張|3-5 sample threshold/);
   assert.match(ledger, /missed worker/i);
   assert.match(ledger, /over-delegated worker/i);
   assert.match(ledger, /workflow-check caught real issue/i);


### PR DESCRIPTION
Closes #274

## Summary
- 將 AWP dogfood outcome ledger 的 baseline sample threshold wording 從舊的 `3-5` 對齊為 freeze 後的 `至少 5 張 target repo PR outcome sample`。
- 更新 policy regression test，避免文件再出現 stale `3-5` threshold wording。
- 僅調整 docs/test wording，沒有 runtime、CLI flag、schema 或 target repo contract 變更。

## Tests / validation
- `pnpm build && node --test tests/hybrid-awp-routing-policy.test.ts`：PASS，12 tests。
- `pnpm test`：PASS，273 tests / 271 pass / 2 skipped。
- `pnpm build`：PASS。
- `git diff --check`：PASS。
- `rg -n "3-5" docs/awp-dogfood-outcome-ledger.md tests/hybrid-awp-routing-policy.test.ts`：只剩 regression test 的 negative regex。

## Spec gate evidence
- spec gate status: pass
- spec evidence ref: https://github.com/Erick52106/spec-injector/issues/274#issuecomment-4529821270
- routing evidence status: pass
- routing evidence ref: controller-direct small docs/test consistency fix with explicit fallback gate; read-only AWP review worker Raman approved before commit.
- finding disposition status: pass
- finding disposition ref: CodeRabbit status success but review was skipped by rate limit, with no actionable findings posted; GraphQL reviewThreads returned 0 nodes; AWP worker review approved.

## Implementation Evidence
- Source issue: #274
- issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/274#issuecomment-4529821270
- commit hash: `b3c9472434f077f7e63657669cbeb75a592df6b6`
- AWP routing: controller-direct small docs/test consistency fix with explicit fallback gate; read-only AWP review worker Raman approved before commit.

## Non-goals
- 不做 `workflow-check` runtime / flags / JSON schema 變更。
- 不做 session hook、enforcement、daemon、hosted control plane 或 auto-merge logic。
- 不修改 target repo wiring 或 downstream repo 檔案。
- 不調整 core AWP baseline policy，只修正 ledger wording 與 regression coverage。

## Scope guard confirmation
- Allowed files: `docs/awp-dogfood-outcome-ledger.md`, `tests/hybrid-awp-routing-policy.test.ts`。
- No runtime/source code behavior changed.

## Review closeout / final merge gate evidence
- CI/checks: `build` pass at latest head; `CodeRabbit` status pass, review skipped by rate limit with no actionable findings posted.
- Review threads: GraphQL `reviewThreads` returned 0 nodes.
- `spec evidence-check`: PASS，13 pass / 0 warning / 0 fail / 0 needs-human-review。
- User authorization: explicit autonomous merge authorization in this Codex thread.

## Final merge gate
- latest head SHA: b3c9472434f077f7e63657669cbeb75a592df6b6
- ready_to_merge: yes