### PR TITLE
feat(discovery): recognize GitHub line anchor refs

### DIFF
--- a/src/docs/finder.ts
+++ b/src/docs/finder.ts
@@ -287,7 +287,7 @@ function isFullRepoRelativePath(filePath: string): boolean {
 }
 
 function normalizeBulletPathCandidate(line: string): string | null {
-  const match = line.match(/^\s*(?:[-*]|\d+\.)\s+([A-Za-z0-9._/-]+)\s*$/);
+  const match = line.match(/^\s*(?:[-*]|\d+\.)\s+([A-Za-z0-9._/#-]+)\s*$/);
   if (!match) return null;
   return normalizeExplicitPathCandidate(match[1]);
 }
@@ -297,10 +297,11 @@ function normalizeExplicitPathCandidate(candidate: string): string | null {
   if (trimmed.length === 0) return null;
   if (trimmed.includes('://')) return null;
   if (trimmed.startsWith('/')) return null;
-  if (trimmed.includes('#')) return null;
-  if (!/^[A-Za-z0-9._/-]+$/.test(trimmed)) return null;
+  const unanchored = stripGitHubLineAnchor(trimmed);
+  if (!unanchored) return null;
+  if (!/^[A-Za-z0-9._/-]+$/.test(unanchored)) return null;
 
-  const normalized = path.posix.normalize(trimmed);
+  const normalized = path.posix.normalize(unanchored);
   if (normalized === '.' || normalized === '..') return null;
   if (normalized.startsWith('../')) return null;
   if (path.posix.isAbsolute(normalized)) return null;
@@ -308,6 +309,16 @@ function normalizeExplicitPathCandidate(candidate: string): string | null {
   if (!hasRecognizedRepoFileShape(normalized)) return null;
 
   return normalized;
+}
+
+function stripGitHubLineAnchor(candidate: string): string | null {
+  const hashIndex = candidate.indexOf('#');
+  if (hashIndex === -1) return candidate;
+
+  const pathPart = candidate.slice(0, hashIndex);
+  const fragment = candidate.slice(hashIndex);
+  if (/^#L\d+(?:-L\d+)?$/.test(fragment)) return pathPart;
+  return null;
 }
 
 function normalizeMarkdownLinkTargetPathCandidate(candidate: string): string | null {

--- a/tests/docs-finder.test.ts
+++ b/tests/docs-finder.test.ts
@@ -194,6 +194,45 @@ test('explicit issue-mentioned TOML config references are classified as issue so
   assert.deepEqual(autoDiscovered.map((doc) => doc.filePath), []);
 });
 
+test('explicit issue-mentioned paths strip GitHub line anchors only', async (t) => {
+  const repoDir = await createTempRepo(t);
+  const issue = {
+    number: 296,
+    title: 'Recognize explicit paths with GitHub line anchors',
+    body: [
+      'Relevant references:',
+      '- `src/foo.ts#L10`',
+      '- src/range.ts#L10-L20',
+      '- [linked source](src/linked.ts#L12)',
+      '- [linked doc](docs/guide.md#L3-L4)',
+      '- `docs/readme.md#section`',
+      '- [ignored section](docs/section.md#heading)',
+    ].join('\n'),
+    labels: [],
+    url: 'https://github.com/Erick52106/spec-injector/issues/296',
+    state: 'OPEN',
+  };
+
+  await writeRepoFiles(repoDir, {
+    'src/foo.ts': 'export const foo = true;\n',
+    'src/range.ts': 'export const range = true;\n',
+    'src/linked.ts': 'export const linked = true;\n',
+    'docs/guide.md': '# Guide\n',
+    'docs/readme.md': '# Readme\n',
+    'docs/section.md': '# Section\n',
+  });
+
+  const explicit = await extractExplicitIssueFileReferences(issue, repoDir);
+
+  assert.deepEqual(explicit.sources.map((doc) => doc.filePath), [
+    'src/foo.ts',
+    'src/range.ts',
+    'src/linked.ts',
+  ]);
+  assert.deepEqual(explicit.docs.map((doc) => doc.filePath), ['docs/guide.md']);
+  assert.deepEqual(explicit.missing.map((doc) => doc.filePath), []);
+});
+
 test('auto source discovery includes Node module extensions while preserving generated and skip-dir filtering', async (t) => {
   const repoDir = await createTempRepo(t);
   const sourceFiles = ['src/cli.mjs', 'src/config.cjs', 'src/module.mts', 'src/legacy.cts'];


### PR DESCRIPTION
Closes #296

## Summary
- 讓 explicit issue-mentioned path 可以接受 GitHub line anchor：`#L10` 與 `#L10-L20`。
- 覆蓋 backtick path、plain bullet path、Markdown link target path 的 line anchor stripping。
- 保留非 line anchor fragment 的拒絕行為，例如 `#section` / `#heading` 不會被誤收。

## Tests / validation
- `pnpm build && node --test tests/docs-finder.test.ts`：10/10 pass
- `pnpm test`：283 pass / 2 skip
- `pnpm build`：pass
- `git diff --check`：pass
- `node dist/cli/index.js evidence-check --repo Erick52106/spec-injector --pr 297 --issue 296 --expected-head 7ebe6d6debdd5ceed5117093c8ef03203ad276e2 --evidence-url https://github.com/Erick52106/spec-injector/issues/296#issuecomment-4530055070`：PASS
- `node dist/cli/index.js workflow-check --repo . --phase merge --pr 297 --head-sha 7ebe6d6debdd5ceed5117093c8ef03203ad276e2 --format json`：PASS

## Implementation Evidence
- Source issue: #296
- Branch: `codex/line-anchors-296`
- Commit: `7ebe6d6debdd5ceed5117093c8ef03203ad276e2`
- AWP routing: `worker:019e5bf1-d687-7293-be5e-57b6f3d0e77d`, `delegation_outcome: completed`
- Issue evidence comment: https://github.com/Erick52106/spec-injector/issues/296#issuecomment-4530055070

## Scope guard
- 只修改 explicit issue path normalization 與 docs-finder regression test。
- 不擴大到 arbitrary URL parsing、GitHub remote reads、或 source discovery scoring。

## Non-goals
- 不新增 hosted control plane。
- 不做 daemon / auto-editing system。
- 不修改 downstream repo Scope Police。
- 不自動寫 output file。

## Spec gate evidence
- spec_evidence_status: pass
- spec_evidence_ref: https://github.com/Erick52106/spec-injector/issues/296#issuecomment-4530055070

## Routing evidence
- routing_evidence_status: pass
- routing_evidence_ref: AWP worker `019e5bf1-d687-7293-be5e-57b6f3d0e77d`
- delegation_outcome: completed
- explicit fallback: not used

## Review finding disposition
- finding_disposition_status: pass
- finding_disposition_ref: GitHub reviewThreads readback found no threads. CodeRabbit skipped review due capacity/rate limit and posted no actionable finding. Codex auto review did not post actionable findings.
- adopted: none
- not adopted: CodeRabbit capacity/rate-limit notice is operational noise, not code feedback.
- needs_human_review: none

## Threshold calibration evidence
- threshold_evidence_status: pass
- threshold_ref: targeted regression plus full suite, no new threshold semantics

## Final merge gate
- ready_to_merge: yes
- expected_head_sha: `7ebe6d6debdd5ceed5117093c8ef03203ad276e2`
- review_threads: none
- checks: build pass; CodeRabbit check pass/skipped
