### PR TITLE
feat(discovery): include GEMINI.md fixed docs

### DIFF
--- a/src/docs/finder.ts
+++ b/src/docs/finder.ts
@@ -348,7 +348,7 @@ async function gatherCandidates(repoPath: string, exclude: Set<string>): Promise
   const candidates: string[] = [];
 
   // Fixed high-value files
-  for (const fixed of ['README.md', 'CLAUDE.md', 'AGENTS.md']) {
+  for (const fixed of ['README.md', 'CLAUDE.md', 'AGENTS.md', 'GEMINI.md']) {
     if (!isPlanDiscoveryExcluded(fixed, exclude) && fs.existsSync(path.join(repoPath, fixed))) {
       candidates.push(fixed);
     }

--- a/tests/docs-finder.test.ts
+++ b/tests/docs-finder.test.ts
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { discoverRelevantDocs } from '../dist/docs/finder.js';
+import { createTempRepo, writeRepoFiles } from './helpers/fixtures.ts';
+
+test('auto relevant docs discovery includes GEMINI.md fixed candidate unless excluded', async (t) => {
+  const repoDir = await createTempRepo(t);
+  const issue = {
+    number: 280,
+    title: 'Refresh Gemini worker routing docs',
+    body: 'Gemini worker routing should be available to planning context.',
+    labels: [],
+    url: 'https://github.com/Erick52106/spec-injector/issues/280',
+    state: 'OPEN',
+  };
+
+  await writeRepoFiles(repoDir, {
+    'GEMINI.md': '# Gemini Worker Routing\n\nGemini worker routing guidance for bounded implementation.\n',
+  });
+
+  const discovered = await discoverRelevantDocs(issue, repoDir, new Set(), 5);
+  assert.equal(discovered.some((doc) => doc.filePath === 'GEMINI.md'), true);
+
+  const excluded = await discoverRelevantDocs(issue, repoDir, new Set(['GEMINI.md']), 5);
+  assert.equal(excluded.some((doc) => doc.filePath === 'GEMINI.md'), false);
+});


### PR DESCRIPTION
Closes #280

## Summary
- Include `GEMINI.md` in fixed high-value relevant-doc candidates alongside `README.md`, `CLAUDE.md`, and `AGENTS.md`.
- Add direct discovery regression coverage for inclusion and `discovery.exclude` behavior.
- Keep scoring, max docs, and deterministic ordering behavior unchanged.

## Tests / validation
- `pnpm build && node --test tests/docs-finder.test.ts`：PASS，1 test。
- `pnpm test`：PASS，274 tests / 272 pass / 2 skipped。
- `pnpm build`：PASS。
- `git diff --check`：PASS。

## Spec gate evidence
- spec gate status: pass
- spec evidence ref: https://github.com/Erick52106/spec-injector/issues/280#issuecomment-4529890823
- routing evidence status: pass
- routing evidence ref: Hybrid AWP worker Feynman implemented bounded discovery/test patch; controller reviewed diff and reran full validation.
- finding disposition status: pass
- finding disposition ref: CodeRabbit Docstring Coverage pre-merge warning classified not adopted / noise: repo does not enforce docstring coverage, this PR only changes a private fixed-candidate list and adds tests, and adding docstrings would be unrelated scope noise; GraphQL reviewThreads returned 0 nodes.

## Implementation Evidence
- Source issue: #280
- issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/280#issuecomment-4529890823
- commit hash: `6491668a3f9ee452eb9ab3e8deae8e8266fba3d7`
- AWP routing: Hybrid AWP worker implementation with controller validation and merge gate ownership.

## Review finding assessment
- CodeRabbit Docstring Coverage warning: not adopted / noise. Rationale: repository validation does not include docstring coverage, the changed production line only extends an internal fixed candidate list, and adding docstrings would be unrelated to #280 scope.
- CodeRabbit walkthrough: informational, no actionable finding.
- Review threads: GraphQL `reviewThreads` returned 0 nodes.

## Non-goals
- 不改 config schema。
- 不改 task package template wording。
- 不修改 target repo 或 downstream wiring。
- 不做 hosted control plane、daemon、dashboard 或 agent orchestration 變更。

## Scope guard confirmation
- Allowed files: `src/docs/finder.ts`, `tests/docs-finder.test.ts`。
- No generated output or private context committed.

## Review closeout / final merge gate evidence
- CI/checks: `build` pass at latest head; `CodeRabbit` status pass after completed review.
- Review threads: GraphQL `reviewThreads` returned 0 nodes.
- `spec evidence-check`: pending rerun after finding disposition update.
- User authorization: explicit autonomous merge authorization in this Codex thread.

## Final merge gate
- latest head SHA: 6491668a3f9ee452eb9ab3e8deae8e8266fba3d7
- ready_to_merge: yes