### PR TITLE
fix(workflow-check): accept boolean ready evidence

### DIFF
--- a/src/cli/workflow-check.ts
+++ b/src/cli/workflow-check.ts
@@ -1559,6 +1559,8 @@ function parseReadyToMerge(body: string): 'yes' | 'no' | 'manual' | null {
   const value = parseTextField(body, 'ready_to_merge') ?? parseTextField(body, 'ready to merge');
   const normalized = normalize(value);
   if (['yes', 'no', 'manual'].includes(normalized)) return normalized as 'yes' | 'no' | 'manual';
+  if (normalized === 'true') return 'yes';
+  if (normalized === 'false') return 'no';
   return null;
 }
 

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -2345,6 +2345,110 @@ test('spec workflow-check merge phase collects closeout readback evidence with m
   assertNoGhMutationCommands(ghLog);
 });
 
+test('spec workflow-check merge closeout accepts boolean ready_to_merge true', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-closeout-ready-true-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+  const headSha = '1212121212121212121212121212121212121212';
+  const fixture = await createEvidenceCheckFixture(t, {
+    issueNumber: 312,
+    headSha,
+    prBody: [
+      'Closes #312',
+      '',
+      '## Spec gate evidence',
+      '- spec gate status: pass',
+      '- spec evidence ref: https://github.com/Erick52106/spec-injector/issues/312#issuecomment-1001',
+      '- routing evidence status: pass',
+      '- routing evidence ref: workflow-check:start:312',
+      '- finding disposition status: pass',
+      '',
+      '## Implementation Evidence',
+      '- Issue evidence: https://github.com/Erick52106/spec-injector/issues/312#issuecomment-1001',
+      `- Commit: ${headSha}`,
+      '',
+      '## Final merge gate',
+      `- latest head SHA: ${headSha}`,
+      '- ready_to_merge: true',
+    ].join('\n'),
+    reviews: [{ author: { login: 'chatgpt-codex-connector' }, body: 'No actionable findings.', state: 'COMMENTED' }],
+    reviewThreads: [],
+    checks: [
+      { name: 'build', state: 'COMPLETED', conclusion: 'SUCCESS', bucket: 'pass' },
+      { name: 'CodeRabbit', state: 'SUCCESS', conclusion: 'SUCCESS', bucket: 'pass' },
+    ],
+  });
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'merge',
+    '--pr', `https://github.com/${fixture.repo}/pull/${fixture.prNumber}`,
+    '--format', 'json',
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.status, 'pass');
+  assert.equal(parsed.closeout_readback_status, 'pass');
+  assert.equal(parsed.ready_to_merge, 'yes');
+  assert.doesNotMatch((parsed.missing_fields as string[]).join('\n'), /ready_to_merge/);
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec workflow-check merge closeout rejects boolean ready_to_merge false', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-closeout-ready-false-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+  const headSha = '3434343434343434343434343434343434343434';
+  const fixture = await createEvidenceCheckFixture(t, {
+    issueNumber: 312,
+    headSha,
+    prBody: [
+      'Closes #312',
+      '',
+      '## Spec gate evidence',
+      '- spec gate status: pass',
+      '- spec evidence ref: https://github.com/Erick52106/spec-injector/issues/312#issuecomment-1001',
+      '- routing evidence status: pass',
+      '- routing evidence ref: workflow-check:start:312',
+      '- finding disposition status: pass',
+      '',
+      '## Implementation Evidence',
+      '- Issue evidence: https://github.com/Erick52106/spec-injector/issues/312#issuecomment-1001',
+      `- Commit: ${headSha}`,
+      '',
+      '## Final merge gate',
+      `- latest head SHA: ${headSha}`,
+      '- ready_to_merge: false',
+    ].join('\n'),
+    reviews: [{ author: { login: 'chatgpt-codex-connector' }, body: 'No actionable findings.', state: 'COMMENTED' }],
+    reviewThreads: [],
+    checks: [
+      { name: 'build', state: 'COMPLETED', conclusion: 'SUCCESS', bucket: 'pass' },
+      { name: 'CodeRabbit', state: 'SUCCESS', conclusion: 'SUCCESS', bucket: 'pass' },
+    ],
+  });
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'merge',
+    '--pr', `https://github.com/${fixture.repo}/pull/${fixture.prNumber}`,
+    '--format', 'json',
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.status, 'fail');
+  assert.equal(parsed.closeout_readback_status, 'fail');
+  assert.equal(parsed.ready_to_merge, 'no');
+  assert.ok((parsed.missing_fields as string[]).includes('ready_to_merge'));
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
 test('spec workflow-check merge closeout prefers explicit spec evidence status over summary command examples', async (t) => {
   const repoDir = await createTempRepo(t, 'spec-injector-workflow-closeout-spec-status-explicit-pass-');
   await writeConfig(repoDir, { version: 2, guardrails: [] });


### PR DESCRIPTION
Closes #312

## Summary
- Accept boolean `ready_to_merge` evidence in `workflow-check --phase merge --pr` closeout readback.
- Map `ready_to_merge: true` to the existing JSON contract value `yes`.
- Map `ready_to_merge: false` to the existing JSON contract value `no` while keeping the merge gate failing.

## Scope
- `src/cli/workflow-check.ts`
- `tests/cli.integration.test.ts`

## Tests / validation
- `pnpm build && node --test tests/cli.integration.test.ts --test-name-pattern "ready_to_merge"` -> pass, 220 tests
- `git diff --check` -> pass
- `pnpm test` -> pass, 299 pass / 2 skip
- `pnpm build` -> pass

## Implementation Evidence
- issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/312#issuecomment-4530466000
- commit hash: `c5b8851aa0fdc6fc175395ade1d04b6d2ee34e71`

## Spec gate evidence
- spec_evidence_status: pass
- spec_evidence_ref: https://github.com/Erick52106/spec-injector/issues/312#issuecomment-4530466000

## Routing evidence
- routing_evidence_status: pass
- routing_evidence_ref: AWP worker `019e5c3e-37cb-7f93-b7f0-e3c339ab1a06`
- delegation_outcome: completed
- explicit fallback: not used

## Review finding disposition
- finding_disposition_status: pass
- finding_disposition_ref: GitHub readback for head `c5b8851aa0fdc6fc175395ade1d04b6d2ee34e71` found 0 review threads and no actionable review findings; CodeRabbit was skipped by rate limit.

## Merge closeout
- ready_to_merge: yes
- merge_gate: pass
- head_sha: `c5b8851aa0fdc6fc175395ade1d04b6d2ee34e71`
- checks: build pass; CodeRabbit skipped/pass
- review_threads: 0
- merge_state: CLEAN

## Non-goals
- No GitHub mutation was added to `workflow-check`.
- No new ready-to-merge output enum was introduced.
- No hosted control plane, daemon, dashboard, auto-merge, or downstream repo Scope Police change.
