### PR TITLE
feat(discovery): recognize explicit JSONC references

### DIFF
--- a/src/docs/finder.ts
+++ b/src/docs/finder.ts
@@ -21,7 +21,7 @@ type ScoredReference = {
 };
 
 const EXPLICIT_FILE_EXTENSIONS = new Set([
-  '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.mts', '.cts', '.go', '.md', '.mdx', '.json', '.yml', '.yaml', '.sql', '.css', '.html', '.sh',
+  '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.mts', '.cts', '.go', '.md', '.mdx', '.json', '.jsonc', '.yml', '.yaml', '.sql', '.css', '.html', '.sh',
 ]);
 const ROOT_DOC_CANDIDATES = ['README.md', 'CLAUDE.md', 'AGENTS.md', 'GEMINI.md'] as const;
 const EXPLICIT_ROOT_FILES = new Set<string>(ROOT_DOC_CANDIDATES);

--- a/tests/docs-finder.test.ts
+++ b/tests/docs-finder.test.ts
@@ -136,6 +136,33 @@ test('explicit issue-mentioned source references include Node module extensions'
   assert.deepEqual(explicit.missing.map((doc) => doc.filePath), []);
 });
 
+test('explicit issue-mentioned JSONC config references are classified as issue sources', async (t) => {
+  const repoDir = await createTempRepo(t);
+  const sourceFiles = ['wrangler.jsonc', 'config/tsconfig.jsonc'];
+  const issue = {
+    number: 288,
+    title: 'Include explicit JSONC config references',
+    body: [
+      'Relevant config references:',
+      ...sourceFiles.map((filePath) => `- \`${filePath}\``),
+    ].join('\n'),
+    labels: [],
+    url: 'https://github.com/Erick52106/spec-injector/issues/288',
+    state: 'OPEN',
+  };
+
+  await writeRepoFiles(repoDir, {
+    'wrangler.jsonc': '{\n  "name": "jsonc-worker"\n}\n',
+    'config/tsconfig.jsonc': '{\n  "extends": "../tsconfig.json"\n}\n',
+  });
+
+  const explicit = await extractExplicitIssueFileReferences(issue, repoDir);
+
+  assert.deepEqual(explicit.docs.map((doc) => doc.filePath), []);
+  assert.deepEqual(explicit.sources.map((doc) => doc.filePath), sourceFiles);
+  assert.deepEqual(explicit.missing.map((doc) => doc.filePath), []);
+});
+
 test('auto source discovery includes Node module extensions while preserving generated and skip-dir filtering', async (t) => {
   const repoDir = await createTempRepo(t);
   const sourceFiles = ['src/cli.mjs', 'src/config.cjs', 'src/module.mts', 'src/legacy.cts'];


### PR DESCRIPTION
Closes #288

## Summary
- Recognize explicit issue-mentioned `.jsonc` config paths as source references.
- Add regression coverage for root and nested JSONC config references.
- Keep `.jsonc` out of auto source discovery so generated or broad config files are not pulled in automatically.

## Tests / validation
- `pnpm build && node --test tests/docs-finder.test.ts` passed (7 tests)
- `pnpm test` passed (280 tests: 278 pass, 2 skipped, 0 fail)
- `pnpm build` passed
- `git diff --check` passed

## Implementation Evidence
- issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/288#issuecomment-4529961713
- commit hash: 99a87434bb43e95a15a59f1c6e8d4c2bd6e61a6c

## Scope guard
- No GitHub mutation in feature tests.
- No target repo edits.
- Scope is limited to explicit issue-mentioned JSONC references and regression coverage.

## Non-goals
- No hosted control plane, daemon, dashboard, or auto-merge feature.
- No broad `.jsonc` auto discovery.
- No downstream repo Scope Police changes.

## Spec gate evidence
- spec gate status: pass
- spec evidence ref: https://github.com/Erick52106/spec-injector/issues/288#issuecomment-4529961713
- routing evidence status: pass
- routing evidence ref: worker:019e5bcb-041d-7472-b6c1-48ec1cc62177
- finding disposition status: pass

## Routing evidence
- routing_evidence_status: pass
- routing_evidence_ref: worker:019e5bcb-041d-7472-b6c1-48ec1cc62177
- routing_plan: AWP controller delegated implementation/test patch to Locke; controller verified diff and validation before PR.
- delegation_outcome: completed
- worker_evidence_refs:
  - worker:019e5bcb-041d-7472-b6c1-48ec1cc62177
- explicit_controller_fallback_reason: not used

## Review finding disposition
- finding disposition status: pass
- CodeRabbit: skipped by rate limit; no actionable findings to adopt.
- Codex connector: no review submitted.
- GitHub review threads: 0 unresolved.
- Human review status: no changes requested.

## Threshold calibration evidence
- profile: layer1-small
- patch_size: 2 files, 28 insertions, 1 deletion
- risk: low; deterministic discovery extension plus regression test
- worker_required: true
- worker_ref: worker:019e5bcb-041d-7472-b6c1-48ec1cc62177

## Final merge gate
- latest head SHA: 99a87434bb43e95a15a59f1c6e8d4c2bd6e61a6c
- ready_to_merge: yes
