### PR TITLE
feat(discovery): recognize MDX docs

### DIFF
--- a/src/docs/finder.ts
+++ b/src/docs/finder.ts
@@ -21,11 +21,11 @@ type ScoredReference = {
 };
 
 const EXPLICIT_FILE_EXTENSIONS = new Set([
-  '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.mts', '.cts', '.go', '.md', '.json', '.yml', '.yaml', '.sql', '.css', '.html', '.sh',
+  '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.mts', '.cts', '.go', '.md', '.mdx', '.json', '.yml', '.yaml', '.sql', '.css', '.html', '.sh',
 ]);
 const ROOT_DOC_CANDIDATES = ['README.md', 'CLAUDE.md', 'AGENTS.md', 'GEMINI.md'] as const;
 const EXPLICIT_ROOT_FILES = new Set<string>(ROOT_DOC_CANDIDATES);
-const DOC_EXTENSIONS = new Set(['.md']);
+const DOC_EXTENSIONS = new Set(['.md', '.mdx']);
 const ISSUE_MENTIONED_REASON = 'mentioned in issue';
 const SOURCE_SNIPPET_BYTES = 500;
 
@@ -376,7 +376,7 @@ function walkMarkdown(
       const relDir = path.relative(repoPath, full);
       if (isPlanDiscoveryExcluded(relDir, exclude)) continue;
       walkMarkdown(full, repoPath, exclude, results);
-    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+    } else if (entry.isFile() && DOC_EXTENSIONS.has(path.extname(entry.name).toLowerCase())) {
       const rel = path.relative(repoPath, full);
       if (!isPlanDiscoveryExcluded(rel, exclude)) results.push(rel);
     }

--- a/tests/docs-finder.test.ts
+++ b/tests/docs-finder.test.ts
@@ -64,6 +64,52 @@ test('root doc candidates share one source for fixed discovery and explicit refe
   );
 });
 
+test('explicit issue-mentioned MDX docs are classified as issue docs', async (t) => {
+  const repoDir = await createTempRepo(t);
+  const issue = {
+    number: 286,
+    title: 'Include MDX docs in docs finder',
+    body: 'Relevant docs:\n- `docs/usage.mdx`',
+    labels: [],
+    url: 'https://github.com/Erick52106/spec-injector/issues/286',
+    state: 'OPEN',
+  };
+
+  await writeRepoFiles(repoDir, {
+    'docs/usage.mdx': '# Usage\n\nMDX usage guidance for docs finder.\n',
+  });
+
+  const explicit = await extractExplicitIssueFileReferences(issue, repoDir);
+
+  assert.deepEqual(explicit.docs.map((doc) => doc.filePath), ['docs/usage.mdx']);
+  assert.equal(explicit.docs[0]?.kind, 'issue-doc');
+  assert.deepEqual(explicit.sources.map((doc) => doc.filePath), []);
+  assert.deepEqual(explicit.missing.map((doc) => doc.filePath), []);
+});
+
+test('auto relevant docs discovery includes scored MDX docs without adding MDX to source discovery', async (t) => {
+  const repoDir = await createTempRepo(t);
+  const issue = {
+    number: 286,
+    title: 'Refresh usage guide docs',
+    body: 'Usage guide docs should be found during relevant docs discovery.',
+    labels: [],
+    url: 'https://github.com/Erick52106/spec-injector/issues/286',
+    state: 'OPEN',
+  };
+
+  await writeRepoFiles(repoDir, {
+    'docs/usage.mdx': '# Usage Guide\n\nRelevant usage guide docs for MDX discovery.\n',
+    'src/usage.mdx': '# Usage Guide\n\nThis MDX file must not be treated as source.\n',
+  });
+
+  const discoveredDocs = await discoverRelevantDocs(issue, repoDir, new Set(), 5);
+  assert.equal(discoveredDocs.some((doc) => doc.filePath === 'docs/usage.mdx'), true);
+
+  const discoveredSources = await discoverSourceFiles(issue, repoDir, ['src'], 5);
+  assert.deepEqual(discoveredSources.map((doc) => doc.filePath), []);
+});
+
 test('explicit issue-mentioned source references include Node module extensions', async (t) => {
   const repoDir = await createTempRepo(t);
   const sourceFiles = ['src/cli.mjs', 'src/config.cjs', 'src/module.mts', 'src/legacy.cts'];


### PR DESCRIPTION
Closes #286

## Summary
- Recognize `.mdx` paths as documentation references for explicit issue-mentioned docs.
- Include `.mdx` files during auto relevant docs discovery under `docs/`.
- Keep `.mdx` out of source discovery and preserve existing exclude/max/ordering behavior.

## Tests / validation
- `pnpm build && node --test tests/docs-finder.test.ts`：PASS，6 tests。
- `pnpm test`：PASS，279 tests / 277 pass / 2 skipped。
- `pnpm build`：PASS。
- `git diff --check`：PASS。

## Spec gate evidence
- spec gate status: pass
- spec evidence ref: https://github.com/Erick52106/spec-injector/issues/286#issuecomment-4529943631
- routing evidence status: pass
- routing evidence ref: Hybrid AWP worker Arendt implemented bounded MDX docs/test patch; controller reviewed diff and reran full validation.
- finding disposition status: pass
- finding disposition ref: CodeRabbit status success but review was skipped by rate limit, with no actionable findings posted; GraphQL reviewThreads returned 0 nodes; controller diff review found no blocker.

## Implementation Evidence
- Source issue: #286
- issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/286#issuecomment-4529943631
- commit hash: `69dd81a4f7245b1f35c7f037c21e4eeaef6db87f`
- AWP routing: Hybrid AWP worker implementation with controller validation and merge gate ownership.

## Review finding assessment
- CodeRabbit rate-limit review skipped: not applicable, no actionable finding posted.
- Review threads: GraphQL `reviewThreads` returned 0 nodes.

## Non-goals
- 不做 MDX parser 或 frontmatter support。
- 不改 output contract 或 task package template wording。
- 不改 config schema。
- 不修改 target repo 或 downstream wiring。
- 不做 hosted control plane、daemon、dashboard 或 agent orchestration 變更。

## Scope guard confirmation
- Allowed files: `src/docs/finder.ts`, `tests/docs-finder.test.ts`。
- No generated output or private context committed.

## Review closeout / final merge gate evidence
- CI/checks: `build` pass at latest head; `CodeRabbit` status pass, review skipped by rate limit with no actionable findings posted.
- Review threads: GraphQL `reviewThreads` returned 0 nodes.
- `spec evidence-check`: PASS，13 pass / 0 warning / 0 fail / 0 needs-human-review。
- User authorization: explicit autonomous merge authorization in this Codex thread.

## Final merge gate
- latest head SHA: 69dd81a4f7245b1f35c7f037c21e4eeaef6db87f
- ready_to_merge: yes