### PR TITLE
feat(discovery): accept GitHub plain refs

### DIFF
--- a/src/docs/finder.ts
+++ b/src/docs/finder.ts
@@ -364,7 +364,7 @@ function normalizeGitHubBlobUrlCandidate(
 
   if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
   if (!['github.com', 'www.github.com'].includes(url.hostname.toLowerCase())) return null;
-  if (url.search.length > 0) return null;
+  if (!isAllowedGitHubBlobQuery(url.searchParams)) return null;
   if (url.hash.length > 0 && !/^#L\d+(?:-L\d+)?$/.test(url.hash)) return null;
 
   const pathSegments = decodeGitHubPathSegments(url.pathname);
@@ -377,6 +377,11 @@ function normalizeGitHubBlobUrlCandidate(
   }
 
   return findGitHubUrlRepoRelativePath(blobSegments, normalizationContext.repoPath);
+}
+
+function isAllowedGitHubBlobQuery(searchParams: URLSearchParams): boolean {
+  const entries = [...searchParams.entries()];
+  return entries.length === 0 || (entries.length === 1 && entries[0][0] === 'plain' && entries[0][1] === '1');
 }
 
 function normalizeGitHubRawUrlCandidate(

--- a/tests/docs-finder.test.ts
+++ b/tests/docs-finder.test.ts
@@ -244,6 +244,10 @@ test('explicit issue-mentioned same-repo GitHub blob URLs normalize to repo-rela
       'Raw reference: https://github.com/Erick52106/spec-injector/blob/main/src/raw.ts#L4.',
       '- [linked source](https://github.com/Erick52106/spec-injector/blob/main/src/linked.ts#L10-L20)',
       '- [linked doc](https://github.com/Erick52106/spec-injector/blob/main/docs/guide.md#L3)',
+      '- `https://github.com/Erick52106/spec-injector/blob/main/src/plain.ts?plain=1#L10`',
+      '- [plain doc](https://github.com/Erick52106/spec-injector/blob/main/docs/plain.md?plain=1)',
+      '- `https://github.com/Erick52106/spec-injector/blob/main/src/ignored-query.ts?foo=bar#L1`',
+      '- `https://github.com/Erick52106/spec-injector/blob/main/src/ignored-plain-zero.ts?plain=0#L1`',
       '- `https://github.com/OtherOrg/spec-injector/blob/main/src/cross-repo.ts#L1`',
       '- `https://github.com/Erick52106/spec-injector/tree/main/src/not-blob.ts`',
       '- `https://example.com/Erick52106/spec-injector/blob/main/src/not-github.ts`',
@@ -258,7 +262,11 @@ test('explicit issue-mentioned same-repo GitHub blob URLs normalize to repo-rela
     'src/foo.ts': 'export const foo = true;\n',
     'src/raw.ts': 'export const raw = true;\n',
     'src/linked.ts': 'export const linked = true;\n',
+    'src/plain.ts': 'export const plain = true;\n',
+    'src/ignored-query.ts': 'export const ignoredQuery = true;\n',
+    'src/ignored-plain-zero.ts': 'export const ignoredPlainZero = true;\n',
     'docs/guide.md': '# Guide\n',
+    'docs/plain.md': '# Plain\n',
   });
 
   const explicit = await extractExplicitIssueFileReferences(issue, repoDir);
@@ -267,8 +275,9 @@ test('explicit issue-mentioned same-repo GitHub blob URLs normalize to repo-rela
     'src/foo.ts',
     'src/raw.ts',
     'src/linked.ts',
+    'src/plain.ts',
   ]);
-  assert.deepEqual(explicit.docs.map((doc) => doc.filePath), ['docs/guide.md']);
+  assert.deepEqual(explicit.docs.map((doc) => doc.filePath), ['docs/guide.md', 'docs/plain.md']);
   assert.deepEqual(explicit.missing.map((doc) => doc.filePath), []);
 });
 


### PR DESCRIPTION
Closes #318

## Summary
- Accept same-repo GitHub `blob` file URLs with deterministic `?plain=1` query strings as explicit references.
- Preserve `#L10` / `#L10-L20` line-anchor handling and repo-relative source/docs classification.
- Keep arbitrary query strings ignored and keep raw GitHub URL query handling unchanged.

## Scope
- `src/docs/finder.ts`
- `tests/docs-finder.test.ts`

## Tests / validation
- `pnpm build && node --test tests/docs-finder.test.ts` -> pass, 12 tests
- `git diff --check` -> pass
- `pnpm test` -> pass, 303 pass / 2 skip
- `pnpm build` -> pass

## Implementation Evidence
- issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/318#issuecomment-4530533955
- commit hash: `7baf925cb15956a56bfa1ada1299273d8ec96aa5`

## Spec gate evidence
- spec_evidence_status: pass
- spec_evidence_ref: https://github.com/Erick52106/spec-injector/issues/318#issuecomment-4530533955

## Routing evidence
- routing_evidence_status: pass
- routing_evidence_ref: AWP worker `019e5c56-d52b-7f52-ade7-5189ed9e9dbb`
- delegation_outcome: completed
- explicit fallback: not used

## Review finding disposition
- finding_disposition_status: pass
- finding_disposition_ref: GitHub readback for head `7baf925cb15956a56bfa1ada1299273d8ec96aa5` found 0 review threads and no actionable review findings; CodeRabbit was skipped by rate limit.

## Merge closeout
- ready_to_merge: yes
- merge_gate: pass
- head_sha: `7baf925cb15956a56bfa1ada1299273d8ec96aa5`
- checks: build pass; CodeRabbit skipped/pass
- review_threads: 0
- merge_state: CLEAN

## Non-goals
- No network reads or GitHub remote state reads were added.
- No arbitrary query-string support was added.
- No GitHub mutation, hosted control plane, daemon, dashboard, agent runtime, or downstream repo Scope Police change.
