### PR TITLE
feat(evidence-check): add json output

### DIFF
--- a/src/cli/evidence-check.ts
+++ b/src/cli/evidence-check.ts
@@ -16,6 +16,7 @@ type EvidenceCheckOptions = {
   issue?: string;
   expectedHead?: string;
   evidenceUrl?: string;
+  format?: string;
 };
 
 type PullRequestPayload = {
@@ -41,6 +42,8 @@ type CheckPayload = {
   bucket?: string;
 };
 
+type EvidenceCheckFormat = 'text' | 'json';
+
 const HASH_PATTERN = /\b[0-9a-f]{7,40}\b/gi;
 const LINKED_ISSUE_PATTERN = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/gi;
 const EVIDENCE_URL_PATTERN = /https:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/issues\/(\d+)#issuecomment-\d+/gi;
@@ -53,6 +56,7 @@ const EXPLICIT_NO_ACTIONABLE_REVIEW_PATTERN = /\bno actionable(?: comments?| fin
 
 export async function evidenceCheck(opts: EvidenceCheckOptions): Promise<void> {
   try {
+    const format = parseFormat(opts.format);
     const context = resolveContext(opts);
     const pr = readJson<PullRequestPayload>([
       'gh',
@@ -103,7 +107,7 @@ export async function evidenceCheck(opts: EvidenceCheckOptions): Promise<void> {
       checksReadError: checksRead.error,
     });
 
-    printReport(report);
+    printReport(report, format);
 
     if (report.overall === 'fail' || report.overall === 'needs-human-review') {
       process.exit(1);
@@ -112,6 +116,14 @@ export async function evidenceCheck(opts: EvidenceCheckOptions): Promise<void> {
     console.error(`✗ Evidence check failed: ${(err as Error).message}`);
     process.exit(1);
   }
+}
+
+function parseFormat(format: string | undefined): EvidenceCheckFormat {
+  const normalized = format ?? 'text';
+  if (normalized === 'text' || normalized === 'json') {
+    return normalized;
+  }
+  throw new Error(`Invalid evidence-check format "${format}". Expected one of: text, json.`);
 }
 
 function resolveContext(opts: EvidenceCheckOptions): { prRef: string; repo: string } {
@@ -541,7 +553,12 @@ function summarizeOverall(checks: EvidenceCheck[]): Severity {
   return 'pass';
 }
 
-function printReport(report: { overall: Severity; checks: EvidenceCheck[] }): void {
+function printReport(report: { overall: Severity; checks: EvidenceCheck[] }, format: EvidenceCheckFormat): void {
+  if (format === 'json') {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+
   const counts = {
     pass: report.checks.filter((check) => check.severity === 'pass').length,
     warning: report.checks.filter((check) => check.severity === 'warning').length,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -240,6 +240,7 @@ program
   .option('--issue <number>', 'Expected linked source issue number')
   .option('--expected-head <sha>', 'Expected latest PR head SHA')
   .option('--evidence-url <url>', 'Expected source issue implementation evidence comment URL')
+  .option('--format <format>', 'Output format: text or json (default: text)')
   .addHelpText('after', `
 Checks:
   - PR body linked issue, required sections, evidence URL, and HEAD freshness
@@ -256,6 +257,7 @@ Safety:
     issue?: string;
     expectedHead?: string;
     evidenceUrl?: string;
+    format?: string;
   }) => {
     const { evidenceCheck } = await import('./evidence-check.js');
     await evidenceCheck(opts);

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -4249,6 +4249,107 @@ test('spec evidence-check passes for complete PR and issue evidence without muta
   assertNoGhMutationCommands(ghLog);
 });
 
+test('spec evidence-check --format json prints parseable pass report without auxiliary footer', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t);
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', String(fixture.prNumber),
+    '--repo', fixture.repo,
+    '--expected-head', fixture.headSha,
+    '--format', 'json',
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(result.stderr, '');
+  assert.doesNotMatch(result.stdout, /Auxiliary notice:/i);
+  assert.doesNotMatch(result.stdout, /Evidence check summary:/i);
+
+  const report = JSON.parse(result.stdout) as {
+    overall?: unknown;
+    checks?: Array<Record<string, unknown>>;
+  };
+  assert.equal(report.overall, 'pass');
+  assert.ok(Array.isArray(report.checks));
+  assert.ok(report.checks.length > 0);
+  for (const check of report.checks) {
+    assert.equal(typeof check.severity, 'string');
+    assert.equal(typeof check.item, 'string');
+    assert.equal(typeof check.evidence, 'string');
+    assert.equal(typeof check.reason, 'string');
+    assert.equal(typeof check.action, 'string');
+  }
+  assert.ok(report.checks.some((check) => check.item === 'PR body linked issue'));
+
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec evidence-check --format json prints parseable fail report and exits non-zero', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t, {
+    prBody: [
+      'Closes #109',
+      '## Summary',
+      'ok',
+      '## Scope',
+      'ok',
+      '## Non-goals',
+      'ok',
+      '## Validation',
+      '- `pnpm test` ✅',
+      '## Implementation Evidence',
+      '- Latest HEAD: 1234567890abcdef1234567890abcdef12345678',
+    ].join('\n'),
+  });
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', String(fixture.prNumber),
+    '--repo', fixture.repo,
+    '--format', 'json',
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.equal(result.stderr, '');
+  assert.doesNotMatch(result.stdout, /Auxiliary notice:/i);
+  assert.doesNotMatch(result.stdout, /Evidence check summary:/i);
+
+  const report = JSON.parse(result.stdout) as {
+    overall?: unknown;
+    checks?: Array<Record<string, unknown>>;
+  };
+  assert.equal(report.overall, 'fail');
+  assert.ok(Array.isArray(report.checks));
+  assert.ok(report.checks.some((check) =>
+    check.severity === 'fail' &&
+    check.item === 'Issue evidence URL' &&
+    check.reason === 'issue evidence URL is missing'
+  ));
+
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec evidence-check rejects invalid --format value clearly', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t);
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', String(fixture.prNumber),
+    '--repo', fixture.repo,
+    '--format', 'yaml',
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stderr, /Invalid evidence-check format "yaml"/i);
+  assert.match(result.stderr, /Expected one of: text, json/i);
+  assertNoRawStackTrace(result);
+
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assert.equal(ghLog.trim(), '');
+  assertNoGhMutationCommands(ghLog);
+});
+
 test('spec evidence-check accepts a full PR URL when --repo matches the encoded repository', async (t) => {
   const fixture = await createEvidenceCheckFixture(t);
 


### PR DESCRIPTION
Closes #313

## Summary
- Add `--format json` to `spec evidence-check` while keeping text output as the default.
- Emit parseable JSON with `overall` and per-check `severity`, `item`, `evidence`, `reason`, and `action` fields.
- Preserve existing read-only decision logic and exit-code behavior for pass/warning/fail/needs-human-review reports.

## Scope
- `src/cli/evidence-check.ts`
- `src/cli/index.ts`
- `tests/cli.integration.test.ts`

## Tests / validation
- `pnpm build && node --test tests/cli.integration.test.ts --test-name-pattern "evidence-check.*json|invalid.*evidence-check"` -> pass, 223 tests
- `git diff --check` -> pass
- `pnpm test` -> pass, 302 pass / 2 skip
- `pnpm build` -> pass

## Implementation Evidence
- issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/313#issuecomment-4530487510
- commit hash: `cff8aa2f6e90222427273534bc77037af07d06ec`

## Spec gate evidence
- spec_evidence_status: pass
- spec_evidence_ref: https://github.com/Erick52106/spec-injector/issues/313#issuecomment-4530487510

## Routing evidence
- routing_evidence_status: pass
- routing_evidence_ref: AWP worker `019e5c45-c512-7003-bc57-62974fa326e2`
- delegation_outcome: completed
- explicit fallback: not used

## Review finding disposition
- finding_disposition_status: pass
- finding_disposition_ref: GitHub readback for head `cff8aa2f6e90222427273534bc77037af07d06ec` found 0 review threads and no actionable review findings; CodeRabbit was skipped by rate limit.

## Merge closeout
- ready_to_merge: yes
- merge_gate: pass
- head_sha: `cff8aa2f6e90222427273534bc77037af07d06ec`
- checks: build pass; CodeRabbit skipped/pass
- review_threads: 0
- merge_state: CLEAN

## Non-goals
- No GitHub mutation, auto-comment, auto-resolve, auto-merge, or auto-close behavior was added.
- No evidence-check decision logic was changed.
- No hosted control plane, daemon, dashboard, agent runtime, or downstream repo Scope Police change.
