### PR TITLE
feat(label-audit): add json output

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -269,6 +269,7 @@ program
   .description('Run a read-only label and milestone metadata audit for issues and PRs')
   .requiredOption('--repo <owner/name>', 'GitHub repository owner/name to audit')
   .option('--limit <number>', 'Maximum number of issues / PRs to fetch per list (default: 200)')
+  .option('--format <format>', 'Output format: text or json (default: text)')
   .addHelpText('after', `
 Checks:
   - open issue area / type / status coverage
@@ -283,6 +284,7 @@ Safety:
   .action(async (opts: {
     repo: string;
     limit?: string;
+    format?: string;
   }) => {
     const { labelAudit } = await import('./label-audit.js');
     await labelAudit(opts);

--- a/src/cli/label-audit.ts
+++ b/src/cli/label-audit.ts
@@ -13,6 +13,14 @@ type LabelAuditCheck = {
 type LabelAuditOptions = {
   repo: string;
   limit?: string;
+  format?: string;
+};
+
+type LabelAuditFormat = 'text' | 'json';
+
+type LabelAuditReport = {
+  overall: Severity;
+  checks: LabelAuditCheck[];
 };
 
 type IssuePayload = {
@@ -69,14 +77,19 @@ const STATUS_IMPLEMENTED = 'status:implemented';
 const STATUS_NEEDS_DESIGN = 'status:needs-design';
 
 export async function labelAudit(opts: LabelAuditOptions): Promise<void> {
+  const format = parseFormat(opts.format);
   try {
     const report = buildLabelAuditReport(opts, process.cwd());
-    printReport(report);
+    printReport(report, format);
 
     if (report.overall === 'needs-human-review') {
       process.exit(1);
     }
   } catch (err) {
+    if (format === 'json') {
+      printReport(singleNeedsHumanReviewReport((err as Error).message), format);
+      process.exit(1);
+    }
     console.error(`✗ Label audit failed: ${(err as Error).message}`);
     process.exit(1);
   }
@@ -85,7 +98,7 @@ export async function labelAudit(opts: LabelAuditOptions): Promise<void> {
 function buildLabelAuditReport(
   opts: LabelAuditOptions,
   repoRoot: string
-): { overall: Severity; checks: LabelAuditCheck[] } {
+): LabelAuditReport {
   const taxonomyRead = loadAcceptedTaxonomy(repoRoot);
   if ('error' in taxonomyRead) {
     return singleNeedsHumanReviewReport(taxonomyRead.error);
@@ -573,6 +586,12 @@ function parseLimit(limitOption: string | undefined): number {
   return parsed;
 }
 
+function parseFormat(formatOption: string | undefined): LabelAuditFormat {
+  if (!formatOption || formatOption === 'text') return 'text';
+  if (formatOption === 'json') return 'json';
+  throw new Error(`Invalid label-audit format "${formatOption}". Expected one of: text, json.`);
+}
+
 function readJsonResult<T>(
   argv: string[],
   readErrorMessage: string,
@@ -600,7 +619,7 @@ function firstMeaningfulMessage(...values: string[]): string {
   return 'no details returned';
 }
 
-function singleNeedsHumanReviewReport(detail: string): { overall: Severity; checks: LabelAuditCheck[] } {
+function singleNeedsHumanReviewReport(detail: string): LabelAuditReport {
   return {
     overall: 'needs-human-review',
     checks: [needsHumanReview('could not complete label audit with high confidence', detail)],
@@ -617,7 +636,12 @@ function summarizeOverall(checks: LabelAuditCheck[]): Severity {
   return 'pass';
 }
 
-function printReport(report: { overall: Severity; checks: LabelAuditCheck[] }): void {
+function printReport(report: LabelAuditReport, format: LabelAuditFormat): void {
+  if (format === 'json') {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+
   const counts = {
     pass: report.checks.filter((check) => check.severity === 'pass').length,
     warning: report.checks.filter((check) => check.severity === 'warning').length,

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -12,6 +12,7 @@ import {
   createEvidenceCheckFixture,
   createExternalConfigPlanFixture,
   createFailingGitEnv,
+  createLabelAuditFixture,
   createMissingPath,
   createPreflightFixture,
   createSpecPlanFixture,
@@ -751,6 +752,7 @@ test('spec plan/config/clean help describe AI-facing usage and safety constraint
   assert.equal(labelAuditHelp.code, 0, labelAuditHelp.stderr);
   assert.match(labelAuditHelp.stdout, /label and milestone metadata audit/i);
   assert.match(labelAuditHelp.stdout, /--repo <owner\/name>/);
+  assert.match(labelAuditHelp.stdout, /--format <format>/);
   assert.match(labelAuditHelp.stdout, /reports only/i);
   assert.match(labelAuditHelp.stdout, /does not create, rename, delete, or mutate/i);
 });
@@ -4246,6 +4248,152 @@ test('spec evidence-check passes for complete PR and issue evidence without muta
   assert.match(result.stdout, /validation evidence lists exact commands/i);
   assert.equal(result.stderr, '');
   const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec label-audit keeps text output as the default and does not mutate GitHub state', async (t) => {
+  const fixture = await createLabelAuditFixture(t, {
+    issues: [{
+      number: 320,
+      title: 'Add label audit JSON output',
+      url: 'https://github.com/Erick52106/spec-injector/issues/320',
+      state: 'OPEN',
+      stateReason: null,
+      labels: [
+        { name: 'type:chore' },
+        { name: 'area:cli' },
+        { name: 'status:ready' },
+        { name: 'layer1 : Core Compiler' },
+      ],
+      milestone: { title: 'Layer 1 — Core Compiler' },
+    }],
+    prs: [],
+  });
+
+  const result = await runSpec([
+    'label-audit',
+    '--repo', fixture.repo,
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Label audit summary:\s+PASS/i);
+  assert.match(result.stdout, /\[PASS\] issue #320 has type metadata/i);
+  assert.equal(result.stderr, '');
+
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assert.match(ghLog, /issue list/);
+  assert.match(ghLog, /pr list/);
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec label-audit --format json prints parseable warning report without text summary', async (t) => {
+  const fixture = await createLabelAuditFixture(t, {
+    issues: [{
+      number: 321,
+      title: 'Missing classification labels',
+      url: 'https://github.com/Erick52106/spec-injector/issues/321',
+      state: 'OPEN',
+      stateReason: null,
+      labels: [],
+      milestone: null,
+    }],
+    prs: [],
+  });
+
+  const result = await runSpec([
+    'label-audit',
+    '--repo', fixture.repo,
+    '--format', 'json',
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(result.stderr, '');
+  assert.doesNotMatch(result.stdout, /Label audit summary:/i);
+  assert.doesNotMatch(result.stdout, /\[(PASS|WARNING|NEEDS-HUMAN-REVIEW)\]/i);
+
+  const report = JSON.parse(result.stdout) as {
+    overall?: unknown;
+    checks?: Array<Record<string, unknown>>;
+  };
+  assert.equal(report.overall, 'warning');
+  assert.ok(Array.isArray(report.checks));
+  assert.ok(report.checks.length > 0);
+  for (const check of report.checks) {
+    assert.equal(typeof check.severity, 'string');
+    assert.equal(typeof check.summary, 'string');
+    assert.equal(typeof check.detail, 'string');
+  }
+  assert.ok(report.checks.some((check) =>
+    check.severity === 'warning' &&
+    String(check.summary).includes('issue #321 is missing a type')
+  ));
+
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec label-audit --format json prints parseable needs-human-review report and exits non-zero', async (t) => {
+  const fixture = await createLabelAuditFixture(t, {
+    issues: [{
+      number: 322,
+      title: 'Conflicting status labels',
+      url: 'https://github.com/Erick52106/spec-injector/issues/322',
+      state: 'OPEN',
+      stateReason: null,
+      labels: [
+        { name: 'type:chore' },
+        { name: 'type:ci' },
+        { name: 'area:cli' },
+        { name: 'status:ready' },
+        { name: 'status:in-review' },
+        { name: 'layer1 : Core Compiler' },
+      ],
+      milestone: { title: 'Layer 1 — Core Compiler' },
+    }],
+    prs: [],
+  });
+
+  const result = await runSpec([
+    'label-audit',
+    '--repo', fixture.repo,
+    '--format', 'json',
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.equal(result.stderr, '');
+  assert.doesNotMatch(result.stdout, /Label audit summary:/i);
+
+  const report = JSON.parse(result.stdout) as {
+    overall?: unknown;
+    checks?: Array<Record<string, unknown>>;
+  };
+  assert.equal(report.overall, 'needs-human-review');
+  assert.ok(Array.isArray(report.checks));
+  assert.ok(report.checks.some((check) =>
+    check.severity === 'needs-human-review' &&
+    String(check.summary).includes('issue #322 has multiple type labels')
+  ));
+
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assertNoGhMutationCommands(ghLog);
+});
+
+test('spec label-audit rejects invalid --format value before reading gh', async (t) => {
+  const fixture = await createLabelAuditFixture(t);
+
+  const result = await runSpec([
+    'label-audit',
+    '--repo', fixture.repo,
+    '--format', 'yaml',
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stderr, /Invalid label-audit format "yaml"/i);
+  assert.match(result.stderr, /Expected one of: text, json/i);
+  assertNoRawStackTrace(result);
+
+  const ghLog = (await readGhLog(fixture.ghLogPath)).join('\n');
+  assert.equal(ghLog.trim(), '');
   assertNoGhMutationCommands(ghLog);
 });
 


### PR DESCRIPTION
Closes #320

## Summary
- Add `--format json` to `spec label-audit` while keeping text output as the default.
- Emit parseable JSON with `overall` and per-check `severity`, `summary`, and `detail` fields.
- Preserve read-only label-audit decision logic and exit-code behavior.

## Scope
- `src/cli/label-audit.ts`
- `src/cli/index.ts`
- `tests/cli.integration.test.ts`

## Tests / validation
- `pnpm build && node --test tests/cli.integration.test.ts --test-name-pattern "label-audit.*json|label-audit.*format|label-audit"` -> pass, 228 tests
- `git diff --check` -> pass
- `pnpm test` -> pass, 307 pass / 2 skip
- `pnpm build` -> pass

## Implementation Evidence
- issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/320#issuecomment-4530571731
- commit hash: `2b88027809a8648da3a742b2651722cd66fee072`

## Spec gate evidence
- spec_evidence_status: pass
- spec_evidence_ref: https://github.com/Erick52106/spec-injector/issues/320#issuecomment-4530571731

## Routing evidence
- routing_evidence_status: pass
- routing_evidence_ref: AWP worker `019e5c5d-3c18-72c2-9939-6f2dd918da8f`
- delegation_outcome: completed
- explicit fallback: not used

## Review finding disposition
- finding_disposition_status: pass
- finding_disposition_ref: GitHub readback for head `2b88027809a8648da3a742b2651722cd66fee072` found 0 review threads; CodeRabbit reported no actionable comments.
- CodeRabbit docstring coverage warning: noise / not applicable. The repository does not define a docstring coverage gate, this PR changes CLI output plumbing with integration tests, and adding docstrings would be unrelated commit noise.

## Merge closeout
- ready_to_merge: yes
- merge_gate: pass
- head_sha: `2b88027809a8648da3a742b2651722cd66fee072`
- checks: build pass; CodeRabbit pass
- review_threads: 0
- merge_state: CLEAN

## Non-goals
- No auto-labeling, auto-milestone, auto-close, or GitHub mutation behavior was added.
- No label-audit decision logic was changed.
- No hosted control plane, daemon, dashboard, agent runtime, or downstream repo Scope Police change.
