### PR TITLE
feat(discovery): normalize GitHub raw references

### DIFF
--- a/src/docs/finder.ts
+++ b/src/docs/finder.ts
@@ -317,8 +317,8 @@ function normalizeExplicitPathCandidate(
 ): string | null {
   const trimmed = candidate.trim();
   if (trimmed.length === 0) return null;
-  const githubBlobPath = normalizeGitHubBlobUrlCandidate(trimmed, normalizationContext);
-  if (githubBlobPath) return githubBlobPath;
+  const githubUrlPath = normalizeGitHubUrlCandidate(trimmed, normalizationContext);
+  if (githubUrlPath) return githubUrlPath;
   if (trimmed.includes('://')) return null;
   if (trimmed.startsWith('/')) return null;
   return normalizeRepoRelativePathCandidate(trimmed);
@@ -337,6 +337,16 @@ function normalizeRepoRelativePathCandidate(candidate: string): string | null {
   if (!hasRecognizedRepoFileShape(normalized)) return null;
 
   return normalized;
+}
+
+function normalizeGitHubUrlCandidate(
+  candidate: string,
+  normalizationContext: ExplicitPathNormalizationContext
+): string | null {
+  return (
+    normalizeGitHubBlobUrlCandidate(candidate, normalizationContext) ??
+    normalizeGitHubRawUrlCandidate(candidate, normalizationContext)
+  );
 }
 
 function normalizeGitHubBlobUrlCandidate(
@@ -366,7 +376,36 @@ function normalizeGitHubBlobUrlCandidate(
     return null;
   }
 
-  return findGitHubBlobRepoRelativePath(blobSegments, normalizationContext.repoPath);
+  return findGitHubUrlRepoRelativePath(blobSegments, normalizationContext.repoPath);
+}
+
+function normalizeGitHubRawUrlCandidate(
+  candidate: string,
+  normalizationContext: ExplicitPathNormalizationContext
+): string | null {
+  if (!normalizationContext.githubRepoSlug) return null;
+
+  let url: URL;
+  try {
+    url = new URL(candidate);
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
+  if (url.hostname.toLowerCase() !== 'raw.githubusercontent.com') return null;
+  if (url.search.length > 0) return null;
+  if (url.hash.length > 0 && !/^#L\d+(?:-L\d+)?$/.test(url.hash)) return null;
+
+  const pathSegments = decodeGitHubPathSegments(url.pathname);
+  if (!pathSegments || pathSegments.length < 4) return null;
+
+  const [owner, repo, ...rawSegments] = pathSegments;
+  if (`${owner.toLowerCase()}/${repo.toLowerCase()}` !== normalizationContext.githubRepoSlug) {
+    return null;
+  }
+
+  return findGitHubUrlRepoRelativePath(rawSegments, normalizationContext.repoPath);
 }
 
 function decodeGitHubPathSegments(pathname: string): string[] | null {
@@ -384,15 +423,15 @@ function trimTrailingUrlPunctuation(candidate: string): string {
   return candidate.replace(/[.,;:]+$/g, '');
 }
 
-function findGitHubBlobRepoRelativePath(blobSegments: string[], repoPath: string): string | null {
-  if (blobSegments.length < 2) return null;
+function findGitHubUrlRepoRelativePath(refAndPathSegments: string[], repoPath: string): string | null {
+  if (refAndPathSegments.length < 2) return null;
 
-  for (let index = 1; index < blobSegments.length; index += 1) {
-    const normalized = normalizeRepoRelativePathCandidate(blobSegments.slice(index).join('/'));
+  for (let index = 1; index < refAndPathSegments.length; index += 1) {
+    const normalized = normalizeRepoRelativePathCandidate(refAndPathSegments.slice(index).join('/'));
     if (normalized && fs.existsSync(path.resolve(repoPath, normalized))) return normalized;
   }
 
-  return normalizeRepoRelativePathCandidate(blobSegments.slice(1).join('/'));
+  return normalizeRepoRelativePathCandidate(refAndPathSegments.slice(1).join('/'));
 }
 
 function stripGitHubLineAnchor(candidate: string): string | null {

--- a/tests/docs-finder.test.ts
+++ b/tests/docs-finder.test.ts
@@ -272,6 +272,48 @@ test('explicit issue-mentioned same-repo GitHub blob URLs normalize to repo-rela
   assert.deepEqual(explicit.missing.map((doc) => doc.filePath), []);
 });
 
+test('explicit issue-mentioned same-repo raw GitHub URLs normalize to repo-relative paths', async (t) => {
+  const repoDir = await createTempRepo(t);
+  const issue = {
+    number: 310,
+    title: 'Recognize explicit same-repo raw GitHub references',
+    body: [
+      'Relevant raw references:',
+      '- `https://raw.githubusercontent.com/Erick52106/spec-injector/main/src/foo.ts#L10`',
+      'Raw inline reference: https://raw.githubusercontent.com/Erick52106/spec-injector/main/src/raw.ts#L4.',
+      '- [linked source](https://raw.githubusercontent.com/Erick52106/spec-injector/main/src/linked.ts#L10-L20)',
+      '- [linked doc](https://raw.githubusercontent.com/Erick52106/spec-injector/main/docs/guide.md#L3)',
+      '- [slash ref source](https://raw.githubusercontent.com/Erick52106/spec-injector/feature/raw-refs/src/slash-ref.ts#L7)',
+      '- `https://raw.githubusercontent.com/OtherOrg/spec-injector/main/src/cross-repo.ts#L1`',
+      '- `https://github.com/Erick52106/spec-injector/raw/main/src/not-raw-host.ts#L1`',
+      '- `https://example.com/Erick52106/spec-injector/main/src/not-github.ts#L1`',
+      '- `https://raw.githubusercontent.com/Erick52106/spec-injector/main/docs/section.md#heading`',
+    ].join('\n'),
+    labels: [],
+    url: 'https://github.com/Erick52106/spec-injector/issues/310',
+    state: 'OPEN',
+  };
+
+  await writeRepoFiles(repoDir, {
+    'src/foo.ts': 'export const foo = true;\n',
+    'src/raw.ts': 'export const raw = true;\n',
+    'src/linked.ts': 'export const linked = true;\n',
+    'src/slash-ref.ts': 'export const slashRef = true;\n',
+    'docs/guide.md': '# Guide\n',
+  });
+
+  const explicit = await extractExplicitIssueFileReferences(issue, repoDir);
+
+  assert.deepEqual(explicit.sources.map((doc) => doc.filePath), [
+    'src/foo.ts',
+    'src/raw.ts',
+    'src/linked.ts',
+    'src/slash-ref.ts',
+  ]);
+  assert.deepEqual(explicit.docs.map((doc) => doc.filePath), ['docs/guide.md']);
+  assert.deepEqual(explicit.missing.map((doc) => doc.filePath), []);
+});
+
 test('auto source discovery includes Node module extensions while preserving generated and skip-dir filtering', async (t) => {
   const repoDir = await createTempRepo(t);
   const sourceFiles = ['src/cli.mjs', 'src/config.cjs', 'src/module.mts', 'src/legacy.cts'];


### PR DESCRIPTION
Closes #310

## Summary
- Normalize same-repo `raw.githubusercontent.com/<owner>/<repo>/<ref>/<path>` URLs into repo-relative explicit references.
- Support backtick URLs, raw inline URLs, Markdown link targets, `#L10` / `#L10-L20` anchors, and slash-containing refs when local files disambiguate the path.
- Keep cross-repo raw URLs, non-raw GitHub URLs, non-GitHub URLs, and non-line fragments ignored.

## Scope
- `src/docs/finder.ts`
- `tests/docs-finder.test.ts`

## Tests / validation
- `pnpm build && node --test tests/docs-finder.test.ts` -> pass, 12 tests
- `git diff --check` -> pass
- `pnpm test` -> pass, 297 pass / 2 skip
- `pnpm build` -> pass

## Implementation Evidence
- issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/310#issuecomment-4530441952
- commit hash: `ad9fbc5dba908631ce0419417d86c8d696872819`

## Spec gate evidence
- spec_evidence_status: pass
- spec_evidence_ref: https://github.com/Erick52106/spec-injector/issues/310#issuecomment-4530441952

## Routing evidence
- routing_evidence_status: pass
- routing_evidence_ref: AWP worker `019e5c32-b3ce-7470-999b-163165690005`
- delegation_outcome: completed
- explicit fallback: not used

## Review finding disposition
- finding_disposition_status: pass
- finding_disposition_ref: GitHub readback for head `ad9fbc5dba908631ce0419417d86c8d696872819` found 0 review threads and no actionable review findings; CodeRabbit was skipped by rate limit.

## Merge closeout
- ready_to_merge: yes
- merge_gate: pass
- head_sha: `ad9fbc5dba908631ce0419417d86c8d696872819`
- checks: build pass; CodeRabbit skipped/pass
- review_threads: 0
- merge_state: CLEAN

## Non-goals
- No network read was added.
- No GitHub mutation was added to discovery logic.
- No hosted control plane, daemon, dashboard, auto-merge, or downstream repo Scope Police change.
