### PR TITLE
feat(workflow-check): support external config path

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -183,6 +183,7 @@ program
   .command('workflow-check')
   .description('Run local-only workflow gate checks for autonomous PR evidence')
   .option('--repo <path>', 'Path to target repo (default: CWD)')
+  .option('--config <path>', 'External config file path (may be outside target repo)')
   .requiredOption('--phase <phase>', 'Workflow phase: start|commit|merge')
   .option('--format <format>', 'Output format: text or json (default: text)')
   .option('--issue <number-or-url>', 'Issue number or URL for start-phase dry-run bounded context checks')
@@ -203,15 +204,18 @@ Checks:
 
 Safety:
   Local-only workflow gate. Prints to stdout by default.
+  --config <path> reads an external config file without copying it into the target repo.
   Does not edit GitHub, add/commit files, write task packages, comment, merge, or mutate downstream repos.
 
 Examples:
   spec workflow-check --repo /path/to/worktree --phase start --issue 326
   spec workflow-check --phase commit --pr-body PR_BODY.md
+  spec workflow-check --repo /path/to/worktree --config /path/to/config.json --phase commit --pr-body PR_BODY.md
   spec workflow-check --phase merge --pr-body PR_BODY.md --head-sha abc123
 `)
   .action(async (opts: {
     repo?: string;
+    config?: string;
     phase: string;
     format?: string;
     issue?: string;

--- a/src/cli/workflow-check.ts
+++ b/src/cli/workflow-check.ts
@@ -15,6 +15,7 @@ type DelegationOutcome = 'n/a' | 'skipped' | 'completed' | 'fell_through' | 'una
 
 type WorkflowCheckOptions = {
   repo?: string;
+  config?: string;
   phase: string;
   format?: string;
   issue?: string;
@@ -242,9 +243,9 @@ export async function workflowCheck(opts: WorkflowCheckOptions): Promise<void> {
   }
 
   try {
-    config = await loadConfig(repoPath);
+    config = await loadConfig(repoPath, { configPath: opts.config });
   } catch (err) {
-    if (isMergePrCloseout(phase, opts)) {
+    if (isMergePrCloseout(phase, opts) && !opts.config) {
       warnings.push(`Local config unavailable; merge --pr closeout continued with readback-only evidence: ${(err as Error).message}`);
     } else {
       const result = buildResult({
@@ -388,6 +389,7 @@ async function runStartPhase(
       dryRun: true,
       format: 'prompt',
       verbose: true,
+      config: opts.config,
     });
   });
 

--- a/src/cli/workflow-check.ts
+++ b/src/cli/workflow-check.ts
@@ -225,6 +225,21 @@ export async function workflowCheck(opts: WorkflowCheckOptions): Promise<void> {
   const checkedAt = new Date().toISOString();
   const warnings: string[] = [];
   let config: Config | null = null;
+  const configProvided = opts.config !== undefined;
+
+  if (configProvided && opts.config === '') {
+    const result = buildResult({
+      phase,
+      repoPath,
+      checkedAt,
+      status: 'fail',
+      missingFields: ['config'],
+      warnings,
+      evidenceSummary: 'workflow-check could not validate repo config: --config path cannot be empty',
+    });
+    printResult(result, format);
+    process.exit(1);
+  }
 
   try {
     ensureRepoPath(repoPath);
@@ -245,7 +260,7 @@ export async function workflowCheck(opts: WorkflowCheckOptions): Promise<void> {
   try {
     config = await loadConfig(repoPath, { configPath: opts.config });
   } catch (err) {
-    if (isMergePrCloseout(phase, opts) && !opts.config) {
+    if (isMergePrCloseout(phase, opts) && !configProvided) {
       warnings.push(`Local config unavailable; merge --pr closeout continued with readback-only evidence: ${(err as Error).message}`);
     } else {
       const result = buildResult({

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -3695,6 +3695,45 @@ test('spec workflow-check merge closeout fails explicit missing external config 
   assert.deepEqual(await readGhLog(fixture.ghLogPath), []);
 });
 
+test('spec workflow-check merge closeout treats empty external config as explicit config failure', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-closeout-empty-config-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+  const headSha = 'efefefefefefefefefefefefefefefefefefefef';
+  const fixture = await createEvidenceCheckFixture(t, {
+    issueNumber: 336,
+    headSha,
+    prBody: [
+      'Closes #336',
+      '',
+      '## Spec gate evidence',
+      '- spec gate status: pass',
+      '- spec evidence ref: https://github.com/Erick52106/spec-injector/issues/336#issuecomment-1001',
+      '',
+      '## Final merge gate',
+      `- latest head SHA: ${headSha}`,
+      '- ready_to_merge: yes',
+    ].join('\n'),
+  });
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--config', '',
+    '--phase', 'merge',
+    '--pr', `https://github.com/${fixture.repo}/pull/${fixture.prNumber}`,
+    '--format', 'json',
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.equal(result.stderr, '');
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.status, 'fail');
+  assert.deepEqual(parsed.missing_fields, ['config']);
+  assert.match(String(parsed.evidence_summary), /--config path cannot be empty/i);
+  assert.deepEqual(await readGhLog(fixture.ghLogPath), []);
+});
+
 test('spec workflow-check still requires local config outside merge --pr closeout', async (t) => {
   const repoDir = await createTempRepo(t, 'spec-injector-workflow-no-config-phases-');
   await fs.writeFile(path.join(repoDir, 'README.md'), '# fixture\n', 'utf8');

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -744,6 +744,8 @@ test('spec plan/config/clean help describe AI-facing usage and safety constraint
   assert.match(workflowCheckHelp.stdout, /--phase <phase>/);
   assert.match(workflowCheckHelp.stdout, /start\|commit\|merge/);
   assert.match(workflowCheckHelp.stdout, /--format <format>/);
+  assert.match(workflowCheckHelp.stdout, /--config <path>/);
+  assert.match(workflowCheckHelp.stdout, /external config file path/i);
   assert.match(workflowCheckHelp.stdout, /--routing-evidence <path>/);
   assert.match(workflowCheckHelp.stdout, /stdout/i);
   assert.match(workflowCheckHelp.stdout, /does not edit GitHub/i);
@@ -992,6 +994,152 @@ test('spec workflow-check emits stable JSON contract for commit phase PR body ev
   assert.deepEqual(parsed.missing_fields, []);
   assert.deepEqual(parsed.warnings, []);
   assert.match(String(parsed.evidence_summary), /commit gate passed/i);
+});
+
+test('spec workflow-check commit phase reads external config without requiring target local config', async (t) => {
+  const fixture = await createExternalConfigPlanFixture(t);
+  await initCleanGitRepo(fixture.repoDir);
+  const beforeSnapshot = await readDirectorySnapshot(fixture.repoDir);
+  const headSha = (await runCommand('git', ['rev-parse', 'HEAD'], fixture.repoDir)).stdout.trim();
+  const prBodyPath = path.join(path.dirname(fixture.repoDir), `${path.basename(fixture.repoDir)}-workflow-pr-body.md`);
+  t.after(async () => {
+    await fs.rm(prBodyPath, { force: true });
+  });
+  await fs.writeFile(prBodyPath, [
+    '## Spec workflow gate',
+    '- spec gate status: pass',
+    `- spec evidence ref: workflow-check:start:${headSha}`,
+  ].join('\n'), 'utf8');
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', fixture.repoDir,
+    '--config', fixture.configPath,
+    '--phase', 'commit',
+    '--pr-body', prBodyPath,
+    '--format', 'json',
+  ]);
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(result.stderr, '');
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.status, 'pass');
+  assert.deepEqual(parsed.missing_fields, []);
+  assert.match(String(parsed.evidence_summary), /commit gate passed/i);
+  await assertFileMissing(path.join(fixture.repoDir, '.spec-injector'));
+  assert.deepEqual(await readDirectorySnapshot(fixture.repoDir), beforeSnapshot);
+});
+
+test('spec workflow-check start phase reads external config without writing target local config', async (t) => {
+  const fixture = await createExternalConfigPlanFixture(t);
+  await initCleanGitRepo(fixture.repoDir);
+  const beforeSnapshot = await readDirectorySnapshot(fixture.repoDir);
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', fixture.repoDir,
+    '--config', fixture.configPath,
+    '--phase', 'start',
+    '--issue', fixture.issueUrl,
+    '--format', 'json',
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(result.stderr, '');
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.phase, 'start');
+  assert.notEqual(parsed.status, 'fail');
+  assert.match(String(parsed.evidence_summary), /bounded context generated/i);
+  await assertFileMissing(path.join(fixture.repoDir, '.spec-injector'));
+  assert.deepEqual(await readDirectorySnapshot(fixture.repoDir), beforeSnapshot);
+});
+
+test('spec workflow-check merge phase reads external config without requiring target local config', async (t) => {
+  const fixture = await createExternalConfigPlanFixture(t);
+  await initCleanGitRepo(fixture.repoDir);
+  const beforeSnapshot = await readDirectorySnapshot(fixture.repoDir);
+  const headSha = (await runCommand('git', ['rev-parse', 'HEAD'], fixture.repoDir)).stdout.trim();
+  const prBodyPath = path.join(path.dirname(fixture.repoDir), `${path.basename(fixture.repoDir)}-workflow-merge-pr-body.md`);
+  t.after(async () => {
+    await fs.rm(prBodyPath, { force: true });
+  });
+  await fs.writeFile(prBodyPath, [
+    '## Spec workflow gate',
+    '- spec gate status: pass',
+    `- spec evidence ref: workflow-check:commit:${headSha}`,
+    '',
+    '## Final merge gate',
+    `- latest head SHA: ${headSha}`,
+    '- ready_to_merge: yes',
+  ].join('\n'), 'utf8');
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', fixture.repoDir,
+    '--config', fixture.configPath,
+    '--phase', 'merge',
+    '--pr-body', prBodyPath,
+    '--head-sha', headSha,
+    '--format', 'json',
+  ]);
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(result.stderr, '');
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.status, 'pass');
+  assert.deepEqual(parsed.missing_fields, []);
+  assert.match(String(parsed.evidence_summary), /merge gate passed/i);
+  await assertFileMissing(path.join(fixture.repoDir, '.spec-injector'));
+  assert.deepEqual(await readDirectorySnapshot(fixture.repoDir), beforeSnapshot);
+});
+
+test('spec workflow-check reports missing external config without falling back to target config', async (t) => {
+  const fixture = await createExternalConfigPlanFixture(t);
+  await writeConfig(fixture.repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(fixture.repoDir);
+  const missingConfigPath = path.join(path.dirname(fixture.configPath), 'missing-config.json');
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', fixture.repoDir,
+    '--config', missingConfigPath,
+    '--phase', 'commit',
+    '--format', 'json',
+  ]);
+
+  assert.notEqual(result.code, 0);
+  assert.equal(result.stderr, '');
+  const parsed = JSON.parse(result.stdout) as { status: string; missing_fields: string[]; warnings: string[]; evidence_summary: string };
+  assert.equal(parsed.status, 'fail');
+  assert.deepEqual(parsed.missing_fields, ['config']);
+  assert.match(parsed.evidence_summary, /External config file not found/i);
+  assert.match(parsed.evidence_summary, new RegExp(escapeRegExp(missingConfigPath)));
+  assert.doesNotMatch(parsed.evidence_summary, /No \.spec-injector\/ directory found/i);
+});
+
+test('spec workflow-check reports invalid external config without falling back to target config', async (t) => {
+  const fixture = await createExternalConfigPlanFixture(t);
+  await writeConfig(fixture.repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(fixture.repoDir);
+  const invalidConfigPath = path.join(path.dirname(fixture.configPath), 'invalid-config.json');
+  await fs.writeFile(invalidConfigPath, '{ invalid json\n', 'utf8');
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', fixture.repoDir,
+    '--config', invalidConfigPath,
+    '--phase', 'commit',
+    '--format', 'json',
+  ]);
+
+  assert.notEqual(result.code, 0);
+  assert.equal(result.stderr, '');
+  const parsed = JSON.parse(result.stdout) as { status: string; missing_fields: string[]; warnings: string[]; evidence_summary: string };
+  assert.equal(parsed.status, 'fail');
+  assert.deepEqual(parsed.missing_fields, ['config']);
+  assert.match(parsed.evidence_summary, /Invalid config\.json/i);
+  assert.match(parsed.evidence_summary, new RegExp(escapeRegExp(invalidConfigPath)));
+  assert.doesNotMatch(parsed.evidence_summary, /No \.spec-injector\/ directory found/i);
 });
 
 test('spec workflow-check fails commit phase when .spec-injector artifacts are staged', async (t) => {
@@ -3497,6 +3645,54 @@ test('spec workflow-check merge closeout with --pr does not require local config
   assert.match(ghLog, /pr checks/);
   assert.match(ghLog, /api graphql/);
   assertNoGhMutationCommands(ghLog);
+});
+
+test('spec workflow-check merge closeout fails explicit missing external config before gh readback', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-workflow-closeout-missing-config-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+  const headSha = 'cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd';
+  const fixture = await createEvidenceCheckFixture(t, {
+    issueNumber: 336,
+    headSha,
+    prBody: [
+      'Closes #336',
+      '',
+      '## Spec gate evidence',
+      '- spec gate status: pass',
+      '- spec evidence ref: https://github.com/Erick52106/spec-injector/issues/336#issuecomment-1001',
+      '- routing evidence status: pass',
+      '- routing evidence ref: workflow-check:start:336',
+      '- finding disposition status: pass',
+      '',
+      '## Implementation Evidence',
+      '- Issue evidence: https://github.com/Erick52106/spec-injector/issues/336#issuecomment-1001',
+      `- Commit: ${headSha}`,
+      '',
+      '## Final merge gate',
+      `- latest head SHA: ${headSha}`,
+      '- ready_to_merge: yes',
+    ].join('\n'),
+  });
+  const missingConfigPath = path.join(path.dirname(repoDir), 'missing-workflow-check-config.json');
+
+  const result = await runSpec([
+    'workflow-check',
+    '--repo', repoDir,
+    '--config', missingConfigPath,
+    '--phase', 'merge',
+    '--pr', `https://github.com/${fixture.repo}/pull/${fixture.prNumber}`,
+    '--format', 'json',
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.equal(result.stderr, '');
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.status, 'fail');
+  assert.deepEqual(parsed.missing_fields, ['config']);
+  assert.match(String(parsed.evidence_summary), /External config file not found/i);
+  assert.match(String(parsed.evidence_summary), new RegExp(escapeRegExp(missingConfigPath)));
+  assert.deepEqual(await readGhLog(fixture.ghLogPath), []);
 });
 
 test('spec workflow-check still requires local config outside merge --pr closeout', async (t) => {


### PR DESCRIPTION
Closes #336

## Summary
- Add `--config <path>` to `spec workflow-check`.
- Forward external config loading through start, commit, and merge gates.
- Keep explicit missing or empty external config failures deterministic, including `merge --pr` before gh readback.

## Scope
- CLI option wiring in `src/cli/index.ts`.
- workflow-check config loading, explicit empty-config handling, and start-phase plan forwarding in `src/cli/workflow-check.ts`.
- Focused integration coverage in `tests/cli.integration.test.ts`.

## Non-goals
- No GitHub mutation inside `workflow-check`.
- No hosted control plane, daemon, dashboard, auto-merge, or auto-comment behavior in CLI core.
- No downstream repo Scope Police changes.
- No automatic output file writes or task package writes.
- No committed `.spec-injector/`, generated output, or private context.

## Tests / validation
- `node --test --test-name-pattern "workflow-check.*external config|workflow-check.*explicit missing external config|workflow-check.*empty external config|help describe AI-facing" tests/cli.integration.test.ts` — pass (8 tests)
- `pnpm test` — pass (334 tests, 332 pass, 2 skipped, 0 fail)
- `pnpm build` — pass
- `git diff --check` — pass

## Implementation Evidence
- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/336#issuecomment-4537006202
- Commit hash: bb90a1ea84d1cbf3a2d8c115857976c30c6e8e15

## AWP / routing evidence
- routing_mode: hybrid_awp
- routing_task_class: bounded_implementation_slice
- controller_fallback: denied
- controller_fallback_reason: n/a
- delegation_outcome: completed
- worker: 019e60c4-fe9d-7010-ba76-032a7ba2a4ee
- code quality reviewer: 019e60c9-02ac-7501-8516-9d8ceb5523c6
- spec re-reviewer: 019e60cc-29cd-7152-96cd-917c9a0df47f

## Review finding disposition
- finding disposition status: pass
- finding disposition ref: https://github.com/Erick52106/spec-injector/pull/337#discussion_r3299856846
- CodeRabbit discussion r3299847767: adopted; explicit empty `--config` now fails as provided config and regression coverage was added.

## Spec gate evidence
- spec gate status: pass
- spec evidence ref: workflow-check:start:issue-336
- routing evidence status: pass
- routing evidence ref: workflow-check:start:issue-336
- commit gate status: pass

## Scope guard / non-goals confirmation
- Scope remained limited to #336 allowed files.
- No `.spec-injector/`, generated output, or private context committed.

## Final merge gate
- latest head SHA: bb90a1ea84d1cbf3a2d8c115857976c30c6e8e15
- ready_to_merge: yes
