### PR TITLE
fix(evidence-check): emit json fatal reports

### DIFF
--- a/src/cli/evidence-check.ts
+++ b/src/cli/evidence-check.ts
@@ -43,6 +43,10 @@ type CheckPayload = {
 };
 
 type EvidenceCheckFormat = 'text' | 'json';
+type EvidenceCheckReport = {
+  overall: Severity;
+  checks: EvidenceCheck[];
+};
 
 const HASH_PATTERN = /\b[0-9a-f]{7,40}\b/gi;
 const LINKED_ISSUE_PATTERN = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/gi;
@@ -113,7 +117,12 @@ export async function evidenceCheck(opts: EvidenceCheckOptions): Promise<void> {
       process.exit(1);
     }
   } catch (err) {
-    console.error(`✗ Evidence check failed: ${(err as Error).message}`);
+    const message = (err as Error).message;
+    if (opts.format === 'json') {
+      printReport(buildFatalReport(message), 'json');
+    } else {
+      console.error(`✗ Evidence check failed: ${message}`);
+    }
     process.exit(1);
   }
 }
@@ -153,7 +162,7 @@ function buildReport(input: {
   expectedHead?: string;
   checks: CheckPayload[];
   checksReadError?: string;
-}): { overall: Severity; checks: EvidenceCheck[] } {
+}): EvidenceCheckReport {
   const checks: EvidenceCheck[] = [];
   const latestHead = input.pr.headRefOid ?? '';
   const evidenceComment = input.evidenceUrl && input.issue
@@ -382,6 +391,20 @@ function buildReport(input: {
   };
 }
 
+function buildFatalReport(message: string): EvidenceCheckReport {
+  return {
+    overall: 'fail',
+    checks: [
+      fail(
+        'Evidence check execution',
+        'pre-report fatal error',
+        message,
+        'Fix the evidence-check invocation, then rerun the read-only checker.'
+      ),
+    ],
+  };
+}
+
 function checkRequiredSections(body: string): EvidenceCheck[] {
   const groups: Array<[string, RegExp, string]> = [
     ['Summary section', /^##+\s*(Summary|摘要)/im, 'Summary'],
@@ -553,7 +576,7 @@ function summarizeOverall(checks: EvidenceCheck[]): Severity {
   return 'pass';
 }
 
-function printReport(report: { overall: Severity; checks: EvidenceCheck[] }, format: EvidenceCheckFormat): void {
+function printReport(report: EvidenceCheckReport, format: EvidenceCheckFormat): void {
   if (format === 'json') {
     console.log(JSON.stringify(report, null, 2));
     return;

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -4399,6 +4399,36 @@ test('spec evidence-check fails when --repo conflicts with the repository encode
   assertNoGhMutationCommands(ghLog);
 });
 
+test('spec evidence-check --format json prints parseable fatal report when --repo conflicts with PR URL', async (t) => {
+  const fixture = await createEvidenceCheckFixture(t);
+
+  const result = await runSpec([
+    'evidence-check',
+    '--pr', `https://github.com/${fixture.repo}/pull/${fixture.prNumber}`,
+    '--repo', 'owner-b/repo-b',
+    '--format', 'json',
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.equal(result.stderr, '');
+
+  const report = JSON.parse(result.stdout) as {
+    overall?: unknown;
+    checks?: Array<Record<string, unknown>>;
+  };
+  assert.equal(report.overall, 'fail');
+  assert.ok(Array.isArray(report.checks));
+  assert.ok(report.checks.some((check) =>
+    check.severity === 'fail' &&
+    check.item === 'Evidence check execution' &&
+    check.reason === '--repo must match the repository encoded in --pr.'
+  ));
+
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assert.equal(ghLog.trim(), '');
+  assertNoGhMutationCommands(ghLog);
+});
+
 test('spec evidence-check still requires --repo when --pr is not a GitHub PR URL', async (t) => {
   const fixture = await createEvidenceCheckFixture(t);
 


### PR DESCRIPTION
Closes #316

## Summary
- Emit parseable JSON fatal reports for valid `spec evidence-check --format json` invocations that fail before normal report construction.
- Keep invalid format handling as text stderr because the requested output format is not valid.
- Preserve text-mode fatal errors and existing evidence-check decision logic.

## Scope
- `src/cli/evidence-check.ts`
- `tests/cli.integration.test.ts`

## Tests / validation
- `pnpm build && node --test tests/cli.integration.test.ts --test-name-pattern "evidence-check.*json|format"` -> pass, 224 tests
- `git diff --check` -> pass
- `pnpm test` -> pass, 303 pass / 2 skip
- `pnpm build` -> pass

## Implementation Evidence
- issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/316#issuecomment-4530506257
- commit hash: `abf3ea6893d2cd50ee3163263ce3458b026dbda4`

## Spec gate evidence
- spec_evidence_status: pass
- spec_evidence_ref: https://github.com/Erick52106/spec-injector/issues/316#issuecomment-4530506257

## Routing evidence
- routing_evidence_status: pass
- routing_evidence_ref: AWP worker `019e5c4e-d708-7430-8b65-3925a5ef0782`
- delegation_outcome: completed
- explicit fallback: not used

## Review finding disposition
- finding_disposition_status: pass
- finding_disposition_ref: GitHub readback for head `abf3ea6893d2cd50ee3163263ce3458b026dbda4` found 0 review threads and no actionable review findings; CodeRabbit was skipped by rate limit.

## Merge closeout
- ready_to_merge: yes
- merge_gate: pass
- head_sha: `abf3ea6893d2cd50ee3163263ce3458b026dbda4`
- checks: build pass; CodeRabbit skipped/pass
- review_threads: 0
- merge_state: CLEAN

## Non-goals
- No GitHub mutation, auto-comment, auto-resolve, auto-merge, or auto-close behavior was added.
- No evidence-check decision logic was changed.
- No hosted control plane, daemon, dashboard, agent runtime, or downstream repo Scope Police change.
