### PR TITLE
feat(workflow): harden dogfood-derived evidence gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ spec workflow-check --repo . --phase commit --pr-body /path/to/pr-body.md --rout
 spec awp-review-check --repo . --evidence /path/to/awp-review-evidence.json
 spec workflow-check --repo . --phase merge --pr-body /path/to/pr-body.md --finding-disposition /path/to/findings.json
 spec workflow-check --repo . --phase merge --pr-body /path/to/pr-body.md --threshold-evidence /path/to/threshold.json
+spec workflow-check --repo . --phase merge --pr-body /path/to/pr-body.md --head-sha <sha> --readback-evidence /path/to/readback.json
 spec workflow-check --repo . --phase merge --pr <number-or-url> --format json
 spec doctor --workflow awp --format json
 ```
@@ -198,8 +199,8 @@ Notes:
 - `spec workflow-check` is a local-only, stdout-first workflow gate for autonomous PR evidence. It does not edit GitHub, add/commit files, write task packages, comment, merge, or mutate downstream repos.
 - Autonomous worker-routing flow 可在 implementation 開始前使用 [Hybrid AWP routing policy](docs/hybrid-awp-routing-policy.md) 作為 start-gate source of truth。
 - Downstream AI entrypoints 可引用 [AI bootstrap install contract](docs/ai-bootstrap-install-contract.md)，用 `SPEC_INJECTOR_DIR` local runner fallback 與 `spec doctor --workflow awp --format json` 檢查 AWP capability，不需要 global install。
-- `spec workflow-check --format json` emits the same stable fields as the text output: `phase`, `status`, `repo`, `head_sha`, `checked_at`, `missing_fields`, `warnings`, and `evidence_summary`.
-- Hybrid AWP checks add optional JSON/text fields such as `routing_mode`, `routing_task_class`, `spark_required`, `worker_5_4_required`, `controller_role`, `controller_fallback`, `controller_fallback_reason`, `delegation_outcome`, `fallback_status`, `fallback_reason_quality`, `routing_mismatch`, `human_review_status`, and `draft_status`.
+- `spec workflow-check --format json` emits the same stable fields as the text output: `phase`, `status`, `repo`, `head_sha`, `checked_at`, `missing_fields`, `warnings`, and `evidence_summary`. Additive fields such as `blocking_reason` and `manual_reason` point to the first deterministic blocker or manual gate.
+- Hybrid AWP checks add optional JSON/text fields such as `routing_mode`, `routing_task_class`, `spark_required`, `worker_5_4_required`, `controller_role`, `controller_fallback`, `controller_fallback_reason`, `delegation_outcome`, `fallback_status`, `fallback_reason_quality`, `routing_mismatch`, `closeout_readback_status`, `checks_status`, `human_review_status`, `draft_status`, `ready_to_merge`, and `unresolved_review_threads_count`.
 - Downstream repos such as `tachigo` / `tachiya` only need to copy or reference the workflow-check `status` and evidence `ref` in their PR body / ledger. Their Scope Police workflows should not parse full `spec plan` or task-package evidence. See the [target repo adoption contract](docs/target-repo-adoption-contract.md).
 - AWP review follow-up 可使用 [AWP review triage gates](docs/awp-review-triage-gates.md) 與 `spec awp-review-check --repo . --evidence <path>` 檢查 review batch freshness、duplicate collapse、root-cause gate、patch budget 與 closeout ledger。這個 checker 只讀 local JSON，不讀寫 GitHub、不 resolve thread、不 auto-fix、不 merge。
 
@@ -207,7 +208,7 @@ Notes:
 
 - `start`: validates repo config. With `--issue`, it performs a dry-run bounded context check through `spec plan --dry-run --format prompt --verbose` without writing a task package. If the issue has an AWP / Codex autonomous routing signal, it also emits a deterministic Hybrid AWP routing plan; if no autonomous signal is present, routing fields are `n/a` and ordinary workflows do not fail.
 - `commit`: checks staged files for `.spec-injector/`, generated task packages / spec output, and private context artifacts. With `--pr-body`, it also checks for spec gate status/ref or manual fallback evidence. With `--routing-evidence`, it checks local PR body routing status/ref, delegation log, Spark / ops evidence, 5.4 worker evidence, and explicit fallback quality.
-- `merge`: checks a local PR body for final merge gate evidence, spec gate status/ref, and latest HEAD SHA. With `--head-sha`, stale or mismatched evidence fails. With `--routing-evidence`, stale start-gate routing evidence or routing/PR-body mismatch fails. With `--pr`, merge closeout readback can continue without local `.spec-injector/config.json`; missing local config is reported as a warning while GitHub PR body / checks / reviews are read.
+- `merge`: checks a local PR body for final merge gate evidence, spec gate status/ref, latest HEAD SHA, and stale pending closeout wording. With `--head-sha`, stale or mismatched evidence fails. With `--routing-evidence`, stale start-gate routing evidence or routing/PR-body mismatch fails. With `--readback-evidence`, local merge closeout JSON can classify checks / review threads / review decision as pass, fail, or manual without calling GitHub. With `--pr`, merge closeout readback can continue without local `.spec-injector/config.json`; missing local config is reported as a warning while GitHub PR body / checks / reviews are read.
 
 ## Optional live gh smoke test
 

--- a/docs/ai-bootstrap-install-contract.md
+++ b/docs/ai-bootstrap-install-contract.md
@@ -23,6 +23,7 @@ The AWP workflow requires `workflow-check` support for:
 - `--phase start|commit|merge`
 - `--finding-disposition`
 - `--threshold-evidence`
+- `--readback-evidence`
 - `--pr`
 
 `spec doctor --workflow awp --format json` is the stable machine-readable readiness check. A `status` of `pass` means the installed CLI exposes the current AWP workflow capabilities. A `status` of `fail` means the bootstrap should use the local runner fallback below or stop for human review.
@@ -77,6 +78,7 @@ Target repo docs can then invoke:
 ```bash
 $SPEC_RUNNER workflow-check --repo . --phase start --issue <number-or-url> --format json
 $SPEC_RUNNER workflow-check --repo . --phase commit --pr-body /path/to/pr-body.md --format json
+$SPEC_RUNNER workflow-check --repo . --phase merge --pr-body /path/to/pr-body.md --head-sha <sha> --readback-evidence /path/to/readback.json --format json
 $SPEC_RUNNER workflow-check --repo . --phase merge --pr <number-or-url> --format json
 ```
 

--- a/docs/target-repo-adoption-contract.md
+++ b/docs/target-repo-adoption-contract.md
@@ -8,9 +8,9 @@ Target repos can use the published CLI behavior directly when `spec-injector` is
 
 - `spec workflow-check --phase start` can emit local Hybrid AWP routing evidence.
 - `spec workflow-check --phase commit` can validate staged-state safety plus PR body status/ref evidence.
-- `spec workflow-check --phase merge` can validate final merge gate evidence, HEAD freshness, finding disposition evidence, threshold calibration evidence, and optional read-only closeout readback.
+- `spec workflow-check --phase merge` can validate final merge gate evidence, HEAD freshness, finding disposition evidence, threshold calibration evidence, stale pending closeout wording, and optional read-only closeout readback.
 - Text output is human-readable; `--format json` emits machine-readable status fields for downstream ledgers.
-- Local JSON inputs such as `--routing-evidence`, `--finding-disposition`, and `--threshold-evidence` stay stdout-first and local-only.
+- Local JSON inputs such as `--routing-evidence`, `--finding-disposition`, `--threshold-evidence`, and `--readback-evidence` stay stdout-first and local-only.
 - Offline/manual checklist fallback remains valid for repos that have not fully adopted `spec-injector`.
 - Target repo PR bodies only need stable status/ref evidence, not full task packages or full AWP review ledgers.
 
@@ -58,6 +58,10 @@ A `tachigo` autonomous PR body can keep a thin evidence section:
 
 The target repo gate only needs the `status` / `ref` fields. The full routing plan, threshold ledger, and finding disposition ledger can remain behind the referenced evidence.
 
+If a PR body still contains pre-PR closeout wording such as `pending`, `unknown`, or `PR not created yet` in the final merge gate, `spec workflow-check --phase merge` treats that as stale evidence. Refresh the PR body before using it as merge evidence.
+
+Review finding dispositions can use either machine-friendly values or the human review vocabulary used in repo workflows: `adopted`, `not adopted`, `optional polish`, `noise / not applicable`, and `needs human review`. `needs human review` is a blocking disposition until a human decision is recorded.
+
 ## Tachiya Example
 
 A `tachiya` PR can use the same status/ref shape even if the repository keeps a different PR template:
@@ -85,5 +89,6 @@ If `tachiya` only has manual checklist fallback for a small change, the checker 
 - Keep generated outputs and private context out of git.
 - Store only status/ref evidence in PR bodies unless a repo explicitly wants more detail.
 - Run `spec workflow-check --format json` locally or in a trusted tooling step.
+- For remote readback collected by another tool, pass a local `--readback-evidence <path>` JSON file rather than asking Scope Police to parse full review transcripts.
 - Use target repo PRs only when changing repo-local docs, templates, CI, or Scope Police enforcement.
 - Preserve human merge authorization as the final gate.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -14,7 +14,7 @@ Issue / PR label taxonomy、visual hierarchy、combination rules、migration sta
 
 Autonomous Worker Profiles / Codex autonomous PR work 的 start-gate routing source of truth 見 [Hybrid AWP routing policy](hybrid-awp-routing-policy.md)。該 policy 只適用於有明確 autonomous routing signal 的 workflow；一般 human PR 或非 autonomous work 不應因缺少 AWP routing evidence 而 fail。
 
-核心 AWP baseline 變更受 [AWP Dogfood Outcome Ledger](awp-dogfood-outcome-ledger.md) 的 #258 freeze gate 控制。未累積至少 5 張真實 AWP PR outcome sample 前，除 P0 break-glass 外，不新增 session / hook / enforcement surface，也不更改 `spec workflow-check` flags 或 schema。
+核心 AWP baseline 變更受 [AWP Dogfood Outcome Ledger](awp-dogfood-outcome-ledger.md) 的 #258 freeze gate 控制。未累積至少 5 張真實 AWP PR outcome sample 前，除 P0 break-glass 外，不新增 session / hook / enforcement surface。Dogfood 已重複證實的 local-only evidence hardening 可以 additive 方式進入 `spec workflow-check`，但不得變成 worker runtime、GitHub mutation 或 downstream Scope Police full-evidence parser。
 
 若 autonomous workflow 有 start-gate routing evidence，可在 commit / merge 階段用 local file 傳入 `spec workflow-check --routing-evidence <path>`。該檢查只讀本地 PR body 與本地 routing JSON，驗證 status/ref、delegation log、Spark / ops evidence、5.4 worker evidence、explicit fallback reason 與 merge HEAD freshness；它不讀取或修改 GitHub remote state，也不要求 downstream Scope Police 解析完整 routing plan。
 
@@ -114,6 +114,8 @@ CodeRabbit / Codex auto review findings 只能作為 auxiliary signals。`spec e
 Thread-level limitation：`spec evidence-check` 目前只做 read-only 輔助檢核，不會完整 enforce GitHub review thread / conversation closeout。它可提醒 PR body / evidence / HEAD / validation / findings shape，但不能保證每條 CodeRabbit / Codex / human thread 都已關閉。`PASS` 僅表示輔助欄位滿足程度，不是 merge approval。該 checker 不能 auto-comment、auto-resolve、auto-merge、auto-close，也不會 mutate GitHub issue / PR metadata；最終 thread-level closeout 必須由 human 逐條確認與接手。
 
 `spec workflow-check --phase merge --pr <number-or-url>` 可做 local-only merge closeout readback。它會讀取 PR body、draft state、review metadata、`gh pr checks` summary 與 review threads，並把無法可靠判斷的 GitHub / `gh` output drift 回報成 `manual` fallback，而不是把工具層 schema mismatch 誤判成 PR 本身不可 merge。這個 `--pr` readback path 不依賴 target repo `.spec-injector/config.json`；若 local config 不存在，checker 會保留 warning 並繼續 readback，避免 repo-local closeout 被 config bootstrap 狀態誤擋。`start` / `commit` phase 仍需要 local config。若 checks readback 回傳缺欄位、未知 enum、或只有無法歸類的 status shape，controller 應以 PR 頁面、`gh pr checks`、Actions UI、review thread readback 補人工 evidence；不得因 manual fallback 自動 merge，也不得讓 checker auto-comment、auto-resolve 或 mutate GitHub。
+
+若 GitHub readback 已由外部 workflow 或 controller 收集，可用 `spec workflow-check --phase merge --pr-body <path> --head-sha <sha> --readback-evidence <path>` 驗證本地 closeout JSON。該 JSON 只作為 local input，不授權 checker 呼叫 GitHub 或修改遠端狀態。`reviewDecision=REVIEW_REQUIRED` / `mergeStateStatus=BLOCKED` 這類需要 human approval 的狀態應回 `manual`，不是假裝 pass。PR body 內殘留 `pending`、`unknown`、`PR not created yet` 等 pre-PR closeout wording 時，merge gate 應 fail 並要求刷新 evidence。
 
 ## Worktree naming
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "files": [
     "dist",
     "bin",
+    "docs",
     "presets",
     "README.md"
   ],

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -49,6 +49,10 @@ async function runDoctor(workflow: string): Promise<DoctorResult> {
   const rootHelp = runSpecHelp(['--help']);
   const workflowHelp = runSpecHelp(['workflow-check', '--help']);
   const awpReviewHelp = runSpecHelp(['awp-review-check', '--help']);
+  const [adoptionContract, bootstrapContract] = await Promise.all([
+    readDocContract('docs/target-repo-adoption-contract.md', [/status\/ref/i, /Scope Police/i, /does not mutate downstream repos/i]),
+    readDocContract('docs/ai-bootstrap-install-contract.md', [/SPEC_INJECTOR_DIR/i, /spec doctor --workflow awp --format json/i, /does not call GitHub/i]),
+  ]);
 
   const workflowOutput = `${workflowHelp.stdout}\n${workflowHelp.stderr}`;
   const capabilities: Capability[] = [
@@ -77,10 +81,28 @@ async function runDoctor(workflow: string): Promise<DoctorResult> {
       evidence: 'spec workflow-check --help includes --threshold-evidence',
     },
     {
+      id: 'workflow_check_readback_evidence',
+      status: /--readback-evidence\b/.test(workflowOutput) ? 'pass' : 'fail',
+      required: true,
+      evidence: 'spec workflow-check --help includes --readback-evidence',
+    },
+    {
       id: 'workflow_check_pr_readback',
       status: hasLongOption(workflowOutput, 'pr') ? 'pass' : 'fail',
       required: true,
       evidence: 'spec workflow-check --help includes --pr',
+    },
+    {
+      id: 'target_repo_adoption_contract_doc',
+      status: adoptionContract ? 'pass' : 'fail',
+      required: true,
+      evidence: 'docs/target-repo-adoption-contract.md documents status/ref thin wiring and no mutation',
+    },
+    {
+      id: 'ai_bootstrap_install_contract_doc',
+      status: bootstrapContract ? 'pass' : 'fail',
+      required: true,
+      evidence: 'docs/ai-bootstrap-install-contract.md documents SPEC_INJECTOR_DIR fallback and local-only doctor',
     },
     {
       id: 'awp_review_check_command',
@@ -155,6 +177,15 @@ async function readPackageVersion(): Promise<string> {
     return parsed.version ?? 'unknown';
   } catch {
     return 'unknown';
+  }
+}
+
+async function readDocContract(docPath: string, requiredPatterns: RegExp[]): Promise<boolean> {
+  try {
+    const content = await fs.readFile(path.join(packageRoot(), docPath), 'utf8');
+    return requiredPatterns.every((pattern) => pattern.test(content));
+  } catch {
+    return false;
   }
 }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -192,12 +192,14 @@ program
   .option('--routing-evidence <path>', 'Path to local Hybrid AWP start-gate routing evidence JSON')
   .option('--finding-disposition <path>', 'Path to local review finding disposition evidence JSON')
   .option('--threshold-evidence <path>', 'Path to local threshold calibration evidence JSON')
+  .option('--readback-evidence <path>', 'Path to local merge closeout readback evidence JSON')
   .addHelpText('after', `
 Checks:
   - start: validate config; with --issue, dry-run bounded context generation without writing a task package
   - commit: detect staged .spec-injector/spec output/private context artifacts and optional PR body spec/routing evidence
   - merge: require final merge gate, spec gate status/ref, routing evidence alignment, finding disposition evidence, threshold evidence, and latest HEAD evidence in the local PR body
   - merge with --pr: collect read-only closeout readback evidence from gh without mutating GitHub
+  - merge with --readback-evidence: validate local closeout readback JSON without calling GitHub
 
 Safety:
   Local-only workflow gate. Prints to stdout by default.
@@ -219,6 +221,7 @@ Examples:
     routingEvidence?: string;
     findingDisposition?: string;
     thresholdEvidence?: string;
+    readbackEvidence?: string;
   }) => {
     const { workflowCheck } = await import('./workflow-check.js');
     await workflowCheck(opts);

--- a/src/cli/workflow-check.ts
+++ b/src/cli/workflow-check.ts
@@ -24,6 +24,7 @@ type WorkflowCheckOptions = {
   routingEvidence?: string;
   findingDisposition?: string;
   thresholdEvidence?: string;
+  readbackEvidence?: string;
 };
 
 type WorkflowCheckResult = {
@@ -65,6 +66,8 @@ type WorkflowCheckResult = {
   spec_gate_status?: string;
   routing_evidence_status?: string;
   ready_to_merge?: 'yes' | 'no' | 'manual';
+  blocking_reason?: string;
+  manual_reason?: string;
 };
 
 type PrBodyEvidence = {
@@ -97,6 +100,7 @@ type PrBodyEvidence = {
   hasFindingDispositionRef: boolean;
   findingDispositionRef: string | null;
   readyToMerge: 'yes' | 'no' | 'manual' | null;
+  hasStaleCloseoutEvidence: boolean;
 };
 
 type RoutingTaskClass =
@@ -194,6 +198,7 @@ const SPEC_REF_PATTERN = /\b(?:spec[_ -]evidence[_ -]ref|spec[_ -]gate[_ -]ref|w
 const MANUAL_FALLBACK_PATTERN = /\bmanual(?: checklist)? fallback\b|\bmanual spec gate\b|\bmanual workflow gate\b/i;
 const FINAL_MERGE_GATE_PATTERN = /\bfinal merge gate\b|\bmerge gate\b/i;
 const LATEST_HEAD_PATTERN = /\b(?:latest head|head sha|commit hash|head)\b[^\n\r]{0,80}\b[0-9a-f]{7,40}\b/i;
+const STALE_CLOSEOUT_PATTERN = /\b(?:ready[- ]to[- ]merge decision|required checks|coderabbit|chatgpt-codex-connector|remote review|final merge gate)\b[^\n\r]{0,160}\b(?:pending|unknown|pr not created yet|not available before pr creation)\b/i;
 const ROUTING_STATUS_PATTERN = /\b(?:routing[_ -]evidence[_ -]status|routing status)\b\s*[:=]\s*(pass|fail|manual|skipped|pending|unknown)\s*$/im;
 const GENERIC_STATUS_VALUES = ['pass', 'fail', 'manual', 'skipped', 'pending', 'unknown'] as const;
 const AUTONOMOUS_SIGNAL_PATTERN = /\b(?:Autonomous Worker Profiles|Hybrid AWP|AWP|Codex autonomous PR|controller_fallback|Delegation Execution Log)\b/i;
@@ -204,7 +209,7 @@ const WORKER_54_EVIDENCE_PATTERN = /\b(?:worker_5_4|5\.4 worker|implementation w
 const CONTROLLER_ONLY_PATTERN = /\b(?:controller-only|controller only|controller_fallback\s*[:=]\s*allowed|controller fallback\s*[:=]\s*allowed)\b/i;
 const WEAK_FALLBACK_REASONS = new Set(['', 'n/a', 'na', 'none', 'small', 'done', 'ok', 'trivial']);
 const FINDING_SOURCES = ['coderabbit', 'chatgpt-codex-connector', 'human', 'self-review'];
-const FINDING_STATUSES = ['adopted', 'not_adopted', 'deferred_follow_up', 'blocked', 'noise'];
+const FINDING_STATUSES = ['adopted', 'not_adopted', 'optional_polish', 'deferred_follow_up', 'blocked', 'noise', 'needs_human_review'];
 const DELEGATION_OUTCOMES = ['n/a', 'skipped', 'completed', 'fell_through', 'unavailable'] as const;
 const THRESHOLD_TASK_SIZES = ['tiny', 'small', 'medium', 'large'];
 const THRESHOLD_RISKS = ['low', 'medium', 'high'];
@@ -618,6 +623,7 @@ async function runMergePhase(
   let routing: RoutingEvidence | null = null;
   const findingDisposition = await readOptionalFindingDispositionAssessment(opts.findingDisposition, warnings);
   const threshold = await readOptionalThresholdAssessment(opts.thresholdEvidence, warnings);
+  const closeoutReadback = await readOptionalCloseoutReadbackAssessment(opts.readbackEvidence, opts.headSha);
   try {
     evidence = await parsePrBodyEvidence(opts.prBody, opts.headSha);
   } catch (err) {
@@ -646,11 +652,14 @@ async function runMergePhase(
   }
 
   const missingFields = missingMergeFields(evidence, Boolean(opts.headSha));
+  const bodyMissingFields = [...missingFields];
   if (isBlockedSpecStatus(evidence.specStatus)) {
     missingFields.push('ready_spec_gate_status');
+    bodyMissingFields.push('ready_spec_gate_status');
   }
   if (evidence.headMatches === false) {
     missingFields.push('head_sha_freshness');
+    bodyMissingFields.push('head_sha_freshness');
   }
   const routingCheck = routing ? assessRoutingAlignment(routing, evidence, 'merge', opts.headSha) : null;
   const delegationOutcome = resolveDelegationOutcome(evidence, routing);
@@ -658,6 +667,12 @@ async function runMergePhase(
   if (routingCheck) missingFields.push(...routingCheck.routing_mismatch);
   if (findingDisposition) missingFields.push(...findingDisposition.missingFields);
   if (threshold) missingFields.push(...threshold.missingFields);
+  if (closeoutReadback) missingFields.push(...closeoutReadback.missingFields);
+  const canReturnManualForReadback = closeoutReadback?.status === 'manual' &&
+    bodyMissingFields.length === 0 &&
+    routingCheck?.fallback_status !== 'fail' &&
+    findingDisposition?.status !== 'fail' &&
+    threshold?.status !== 'fail';
 
   if (evidence.hasManualFallback && missingFields.length > 0 && !isBlockedSpecStatus(evidence.specStatus) && evidence.headMatches !== false) {
     return buildResult({
@@ -673,6 +688,7 @@ async function runMergePhase(
       findingDispositionAssessment: findingDisposition,
       threshold: threshold?.evidence,
       thresholdAssessment: threshold,
+      closeout: closeoutReadback ?? undefined,
       delegationOutcome,
     });
   }
@@ -682,15 +698,18 @@ async function runMergePhase(
       phase: 'merge',
       repoPath,
       checkedAt,
-      status: 'fail',
+      status: canReturnManualForReadback ? 'manual' : 'fail',
       missingFields,
-      warnings: [...warnings, ...delegationWarnings, ...(findingDisposition?.warnings ?? []), ...(threshold?.warnings ?? [])],
-      evidenceSummary: renderMergeFailureSummary(missingFields),
+      warnings: [...warnings, ...delegationWarnings, ...(findingDisposition?.warnings ?? []), ...(threshold?.warnings ?? []), ...(closeoutReadback?.warnings ?? [])],
+      evidenceSummary: canReturnManualForReadback
+        ? `merge gate requires manual fallback: ${closeoutReadback.missingFields.join(', ')}`
+        : renderMergeFailureSummary(missingFields),
       routing: routing ?? undefined,
       fallback: routingCheck ?? undefined,
       findingDispositionAssessment: findingDisposition,
       threshold: threshold?.evidence,
       thresholdAssessment: threshold,
+      closeout: closeoutReadback ?? undefined,
       delegationOutcome,
     });
   }
@@ -701,13 +720,14 @@ async function runMergePhase(
     checkedAt,
     status: 'pass',
     missingFields: [],
-    warnings: [...warnings, ...delegationWarnings, ...(findingDisposition?.warnings ?? []), ...(threshold?.warnings ?? [])],
+    warnings: [...warnings, ...delegationWarnings, ...(findingDisposition?.warnings ?? []), ...(threshold?.warnings ?? []), ...(closeoutReadback?.warnings ?? [])],
     evidenceSummary: 'merge gate passed: final merge gate, spec evidence, and HEAD freshness are present',
     routing: routing ?? undefined,
     fallback: routingCheck ?? inferFallbackFromEvidence(evidence),
     findingDispositionAssessment: findingDisposition,
     threshold: threshold?.evidence,
     thresholdAssessment: threshold,
+    closeout: closeoutReadback ?? undefined,
     delegationOutcome,
   });
 }
@@ -973,6 +993,7 @@ function parsePrBodyEvidenceText(body: string, expectedHeadSha?: string): PrBody
     hasFindingDispositionRef: Boolean(findingDispositionRef),
     findingDispositionRef,
     readyToMerge,
+    hasStaleCloseoutEvidence: STALE_CLOSEOUT_PATTERN.test(body),
   };
 }
 
@@ -1034,6 +1055,79 @@ async function readOptionalFindingDispositionAssessment(
   }
 }
 
+async function readOptionalCloseoutReadbackAssessment(
+  closeoutReadbackPath: string | undefined,
+  expectedHeadSha?: string
+): Promise<CloseoutReadback | null> {
+  if (!closeoutReadbackPath) return null;
+  try {
+    const raw = JSON.parse(await fs.readFile(path.resolve(closeoutReadbackPath), 'utf8')) as Record<string, unknown>;
+    return assessCloseoutReadbackEvidence(raw, expectedHeadSha);
+  } catch (err) {
+    return manualCloseout(['readback_evidence'], [`Could not read closeout readback evidence: ${(err as Error).message}`]);
+  }
+}
+
+function assessCloseoutReadbackEvidence(raw: Record<string, unknown>, expectedHeadSha?: string): CloseoutReadback {
+  const missing: string[] = [];
+  const warnings: string[] = [];
+  const checksStatus = parseWorkflowStatusField(raw.checks_status, 'checks_status', missing);
+  const coderabbitStatus = parseAutomationStatusField(raw.coderabbit_status, 'coderabbit_status', missing);
+  const codexConnectorStatus = parseAutomationStatusField(raw.codex_connector_status, 'codex_connector_status', missing);
+  const draftStatus = parseWorkflowStatusField(raw.draft_status, 'draft_status', missing);
+  const sourceIssueEvidenceStatus = parseWorkflowStatusField(raw.source_issue_evidence_status, 'source_issue_evidence_status', missing);
+  const specGateStatus = parseWorkflowStatusField(raw.spec_gate_status, 'spec_gate_status', missing);
+  const routingEvidenceStatus = parseWorkflowStatusField(raw.routing_evidence_status, 'routing_evidence_status', missing);
+  const findingDispositionStatus = parseWorkflowStatusField(raw.finding_disposition_status, 'finding_disposition_status', missing);
+  const readyToMerge = parseReadyToMergeValue(raw.ready_to_merge, missing);
+  const unresolvedReviewThreadsCount = parseReviewThreadCount(raw.unresolved_review_threads_count, missing);
+  const humanReviewStatus = summarizeReadbackHumanReview(raw, missing);
+
+  if (expectedHeadSha && raw.head_sha !== expectedHeadSha) missing.push('head_sha_freshness');
+  if (checksStatus !== 'pass') missing.push('checks_status');
+  if (unresolvedReviewThreadsCount !== null && unresolvedReviewThreadsCount > 0) missing.push('unresolved_review_threads');
+  if (humanReviewStatus !== 'pass') missing.push('human_review_status');
+  if (draftStatus !== 'pass') missing.push('draft_pr');
+  if (sourceIssueEvidenceStatus !== 'pass') missing.push('source_issue_evidence');
+  if (specGateStatus !== 'pass') missing.push('spec_gate_status');
+  if (routingEvidenceStatus !== 'pass') missing.push('routing_evidence_status');
+  if (findingDispositionStatus !== 'pass') missing.push('finding_disposition_status');
+  if (readyToMerge !== 'yes') missing.push('ready_to_merge');
+
+  const failStatuses: Array<WorkflowStatus | 'skipped'> = [
+    checksStatus,
+    draftStatus,
+    sourceIssueEvidenceStatus,
+    specGateStatus,
+    routingEvidenceStatus,
+    findingDispositionStatus,
+    humanReviewStatus,
+  ];
+  const hasFail = failStatuses.includes('fail') ||
+    readyToMerge === 'no' ||
+    (unresolvedReviewThreadsCount ?? 0) > 0 ||
+    (expectedHeadSha !== undefined && raw.head_sha !== expectedHeadSha);
+  const hasManual = missing.length > 0 || failStatuses.includes('manual') || readyToMerge === 'manual';
+  const status: WorkflowStatus = hasFail ? 'fail' : hasManual ? 'manual' : 'pass';
+
+  return {
+    status,
+    missingFields: unique(missing),
+    warnings,
+    checksStatus,
+    unresolvedReviewThreadsCount,
+    coderabbitStatus,
+    codexConnectorStatus,
+    humanReviewStatus,
+    draftStatus,
+    sourceIssueEvidenceStatus,
+    specGateStatus,
+    routingEvidenceStatus,
+    findingDispositionStatus,
+    readyToMerge,
+  };
+}
+
 function assessFindingDisposition(evidence: FindingDispositionEvidence): GateAssessment {
   const missing: string[] = [];
   const warnings: string[] = [];
@@ -1044,11 +1138,12 @@ function assessFindingDisposition(evidence: FindingDispositionEvidence): GateAss
   for (const finding of evidence.findings) {
     if (!meaningful(finding.finding_id)) missing.push('finding_id');
     if (!FINDING_SOURCES.includes(normalize(finding.source))) missing.push('finding_source');
-    const status = normalize(finding.status);
+    const status = normalizeFindingStatus(finding.status);
     if (!FINDING_STATUSES.includes(status)) missing.push('finding_status');
     if (!['yes', 'no', 'n/a'].includes(normalize(finding.resolved))) missing.push('finding_resolved');
     if (status === 'blocked') missing.push('review_finding_blocked');
-    if (['not_adopted', 'blocked', 'noise'].includes(status) && !isEvidenceRefValue(finding.rationale_ref)) {
+    if (status === 'needs_human_review') missing.push('review_finding_needs_human_review');
+    if (['not_adopted', 'optional_polish', 'blocked', 'noise', 'needs_human_review'].includes(status) && !isEvidenceRefValue(finding.rationale_ref)) {
       missing.push('finding_rationale_ref');
     }
     if (status === 'deferred_follow_up' && !isFollowUpRef(finding.follow_up_issue)) {
@@ -1118,6 +1213,7 @@ function missingMergeFields(evidence: PrBodyEvidence, expectedHeadProvided: bool
   const missing = missingCommitFields(evidence);
   if (!evidence.hasFinalMergeGate) missing.push('final_merge_gate');
   if (!evidence.hasLatestHead) missing.push(expectedHeadProvided ? 'head_sha_freshness' : 'latest_head_sha');
+  if (evidence.hasStaleCloseoutEvidence) missing.push('stale_closeout_evidence');
   return missing;
 }
 
@@ -1128,6 +1224,7 @@ function isBlockedSpecStatus(status: PrBodyEvidence['specStatus']): boolean {
 function renderMergeFailureSummary(missingFields: string[]): string {
   if (missingFields.includes('spec_evidence_ref')) return 'merge gate missing spec evidence ref';
   if (missingFields.includes('head_sha_freshness')) return 'merge gate evidence does not match expected head SHA';
+  if (missingFields.includes('stale_closeout_evidence')) return 'merge gate contains stale pending closeout evidence';
   return `merge gate missing ${missingFields.join(', ')}`;
 }
 
@@ -1202,6 +1299,13 @@ function buildResult(input: {
     result.finding_disposition_status = input.closeout.findingDispositionStatus;
     result.ready_to_merge = input.closeout.readyToMerge;
   }
+  const primaryMissingField = result.missing_fields[0];
+  if (primaryMissingField && result.status === 'fail') {
+    result.blocking_reason = primaryMissingField;
+  }
+  if (primaryMissingField && result.status === 'manual') {
+    result.manual_reason = primaryMissingField;
+  }
   return result;
 }
 
@@ -1255,6 +1359,8 @@ function printResult(result: WorkflowCheckResult, format: OutputFormat): void {
     'spec_gate_status',
     'routing_evidence_status',
     'ready_to_merge',
+    'blocking_reason',
+    'manual_reason',
   ] as const) {
     if (result[key]) console.log(`${key}=${result[key]}`);
   }
@@ -1562,6 +1668,63 @@ function parseReadyToMerge(body: string): 'yes' | 'no' | 'manual' | null {
   if (normalized === 'true') return 'yes';
   if (normalized === 'false') return 'no';
   return null;
+}
+
+function parseWorkflowStatusField(value: unknown, fieldName: string, missing: string[]): WorkflowStatus {
+  const normalized = normalize(value);
+  if (['pass', 'fail', 'manual', 'skipped'].includes(normalized)) return normalized as WorkflowStatus;
+  missing.push(fieldName);
+  return 'manual';
+}
+
+function parseAutomationStatusField(value: unknown, fieldName: string, missing: string[]): WorkflowStatus | 'skipped' {
+  const normalized = normalize(value);
+  if (['pass', 'fail', 'manual', 'skipped'].includes(normalized)) return normalized as WorkflowStatus | 'skipped';
+  missing.push(fieldName);
+  return 'manual';
+}
+
+function parseReadyToMergeValue(value: unknown, missing: string[]): 'yes' | 'no' | 'manual' {
+  const normalized = normalize(value);
+  if (['yes', 'no', 'manual'].includes(normalized)) return normalized as 'yes' | 'no' | 'manual';
+  if (normalized === 'true') return 'yes';
+  if (normalized === 'false') return 'no';
+  missing.push('ready_to_merge');
+  return 'manual';
+}
+
+function parseReviewThreadCount(value: unknown, missing: string[]): number | null {
+  if (typeof value === 'number' && Number.isInteger(value) && value >= 0) return value;
+  if (value === null || value === undefined) {
+    missing.push('unresolved_review_threads_count');
+    return null;
+  }
+  const parsed = Number(value);
+  if (Number.isInteger(parsed) && parsed >= 0) return parsed;
+  missing.push('unresolved_review_threads_count');
+  return null;
+}
+
+function summarizeReadbackHumanReview(raw: Record<string, unknown>, missing: string[]): WorkflowStatus {
+  const explicit = raw.human_review_status;
+  if (explicit !== undefined) return parseWorkflowStatusField(explicit, 'human_review_status', missing);
+
+  const reviewDecision = normalize(raw.review_decision);
+  const mergeStateStatus = normalize(raw.merge_state_status);
+  if (['approved'].includes(reviewDecision)) return 'pass';
+  if (['changes_requested'].includes(reviewDecision)) return 'fail';
+  if (['review_required'].includes(reviewDecision)) return 'manual';
+  if (['blocked', 'dirty'].includes(mergeStateStatus)) return 'manual';
+  missing.push('human_review_status');
+  return 'manual';
+}
+
+function normalizeFindingStatus(value: unknown): string {
+  const normalized = normalize(value)
+    .replace(/\s*\/\s*/g, '_')
+    .replace(/[\s-]+/g, '_');
+  if (normalized === 'not_applicable' || normalized === 'noise_not_applicable') return 'noise';
+  return normalized;
 }
 
 function summarizeWorkflowStatus(statuses: WorkflowStatus[]): WorkflowStatus {

--- a/src/cli/workflow-check.ts
+++ b/src/cli/workflow-check.ts
@@ -668,13 +668,24 @@ async function runMergePhase(
   if (findingDisposition) missingFields.push(...findingDisposition.missingFields);
   if (threshold) missingFields.push(...threshold.missingFields);
   if (closeoutReadback) missingFields.push(...closeoutReadback.missingFields);
+  const hasDeterministicBlocker = mergeMissingFieldsIncludeDeterministicBlocker(missingFields) ||
+    routingCheck?.fallback_status === 'fail' ||
+    findingDisposition?.status === 'fail' ||
+    threshold?.status === 'fail' ||
+    closeoutReadback?.status === 'fail';
   const canReturnManualForReadback = closeoutReadback?.status === 'manual' &&
     bodyMissingFields.length === 0 &&
     routingCheck?.fallback_status !== 'fail' &&
     findingDisposition?.status !== 'fail' &&
     threshold?.status !== 'fail';
 
-  if (evidence.hasManualFallback && missingFields.length > 0 && !isBlockedSpecStatus(evidence.specStatus) && evidence.headMatches !== false) {
+  if (
+    evidence.hasManualFallback &&
+    missingFields.length > 0 &&
+    !hasDeterministicBlocker &&
+    !isBlockedSpecStatus(evidence.specStatus) &&
+    evidence.headMatches !== false
+  ) {
     return buildResult({
       phase: 'merge',
       repoPath,
@@ -1226,6 +1237,24 @@ function renderMergeFailureSummary(missingFields: string[]): string {
   if (missingFields.includes('head_sha_freshness')) return 'merge gate evidence does not match expected head SHA';
   if (missingFields.includes('stale_closeout_evidence')) return 'merge gate contains stale pending closeout evidence';
   return `merge gate missing ${missingFields.join(', ')}`;
+}
+
+function mergeMissingFieldsIncludeDeterministicBlocker(missingFields: string[]): boolean {
+  return missingFields.some((field) => [
+    'stale_closeout_evidence',
+    'ready_spec_gate_status',
+    'head_sha_freshness',
+    'review_finding_blocked',
+    'review_finding_needs_human_review',
+    'checks_status',
+    'unresolved_review_threads',
+    'draft_pr',
+    'source_issue_evidence',
+    'spec_gate_status',
+    'routing_evidence_status',
+    'finding_disposition_status',
+    'ready_to_merge',
+  ].includes(field));
 }
 
 function buildResult(input: {

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -793,7 +793,10 @@ test('spec doctor reports current AWP workflow capabilities as JSON', async () =
     'workflow_check_phase_start_commit_merge',
     'workflow_check_finding_disposition',
     'workflow_check_threshold_evidence',
+    'workflow_check_readback_evidence',
     'workflow_check_pr_readback',
+    'target_repo_adoption_contract_doc',
+    'ai_bootstrap_install_contract_doc',
     'awp_review_check_command',
   ]) {
     assert.equal(parsed.capabilities.find((capability) => capability.id === id)?.status, 'pass', id);
@@ -820,6 +823,7 @@ test('spec doctor accepts workflow-check phase tokens with non-pipe separators',
       'Supported phases: start, commit, merge',
       '--finding-disposition <path>',
       '--threshold-evidence <path>',
+      '--readback-evidence <path>',
       '--pr <number-or-url>',
     ].join('\\n'),
     awpReviewHelp: 'Usage: spec awp-review-check\\n',
@@ -843,6 +847,7 @@ test('spec doctor does not report target repo HEAD when installed package root i
   const packageDir = path.join(targetRepo, 'node_modules', 'spec-injector');
   await fs.mkdir(packageDir, { recursive: true });
   await fs.cp(path.join(repoRoot, 'dist'), path.join(packageDir, 'dist'), { recursive: true });
+  await fs.cp(path.join(repoRoot, 'docs'), path.join(packageDir, 'docs'), { recursive: true });
   await fs.symlink(path.join(repoRoot, 'node_modules'), path.join(packageDir, 'node_modules'), 'dir');
   const packageJson = JSON.parse(await fs.readFile(path.join(repoRoot, 'package.json'), 'utf8')) as { version: string };
   await fs.writeFile(path.join(packageDir, 'package.json'), `${JSON.stringify({ version: packageJson.version }, null, 2)}\n`, 'utf8');
@@ -901,6 +906,7 @@ test('spec doctor fails when installed workflow-check lacks #242 AWP flags', asy
   assert.equal(parsed.status, 'fail');
   assert.ok(parsed.missing_capabilities.includes('workflow_check_finding_disposition'));
   assert.ok(parsed.missing_capabilities.includes('workflow_check_threshold_evidence'));
+  assert.ok(parsed.missing_capabilities.includes('workflow_check_readback_evidence'));
   assert.ok(parsed.missing_capabilities.includes('workflow_check_pr_readback'));
 });
 
@@ -2284,6 +2290,177 @@ test('spec workflow-check accepts tachigo and tachiya AWP compatibility fixtures
     assert.equal(parsed.status, 'pass');
     assert.equal(parsed.threshold_calibration_status, 'pass');
   }
+});
+
+test('spec workflow-check merge phase fails stale pre-PR closeout wording', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-stale-closeout-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+  const headSha = (await runCommand('git', ['rev-parse', 'HEAD'], repoDir)).stdout.trim();
+  const prBodyPath = path.join(repoDir, 'PR_BODY.md');
+  await fs.writeFile(prBodyPath, [
+    'Closes #329',
+    '',
+    '## Spec gate evidence',
+    '- spec gate status: pass',
+    '- spec evidence ref: workflow-check:commit:329',
+    '',
+    '## Final merge gate',
+    '- Ready-to-merge decision：pending with reason - PR not created yet',
+    `- latest head SHA: ${headSha}`,
+  ].join('\n'), 'utf8');
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'merge',
+    '--pr-body', prBodyPath,
+    '--head-sha', headSha,
+    '--format', 'json',
+  ]);
+
+  assert.notEqual(result.code, 0);
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.status, 'fail');
+  assert.ok((parsed.missing_fields as string[]).includes('stale_closeout_evidence'));
+  assert.equal(parsed.blocking_reason, 'stale_closeout_evidence');
+});
+
+test('spec workflow-check merge phase uses local readback evidence for review-required manual gate', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-local-readback-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+  const headSha = (await runCommand('git', ['rev-parse', 'HEAD'], repoDir)).stdout.trim();
+  const prBodyPath = path.join(repoDir, 'PR_BODY.md');
+  await fs.writeFile(prBodyPath, [
+    'Closes #329',
+    '',
+    '## Spec gate evidence',
+    '- spec gate status: pass',
+    '- spec evidence ref: workflow-check:commit:329',
+    '- routing evidence status: pass',
+    '- routing evidence ref: workflow-check:start:329',
+    '- finding disposition status: pass',
+    '',
+    '## Implementation Evidence',
+    '- Issue evidence: https://github.com/Erick52106/spec-injector/issues/329#issuecomment-1001',
+    `- Commit: ${headSha}`,
+    '',
+    '## Final merge gate',
+    `- latest head SHA: ${headSha}`,
+    '- ready_to_merge: yes',
+  ].join('\n'), 'utf8');
+  const readbackPath = path.join(repoDir, 'readback.json');
+  await fs.writeFile(readbackPath, JSON.stringify({
+    head_sha: headSha,
+    checks_status: 'pass',
+    unresolved_review_threads_count: 0,
+    coderabbit_status: 'skipped',
+    codex_connector_status: 'skipped',
+    review_decision: 'REVIEW_REQUIRED',
+    merge_state_status: 'BLOCKED',
+    draft_status: 'pass',
+    source_issue_evidence_status: 'pass',
+    spec_gate_status: 'pass',
+    routing_evidence_status: 'pass',
+    finding_disposition_status: 'pass',
+    ready_to_merge: 'manual',
+  }, null, 2), 'utf8');
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'merge',
+    '--pr-body', prBodyPath,
+    '--head-sha', headSha,
+    '--readback-evidence', readbackPath,
+    '--format', 'json',
+  ]);
+
+  assert.equal(result.code, 0, result.stderr);
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.status, 'manual');
+  assert.equal(parsed.closeout_readback_status, 'manual');
+  assert.equal(parsed.human_review_status, 'manual');
+  assert.equal(parsed.ready_to_merge, 'manual');
+  assert.ok((parsed.missing_fields as string[]).includes('human_review_status'));
+  assert.ok((parsed.missing_fields as string[]).includes('ready_to_merge'));
+  assert.equal(parsed.manual_reason, 'human_review_status');
+});
+
+test('spec workflow-check finding disposition accepts docs wording and blocks needs human review', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-finding-docs-wording-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+  const headSha = (await runCommand('git', ['rev-parse', 'HEAD'], repoDir)).stdout.trim();
+  const thinBody = await fs.readFile(path.join(repoRoot, 'tests', 'fixtures', 'workflow', 'tachigo-thin-pr-body.md'), 'utf8');
+  const prBodyPath = path.join(repoDir, 'PR_BODY.md');
+  await fs.writeFile(prBodyPath, thinBody.replaceAll('__HEAD_SHA__', headSha), 'utf8');
+  const acceptedPath = path.join(repoDir, 'accepted-findings.json');
+  await fs.writeFile(acceptedPath, JSON.stringify({
+    findings: [
+      {
+        finding_id: 'finding-1',
+        source: 'coderabbit',
+        status: 'not adopted',
+        resolved: 'yes',
+        rationale_ref: 'workflow-check:finding:rationale-1',
+      },
+      {
+        finding_id: 'finding-2',
+        source: 'chatgpt-codex-connector',
+        status: 'optional polish',
+        resolved: 'yes',
+        rationale_ref: 'workflow-check:finding:rationale-2',
+      },
+      {
+        finding_id: 'finding-3',
+        source: 'self-review',
+        status: 'noise / not applicable',
+        resolved: 'yes',
+        rationale_ref: 'workflow-check:finding:rationale-3',
+      },
+    ],
+  }, null, 2), 'utf8');
+
+  const accepted = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'merge',
+    '--pr-body', prBodyPath,
+    '--head-sha', headSha,
+    '--finding-disposition', acceptedPath,
+    '--format', 'json',
+  ]);
+  assert.equal(accepted.code, 0, accepted.stderr);
+  assert.equal((JSON.parse(accepted.stdout) as Record<string, unknown>).finding_disposition_status, 'pass');
+
+  const blockedPath = path.join(repoDir, 'blocked-findings.json');
+  await fs.writeFile(blockedPath, JSON.stringify({
+    findings: [
+      {
+        finding_id: 'finding-4',
+        source: 'human',
+        status: 'needs human review',
+        resolved: 'no',
+        rationale_ref: 'workflow-check:finding:rationale-4',
+      },
+    ],
+  }, null, 2), 'utf8');
+
+  const blocked = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--phase', 'merge',
+    '--pr-body', prBodyPath,
+    '--head-sha', headSha,
+    '--finding-disposition', blockedPath,
+    '--format', 'json',
+  ]);
+  assert.notEqual(blocked.code, 0);
+  const parsed = JSON.parse(blocked.stdout) as Record<string, unknown>;
+  assert.equal(parsed.finding_disposition_status, 'fail');
+  assert.ok((parsed.missing_fields as string[]).includes('review_finding_needs_human_review'));
 });
 
 test('spec workflow-check merge phase collects closeout readback evidence with mocked gh', async (t) => {

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -2304,6 +2304,7 @@ test('spec workflow-check merge phase fails stale pre-PR closeout wording', asyn
     '## Spec gate evidence',
     '- spec gate status: pass',
     '- spec evidence ref: workflow-check:commit:329',
+    '- manual workflow gate: available when deterministic blockers are absent',
     '',
     '## Final merge gate',
     '- Ready-to-merge decision：pending with reason - PR not created yet',


### PR DESCRIPTION
Closes #329

## Summary

- 強化 `spec workflow-check --phase merge`：偵測 stale pre-PR closeout wording、支援 local-only `--readback-evidence` JSON，並在 JSON/text 輸出加上 additive `blocking_reason` / `manual_reason`。
- 擴充 review finding disposition gate：接受 repo workflow 常用的人類文字（`not adopted`、`optional polish`、`noise / not applicable`），並讓 `needs human review` 成為 blocking disposition。
- 擴充 `spec doctor --workflow awp`：檢查 `--readback-evidence` capability 與 target repo adoption / AI bootstrap docs contract，並把 docs 納入 package files。
- 更新 README / workflow docs / adoption contract，明確 downstream repo 只引用 status/ref，不解析完整 evidence，且 checker 維持 local-only / stdout-first / no GitHub mutation。

## Tests / validation

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm test`（316 tests；314 pass；2 skip；0 fail）
- focused workflow-check / doctor / AWP policy tests
- `git diff --check`
- `pnpm pack --dry-run`
- `node bin/spec.js workflow-check --help`
- `node bin/spec.js doctor --workflow awp --format json`

## Implementation Evidence

- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/329#issuecomment-4533871026
- Commit hash: `84a160f80955daf7f4e359e385b8f9b8eaecddd1`
- Branch: `codex/dogfood-workflow-evidence-329`

## AWP routing evidence

- `routing_mode`: `hybrid_awp`
- `routing_task_class`: `workflow_policy`
- `controller_role`: `integration_owner`
- `controller_fallback`: `denied`
- `controller_fallback_reason`: `One read-only explorer worker completed bounded discovery; a second docs/doctor explorer dispatch was unavailable due agent thread limit, so controller handled that bounded slice and records the fallback explicitly.`
- `delegation_outcome`: `completed_with_partial_unavailable`
- Worker evidence: read-only explorer `Nash` (`019e5e27-b036-7c92-b898-7350f6855ec7`) reviewed workflow-check / docs direction and recommended disposition vocabulary, `needs human review` blocking semantics, stale closeout wording detection, readback evidence, and docs parity.

## Spec-injector self-dogfood caveat

- `workflow-check start/commit config caveat`: this repository worktree does not currently contain `.spec-injector/config.json`, so direct self-dogfood start/commit runs report `missing_fields=[config]`.
- The caveat is recorded in the source issue evidence comment and is not treated as downstream `spec_gate_status` evidence.

## Review finding disposition

- CodeRabbit / Codex finding: adopted.
- Disposition ref: https://github.com/Erick52106/spec-injector/pull/330#discussion_r3297897254
- Fix commit: `84a160f80955daf7f4e359e385b8f9b8eaecddd1`
- Regression: stale pre-PR closeout wording test now includes manual fallback text and still asserts `blocking_reason=stale_closeout_evidence`.

## Scope guard / non-goals confirmation

本 PR 明確不做：

- 不做 GitHub mutation from CLI core。
- 不做 hosted control plane / daemon / dashboard。
- 不做 AWP worker runtime / hidden LLM wrapper。
- 不做 downstream repo Scope Police changes。
- 不自動寫 output file。
- 不自動 comment / review / approve / merge。

## Review closeout / final merge gate evidence

- spec_gate_status: pass
- spec_evidence_ref: https://github.com/Erick52106/spec-injector/issues/329#issuecomment-4533871026
- routing_evidence_status: pass
- routing_evidence_ref: workflow-check:start:329-pr-330
- finding_disposition_status: pass
- finding_disposition_ref: https://github.com/Erick52106/spec-injector/pull/330#discussion_r3297897254
- latest head SHA: 84a160f80955daf7f4e359e385b8f9b8eaecddd1
- ready_to_merge: yes