### PR TITLE
feat(preflight): add json output

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -122,6 +122,7 @@ program
   .option('--expected-branch <name>', 'Expected current branch name for the dedicated worktree')
   .option('--expected-worktree-root <path>', 'Expected parent directory for dedicated worktrees')
   .option('--target-repo <path>', 'Optional target repo path for read-only safety checks')
+  .option('--format <format>', 'Output format: text or json (default: text)')
   .addHelpText('after', `
 Checks:
   - main repo clean / synced status
@@ -139,6 +140,7 @@ Safety:
     expectedBranch?: string;
     expectedWorktreeRoot?: string;
     targetRepo?: string;
+    format?: string;
   }) => {
     const { preflight } = await import('./preflight.js');
     await preflight(opts);

--- a/src/cli/preflight.ts
+++ b/src/cli/preflight.ts
@@ -17,20 +17,24 @@ type PreflightCheck = {
   detail: string;
 };
 
+type PreflightFormat = 'text' | 'json';
+
 type PreflightOptions = {
   repo?: string;
   expectedBranch?: string;
   expectedWorktreeRoot?: string;
   targetRepo?: string;
+  format?: string;
 };
 
 export async function preflight(opts: PreflightOptions): Promise<void> {
+  const format = parseFormat(opts.format);
   const repoPath = canonicalizePath(path.resolve(opts.repo ?? process.cwd()));
 
   try {
     ensureRepoPath(repoPath);
     const report = buildPreflightReport(repoPath, opts);
-    printReport(report);
+    printReport(report, format);
 
     if (report.overall === 'fail' || report.overall === 'needs-human-review') {
       process.exit(1);
@@ -39,6 +43,12 @@ export async function preflight(opts: PreflightOptions): Promise<void> {
     console.error(`✗ Preflight failed: ${(err as Error).message}`);
     process.exit(1);
   }
+}
+
+function parseFormat(formatOption: string | undefined): PreflightFormat {
+  if (!formatOption || formatOption === 'text') return 'text';
+  if (formatOption === 'json') return 'json';
+  throw new Error(`Invalid preflight format "${formatOption}". Expected one of: text, json.`);
 }
 
 function buildPreflightReport(repoPath: string, opts: PreflightOptions): {
@@ -218,7 +228,12 @@ function summarizeOverall(checks: PreflightCheck[]): PreflightSeverity {
   return 'pass';
 }
 
-function printReport(report: { overall: PreflightSeverity; checks: PreflightCheck[] }): void {
+function printReport(report: { overall: PreflightSeverity; checks: PreflightCheck[] }, format: PreflightFormat): void {
+  if (format === 'json') {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+
   const counts = {
     pass: report.checks.filter((check) => check.severity === 'pass').length,
     warning: report.checks.filter((check) => check.severity === 'warning').length,

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -4050,6 +4050,85 @@ test('spec preflight passes for a clean dedicated worktree and avoids mutating g
   assertNoGitMutationCommands(gitLog);
 });
 
+test('spec preflight --format json prints a parseable machine-readable report', async (t) => {
+  const fixture = await createPreflightFixture(t);
+
+  const result = await runSpec([
+    'preflight',
+    '--repo', fixture.worktreeDir,
+    '--expected-branch', fixture.branchName,
+    '--expected-worktree-root', path.dirname(fixture.worktreeDir),
+    '--format', 'json',
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(result.stderr, '');
+  assert.doesNotMatch(result.stdout, /Preflight summary/i);
+
+  const parsed = JSON.parse(result.stdout) as {
+    overall?: unknown;
+    checks?: Array<{ severity?: unknown; summary?: unknown; detail?: unknown }>;
+  };
+  assert.equal(parsed.overall, 'pass');
+  assert.ok(Array.isArray(parsed.checks));
+  assert.ok(parsed.checks.length > 0);
+  assert.ok(parsed.checks.every((check) => typeof check.severity === 'string'));
+  assert.ok(parsed.checks.every((check) => typeof check.summary === 'string'));
+  assert.ok(parsed.checks.every((check) => typeof check.detail === 'string'));
+  assert.ok(parsed.checks.some((check) => check.summary === 'current worktree is dedicated'));
+
+  const gitLog = (await readGhLog(fixture.gitLogPath)).join('\n');
+  assertNoGitMutationCommands(gitLog);
+});
+
+test('spec preflight --format json preserves non-zero exit behavior for failing checks', async (t) => {
+  const fixture = await createPreflightFixture(t);
+
+  const result = await runSpec([
+    'preflight',
+    '--repo', fixture.worktreeDir,
+    '--expected-branch', 'feat/some-other-branch',
+    '--format', 'json',
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.equal(result.stderr, '');
+  const parsed = JSON.parse(result.stdout) as {
+    overall?: unknown;
+    checks?: Array<{ severity?: unknown; summary?: unknown; detail?: unknown }>;
+  };
+  assert.equal(parsed.overall, 'fail');
+  assert.ok(parsed.checks?.some((check) =>
+    check.severity === 'fail' &&
+    check.summary === 'current branch does not match expected branch' &&
+    typeof check.detail === 'string' &&
+    check.detail.includes('feat/some-other-branch')
+  ));
+
+  const gitLog = (await readGhLog(fixture.gitLogPath)).join('\n');
+  assertNoGitMutationCommands(gitLog);
+});
+
+test('spec preflight rejects invalid --format before running git checks', async (t) => {
+  const fixture = await createPreflightFixture(t);
+
+  const result = await runSpec([
+    'preflight',
+    '--repo', fixture.worktreeDir,
+    '--expected-branch', fixture.branchName,
+    '--format', 'yaml',
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.equal(result.stdout, '');
+  assert.match(result.stderr, /Invalid preflight format "yaml"/i);
+  assert.match(result.stderr, /text, json/i);
+  assertNoRawStackTrace(result);
+
+  const gitLog = (await readGhLog(fixture.gitLogPath)).join('\n');
+  assert.equal(gitLog, '');
+});
+
 test('spec preflight reports the actual main upstream ref in sync summaries', async (t) => {
   const fixture = await createPreflightFixture(t);
   await runCommand('git', ['remote', 'rename', 'origin', 'upstream'], fixture.mainRepoDir);


### PR DESCRIPTION
Closes #322

## Summary
- Add `--format json` to `spec preflight` while keeping text output as the default.
- Emit parseable JSON with `overall` and per-check `severity`, `summary`, and `detail` fields.
- Preserve existing preflight exit-code behavior and read-only safety boundaries.

## Scope
- `src/cli/preflight.ts`
- `src/cli/index.ts`
- `tests/cli.integration.test.ts`

## Tests / validation
- `pnpm build && node --test tests/cli.integration.test.ts --test-name-pattern "preflight"` -> pass, 231 tests
- `git diff --check HEAD~1..HEAD` -> pass
- `pnpm test` -> pass, 310 pass / 2 skip
- `pnpm build` -> pass

## Implementation Evidence
- issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/322#issuecomment-4530618013
- commit hash: `e7df7c7a293fe3a63eda61a68368f5482d456b60`

## Spec gate evidence
- spec_evidence_status: pass
- spec_evidence_ref: https://github.com/Erick52106/spec-injector/issues/322#issuecomment-4530618013

## Routing evidence
- routing_evidence_status: pass
- routing_evidence_ref: AWP worker `019e5c72-7924-7302-8539-b1429e30fc20`
- delegation_outcome: completed
- explicit fallback: not used

## Review finding disposition
- finding_disposition_status: pass
- finding_disposition_ref: Spec compliance reviewer `019e5c75-bc74-7dd1-885e-de677f3c13bd` PASS; code quality reviewer `019e5c75-d634-7070-8af1-6eed4e3e043f` APPROVED; GitHub readback for head `e7df7c7a293fe3a63eda61a68368f5482d456b60` found 0 review threads and 0 submitted reviews.
- Automated review rate-limit notice: manual fallback accepted / no actionable finding available. The automated review comment says review capacity was exhausted before analysis started, so there are no code findings to adopt or reject. This PR still has explicit AWP spec and quality reviewer evidence plus local and remote CI validation.

## Merge closeout
- ready_to_merge: yes
- merge_gate: pass
- head_sha: `e7df7c7a293fe3a63eda61a68368f5482d456b60`
- checks: build pass; automated review status context pass with rate-limit notice recorded above
- review_threads: 0
- merge_state: CLEAN

## Non-goals
- No `workflow-check` flags, JSON schema, or exit-code semantics changed.
- No hosted control plane, daemon, dashboard, auto-comment, auto-merge, or agent runtime added.
- No generated output files or target repo mutation behavior added.
- No preflight auto-fix behavior added.
