### PR TITLE
feat(discovery): accept titled Markdown link targets

### DIFF
--- a/src/docs/finder.ts
+++ b/src/docs/finder.ts
@@ -310,10 +310,28 @@ function normalizeExplicitPathCandidate(candidate: string): string | null {
 }
 
 function normalizeMarkdownLinkTargetPathCandidate(candidate: string): string | null {
-  const normalized = normalizeExplicitPathCandidate(candidate);
+  const target = extractMarkdownLinkDestination(candidate);
+  if (!target) return null;
+
+  const normalized = normalizeExplicitPathCandidate(target);
   if (!normalized) return null;
   if (normalized.startsWith('api/')) return null;
   return normalized;
+}
+
+function extractMarkdownLinkDestination(candidate: string): string | null {
+  const trimmed = candidate.trim();
+  if (trimmed.length === 0) return null;
+
+  const angleMatch = trimmed.match(/^<([^<>\s]+)>(?:\s+(["'])([^"']*)\2)?$/);
+  if (angleMatch) return angleMatch[1];
+  if (trimmed.startsWith('<') || trimmed.endsWith('>')) return null;
+
+  const titleMatch = trimmed.match(/^([^\s]+)\s+(["'])([^"']*)\2$/);
+  if (titleMatch) return titleMatch[1];
+
+  if (/\s/.test(trimmed)) return null;
+  return trimmed;
 }
 
 function hasRecognizedRepoFileShape(filePath: string): boolean {

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -5356,6 +5356,10 @@ test('spec plan treats Markdown link labels and repo-relative targets as issue-m
       'Relevant linked references:',
       '- [apps/dashboard/src/providers/dataProvider.ts](https://github.com/example/repo/blob/main/apps/dashboard/src/providers/dataProvider.ts)',
       '- [Architecture](docs/architecture.md)',
+      '- [Angle wrapped doc](<docs/angle-reference.md>)',
+      '- [Angle wrapped titled doc](<docs/angle-title-reference.md> "Angle title")',
+      '- [Double titled doc](docs/double-title-reference.md "Double title")',
+      "- [Single titled doc](docs/single-title-reference.md 'Single title')",
       '- [external API](https://example.com/src/external-api.ts)',
       '- [Anchor only](#local-anchor)',
       '- [Anchored doc](docs/architecture.md#anchor)',
@@ -5364,10 +5368,16 @@ test('spec plan treats Markdown link labels and repo-relative targets as issue-m
       '- [Traversal](../outside.md)',
       '- [Route-like API](/api/specs/openapi.json)',
       '- [Relative route-like API](api/specs/openapi.json)',
+      '- [Malformed angle](<docs/malformed-angle.md)',
+      '- [Malformed title](docs/malformed-title.md "unterminated title)',
     ],
     repoFiles: {
       'apps/dashboard/src/providers/dataProvider.ts': 'export const provider = "MARKDOWN_LINK_SOURCE_SENTINEL";\n',
       'docs/architecture.md': '# Architecture\n\nMARKDOWN_LINK_DOC_SENTINEL\n',
+      'docs/angle-reference.md': '# Angle Reference\n\nMARKDOWN_LINK_ANGLE_DOC_SENTINEL\n',
+      'docs/angle-title-reference.md': '# Angle Title Reference\n\nMARKDOWN_LINK_ANGLE_TITLE_DOC_SENTINEL\n',
+      'docs/double-title-reference.md': '# Double Title Reference\n\nMARKDOWN_LINK_DOUBLE_TITLE_DOC_SENTINEL\n',
+      'docs/single-title-reference.md': '# Single Title Reference\n\nMARKDOWN_LINK_SINGLE_TITLE_DOC_SENTINEL\n',
     },
   });
 
@@ -5381,14 +5391,28 @@ test('spec plan treats Markdown link labels and repo-relative targets as issue-m
   const promptIssueSources = sectionBetween(promptResult.stdout, '### Issue-Mentioned Source Files', '### Auto-Discovered Docs');
 
   assert.match(promptIssueDocs, /`docs\/architecture\.md` — issue-mentioned; mentioned in issue/);
+  assert.match(promptIssueDocs, /`docs\/angle-reference\.md` — issue-mentioned; mentioned in issue/);
+  assert.match(promptIssueDocs, /`docs\/angle-title-reference\.md` — issue-mentioned; mentioned in issue/);
+  assert.match(promptIssueDocs, /`docs\/double-title-reference\.md` — issue-mentioned; mentioned in issue/);
+  assert.match(promptIssueDocs, /`docs\/single-title-reference\.md` — issue-mentioned; mentioned in issue/);
   assert.match(promptIssueSources, /`apps\/dashboard\/src\/providers\/dataProvider\.ts` — issue-mentioned; mentioned in issue/);
   assert.doesNotMatch(promptResult.stdout, /src\/external-api\.ts/);
   assert.doesNotMatch(promptResult.stdout, /docs\/architecture\.md#anchor/);
   assert.doesNotMatch(promptResult.stdout, /docs\/absolute\.md/);
   assert.doesNotMatch(promptResult.stdout, /outside\.md/);
   assert.doesNotMatch(promptResult.stdout, /api\/specs\/openapi\.json/);
+  assert.doesNotMatch(promptResult.stdout, /docs\/malformed-angle\.md/);
+  assert.doesNotMatch(promptResult.stdout, /docs\/malformed-title\.md/);
   assert.match(fullResult.stdout, /### docs\/architecture\.md\n\n_source: issue-mentioned; mentioned in issue_/);
   assert.match(fullResult.stdout, /MARKDOWN_LINK_DOC_SENTINEL/);
+  assert.match(fullResult.stdout, /### docs\/angle-reference\.md\n\n_source: issue-mentioned; mentioned in issue_/);
+  assert.match(fullResult.stdout, /MARKDOWN_LINK_ANGLE_DOC_SENTINEL/);
+  assert.match(fullResult.stdout, /### docs\/angle-title-reference\.md\n\n_source: issue-mentioned; mentioned in issue_/);
+  assert.match(fullResult.stdout, /MARKDOWN_LINK_ANGLE_TITLE_DOC_SENTINEL/);
+  assert.match(fullResult.stdout, /### docs\/double-title-reference\.md\n\n_source: issue-mentioned; mentioned in issue_/);
+  assert.match(fullResult.stdout, /MARKDOWN_LINK_DOUBLE_TITLE_DOC_SENTINEL/);
+  assert.match(fullResult.stdout, /### docs\/single-title-reference\.md\n\n_source: issue-mentioned; mentioned in issue_/);
+  assert.match(fullResult.stdout, /MARKDOWN_LINK_SINGLE_TITLE_DOC_SENTINEL/);
   assert.match(fullResult.stdout, /### apps\/dashboard\/src\/providers\/dataProvider\.ts\n\n_source: issue-mentioned; mentioned in issue_/);
   assert.match(fullResult.stdout, /MARKDOWN_LINK_SOURCE_SENTINEL/);
 });


### PR DESCRIPTION
Closes #278

## Summary
- Support Markdown link destinations with angle wrappers and optional quoted titles, including `[Docs](<docs/a.md>)`, `[Docs](docs/a.md "title")`, and `[Docs](<docs/a.md> "title")`.
- Preserve #276 plain target extraction and existing link-label path extraction.
- Keep malformed, external, anchor, absolute, traversal, and `api/` route-like targets ignored.

## Tests / validation
- `pnpm build && node --test tests/cli.integration.test.ts --test-name-pattern "Markdown link labels"`：PASS，204 tests / 204 pass。
- `pnpm test`：PASS，273 tests / 271 pass / 2 skipped。
- `pnpm build`：PASS。
- `git diff --check`：PASS。

## Spec gate evidence
- spec gate status: pass
- spec evidence ref: https://github.com/Erick52106/spec-injector/issues/278#issuecomment-4529870959
- routing evidence status: pass
- routing evidence ref: Hybrid AWP worker Erdos implemented bounded parser/test patch; controller reviewed diff, added angle-plus-title coverage, and reran validation.
- finding disposition status: pass
- finding disposition ref: CodeRabbit status success but review was skipped by rate limit, with no actionable findings posted; GraphQL reviewThreads returned 0 nodes; controller diff review found and fixed angle-plus-title coverage before commit.

## Implementation Evidence
- Source issue: #278
- issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/278#issuecomment-4529870959
- commit hash: `3ad1329d7ddba5c3ae4c18c0b7b624f92dcf6488`
- AWP routing: Hybrid AWP worker implementation with controller refinement, validation, and merge gate ownership.

## Non-goals
- 不引入 full CommonMark parser。
- 不支援 nested parentheses。
- 不改 GitHub API 行為。
- 不改 task package template wording。
- 不修改 target repo 或 downstream wiring。
- 不做 hosted control plane、daemon、dashboard 或 agent orchestration 變更。

## Scope guard confirmation
- Allowed files: `src/docs/finder.ts`, `tests/cli.integration.test.ts`。
- No generated output or private context committed.

## Review closeout / final merge gate evidence
- CI/checks: `build` pass at latest head; `CodeRabbit` status pass, review skipped by rate limit with no actionable findings posted.
- Review threads: GraphQL `reviewThreads` returned 0 nodes.
- `spec evidence-check`: PASS，13 pass / 0 warning / 0 fail / 0 needs-human-review。
- User authorization: explicit autonomous merge authorization in this Codex thread.

## Final merge gate
- latest head SHA: 3ad1329d7ddba5c3ae4c18c0b7b624f92dcf6488
- ready_to_merge: yes