### PR TITLE
fix(workflow-check): prefer explicit spec gate status

### DIFF
--- a/src/cli/workflow-check.ts
+++ b/src/cli/workflow-check.ts
@@ -180,6 +180,16 @@ type CloseoutReadback = {
 const PHASES = new Set<WorkflowPhase>(['start', 'commit', 'merge']);
 const FORMATS = new Set<OutputFormat>(['text', 'json']);
 const SPEC_STATUS_PATTERN = /\b(?:spec(?:[-_ ](?:gate|workflow|workflow-check|evidence))?|workflow-check|spec_evidence_status)\b[^\n\r]{0,120}\b(pass|fail|manual|skipped|pending|unknown)\b/i;
+const SPEC_STATUS_FIELD_NAMES = [
+  'spec_evidence_status',
+  'spec evidence status',
+  'spec_gate_status',
+  'spec gate status',
+  'workflow_check_status',
+  'workflow-check status',
+  'workflow check status',
+  'spec status',
+];
 const SPEC_REF_PATTERN = /\b(?:spec[_ -]evidence[_ -]ref|spec[_ -]gate[_ -]ref|workflow-check[_ -]ref|spec gate evidence ref|spec gate evidence|workflow-check evidence)\b\s*[:=]?\s*\S+/i;
 const MANUAL_FALLBACK_PATTERN = /\bmanual(?: checklist)? fallback\b|\bmanual spec gate\b|\bmanual workflow gate\b/i;
 const FINAL_MERGE_GATE_PATTERN = /\bfinal merge gate\b|\bmerge gate\b/i;
@@ -901,8 +911,11 @@ async function parsePrBodyEvidence(prBodyPath: string, expectedHeadSha?: string)
 }
 
 function parsePrBodyEvidenceText(body: string, expectedHeadSha?: string): PrBodyEvidence {
-  const statusMatch = body.match(SPEC_STATUS_PATTERN);
-  const specStatus = statusMatch?.[1]?.toLowerCase() as PrBodyEvidence['specStatus'] | undefined;
+  const explicitSpecStatus = parseExplicitSpecStatus(body);
+  const statusMatch = explicitSpecStatus.hasSpecStatus ? null : body.match(SPEC_STATUS_PATTERN);
+  const specStatus = explicitSpecStatus.hasSpecStatus
+    ? explicitSpecStatus.specStatus
+    : statusMatch?.[1]?.toLowerCase() as PrBodyEvidence['specStatus'] | undefined;
   const rawRoutingStatus = parseTextField(body, 'routing_evidence_status') ?? parseTextField(body, 'routing evidence status') ?? null;
   const routingStatus = parseRoutingStatus(rawRoutingStatus);
   const routingRef = parseTextField(body, 'routing_evidence_ref') ??
@@ -926,7 +939,7 @@ function parsePrBodyEvidenceText(body: string, expectedHeadSha?: string): PrBody
     : LATEST_HEAD_PATTERN.test(body);
 
   return {
-    hasSpecStatus: Boolean(statusMatch),
+    hasSpecStatus: explicitSpecStatus.hasSpecStatus || Boolean(statusMatch),
     specStatus: specStatus ?? null,
     hasSpecRef: SPEC_REF_PATTERN.test(body),
     hasManualFallback: MANUAL_FALLBACK_PATTERN.test(body),
@@ -960,6 +973,17 @@ function parsePrBodyEvidenceText(body: string, expectedHeadSha?: string): PrBody
     findingDispositionRef,
     readyToMerge,
   };
+}
+
+function parseExplicitSpecStatus(body: string): { hasSpecStatus: boolean; specStatus: PrBodyEvidence['specStatus'] } {
+  for (const fieldName of SPEC_STATUS_FIELD_NAMES) {
+    if (!hasTextField(body, fieldName)) continue;
+    return {
+      hasSpecStatus: true,
+      specStatus: parseGenericStatus(parseTextField(body, fieldName)),
+    };
+  }
+  return { hasSpecStatus: false, specStatus: null };
 }
 
 async function readRoutingEvidence(routingEvidencePath: string): Promise<RoutingEvidence> {

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -2345,6 +2345,137 @@ test('spec workflow-check merge phase collects closeout readback evidence with m
   assertNoGhMutationCommands(ghLog);
 });
 
+test('spec workflow-check merge closeout prefers explicit spec evidence status over summary command examples', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-closeout-spec-status-explicit-pass-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+  const headSha = 'abababababababababababababababababababab';
+  const fixture = await createEvidenceCheckFixture(t, {
+    issueNumber: 300,
+    headSha,
+    prBody: [
+      'Closes #300',
+      '',
+      '## Summary',
+      'Regression coverage for `workflow-check --phase merge --pr https://github.com/Erick52106/spec-injector/pull/300 --format json` returning fail before the parser fix.',
+      '',
+      '## Scope',
+      'Read-only closeout evidence collection.',
+      '',
+      '## Non-goals',
+      'No mutation.',
+      '',
+      '## Spec gate evidence',
+      '- spec_evidence_status: pass',
+      '- spec evidence ref: https://github.com/Erick52106/spec-injector/issues/300#issuecomment-1001',
+      '- routing evidence status: pass',
+      '- routing evidence ref: workflow-check:start:300',
+      '- delegation_outcome: completed',
+      '- finding disposition status: pass',
+      '',
+      '## Implementation Evidence',
+      '- Issue evidence: https://github.com/Erick52106/spec-injector/issues/300#issuecomment-1001',
+      `- Commit: ${headSha}`,
+      '',
+      '## Validation',
+      '- `pnpm test`',
+      '',
+      '## Final merge gate',
+      `- latest head SHA: ${headSha}`,
+      '- ready_to_merge: yes',
+    ].join('\n'),
+    reviews: [{ author: { login: 'chatgpt-codex-connector' }, body: 'No actionable findings.', state: 'COMMENTED' }],
+    reviewThreads: [],
+    checks: [
+      { name: 'build', state: 'COMPLETED', conclusion: 'SUCCESS', bucket: 'pass' },
+      { name: 'CodeRabbit', state: 'SUCCESS', conclusion: 'SUCCESS', bucket: 'pass' },
+    ],
+  });
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'merge',
+    '--pr', `https://github.com/${fixture.repo}/pull/${fixture.prNumber}`,
+    '--format', 'json',
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.status, 'pass');
+  assert.equal(parsed.closeout_readback_status, 'pass');
+  assert.equal(parsed.spec_gate_status, 'pass');
+  assert.doesNotMatch((parsed.missing_fields as string[]).join('\n'), /spec_gate_status/);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec workflow-check merge closeout fails explicit spec evidence status fail', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-closeout-spec-status-explicit-fail-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+  const headSha = 'acacacacacacacacacacacacacacacacacacacac';
+  const fixture = await createEvidenceCheckFixture(t, {
+    issueNumber: 300,
+    headSha,
+    prBody: [
+      'Closes #300',
+      '',
+      '## Summary',
+      'Closeout readback evidence with a command example that would otherwise look pass: `workflow-check --phase merge --pr https://github.com/Erick52106/spec-injector/pull/300 --format json pass`.',
+      '',
+      '## Scope',
+      'Read-only closeout evidence collection.',
+      '',
+      '## Non-goals',
+      'No mutation.',
+      '',
+      '## Spec gate evidence',
+      '- spec_evidence_status: fail',
+      '- spec evidence ref: https://github.com/Erick52106/spec-injector/issues/300#issuecomment-1001',
+      '- routing evidence status: pass',
+      '- routing evidence ref: workflow-check:start:300',
+      '- delegation_outcome: completed',
+      '- finding disposition status: pass',
+      '',
+      '## Implementation Evidence',
+      '- Issue evidence: https://github.com/Erick52106/spec-injector/issues/300#issuecomment-1001',
+      `- Commit: ${headSha}`,
+      '',
+      '## Validation',
+      '- `pnpm test`',
+      '',
+      '## Final merge gate',
+      `- latest head SHA: ${headSha}`,
+      '- ready_to_merge: yes',
+    ].join('\n'),
+    reviews: [{ author: { login: 'chatgpt-codex-connector' }, body: 'No actionable findings.', state: 'COMMENTED' }],
+    reviewThreads: [],
+    checks: [
+      { name: 'build', state: 'COMPLETED', conclusion: 'SUCCESS', bucket: 'pass' },
+      { name: 'CodeRabbit', state: 'SUCCESS', conclusion: 'SUCCESS', bucket: 'pass' },
+    ],
+  });
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'merge',
+    '--pr', `https://github.com/${fixture.repo}/pull/${fixture.prNumber}`,
+    '--format', 'json',
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.status, 'fail');
+  assert.equal(parsed.closeout_readback_status, 'fail');
+  assert.equal(parsed.spec_gate_status, 'fail');
+  assert.equal(parsed.ready_to_merge, 'no');
+  assert.ok((parsed.missing_fields as string[]).includes('spec_gate_status'));
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
 test('spec workflow-check merge closeout fails malformed delegation outcome evidence', async (t) => {
   const repoDir = await createTempRepo(t, 'spec-injector-workflow-closeout-delegation-outcome-');
   await writeConfig(repoDir, { version: 2, guardrails: [] });


### PR DESCRIPTION
Closes #300

## Summary
- 讓 merge closeout spec status parser 優先讀 explicit machine-readable 欄位。
- 避免 Summary / narrative / command examples 中的 `workflow-check ... fail` 誤蓋過 `spec_evidence_status: pass`。
- 保留舊 `SPEC_STATUS_PATTERN` fallback，維持既有 downstream status/ref evidence compatibility。

## Spec gate evidence
- spec_evidence_status: pass
- spec_evidence_ref: https://github.com/Erick52106/spec-injector/issues/300#issuecomment-4530171421

## Routing evidence
- routing_evidence_status: pass
- routing_evidence_ref: AWP worker `019e5c04-6481-7973-8607-d144ecc412ef`
- delegation_outcome: completed
- explicit fallback: not used

## Review finding disposition
- finding_disposition_status: pass
- finding_disposition_ref: GitHub reviewThreads readback found no threads. CodeRabbit skipped review due capacity/rate limit and posted no actionable finding. Codex auto review did not post actionable findings.
- adopted: none
- not adopted: CodeRabbit capacity/rate-limit notice is operational noise, not code feedback.
- needs_human_review: none

## Threshold calibration evidence
- threshold_evidence_status: pass
- threshold_ref: targeted parser regression plus full suite, no threshold semantics changed

## Tests / validation
- `pnpm build && node --test --test-name-pattern "explicit spec evidence status|closeout readback evidence" tests/cli.integration.test.ts`：3 pass
- `pnpm test`：287 pass / 2 skip
- `pnpm build`：pass
- `git diff --check`：pass
- evidence-check command for PR #301 / issue #300 / head `288e82d40c70e709cbf9d0ce03ca1d72e10387cf`：PASS
- workflow-check merge command for PR #301 / head `288e82d40c70e709cbf9d0ce03ca1d72e10387cf`：PASS

## Implementation Evidence
- Source issue: #300
- Branch: `codex/spec-status-parser-300`
- Commit: `288e82d40c70e709cbf9d0ce03ca1d72e10387cf`
- AWP routing: `worker:019e5c04-6481-7973-8607-d144ecc412ef`, `delegation_outcome: completed`
- Issue evidence comment: https://github.com/Erick52106/spec-injector/issues/300#issuecomment-4530171421

## Scope guard
- 只修改 `workflow-check` PR body spec status parsing 與 CLI integration tests。
- 不修改 GitHub mutation behavior、不新增 hosted control plane、不改 downstream repo Scope Police。

## Non-goals
- 不做 auto-merge runtime。
- 不做 daemon / hidden LLM wrapper。
- 不移除舊 narrative fallback。

## Final merge gate
- ready_to_merge: yes
- expected_head_sha: `288e82d40c70e709cbf9d0ce03ca1d72e10387cf`
- review_threads: none
- checks: build pass; CodeRabbit check pass/skipped
