### PR TITLE
feat(doctor): verify workflow-check external config support

### DIFF
--- a/docs/ai-bootstrap-install-contract.md
+++ b/docs/ai-bootstrap-install-contract.md
@@ -21,6 +21,7 @@ spec workflow-check --help
 The AWP workflow requires `workflow-check` support for:
 
 - `--phase start|commit|merge`
+- `--config <path>` for external config snapshots when the target repo does not commit `.spec-injector/`
 - `--finding-disposition`
 - `--threshold-evidence`
 - `--readback-evidence`
@@ -76,9 +77,9 @@ fi
 Target repo docs can then invoke:
 
 ```bash
-$SPEC_RUNNER workflow-check --repo . --phase start --issue <number-or-url> --format json
-$SPEC_RUNNER workflow-check --repo . --phase commit --pr-body /path/to/pr-body.md --format json
-$SPEC_RUNNER workflow-check --repo . --phase merge --pr-body /path/to/pr-body.md --head-sha <sha> --readback-evidence /path/to/readback.json --format json
+$SPEC_RUNNER workflow-check --repo . --config /path/to/config.json --phase start --issue <number-or-url> --format json
+$SPEC_RUNNER workflow-check --repo . --config /path/to/config.json --phase commit --pr-body /path/to/pr-body.md --format json
+$SPEC_RUNNER workflow-check --repo . --config /path/to/config.json --phase merge --pr-body /path/to/pr-body.md --head-sha <sha> --readback-evidence /path/to/readback.json --format json
 $SPEC_RUNNER workflow-check --repo . --phase merge --pr <number-or-url> --format json
 ```
 

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -69,6 +69,12 @@ async function runDoctor(workflow: string): Promise<DoctorResult> {
       evidence: 'spec workflow-check --help includes start|commit|merge',
     },
     {
+      id: 'workflow_check_external_config',
+      status: hasLongOptionWithValue(workflowOutput, 'config', 'path') ? 'pass' : 'fail',
+      required: true,
+      evidence: 'spec workflow-check --help includes --config <path>',
+    },
+    {
       id: 'workflow_check_finding_disposition',
       status: /--finding-disposition\b/.test(workflowOutput) ? 'pass' : 'fail',
       required: true,
@@ -155,6 +161,12 @@ function runSpecHelp(args: string[]) {
 function hasLongOption(output: string, optionName: string): boolean {
   const escaped = optionName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   return new RegExp(`(?:^|\\s)--${escaped}(?:\\s|,|$)`, 'm').test(output);
+}
+
+function hasLongOptionWithValue(output: string, optionName: string, valueName: string): boolean {
+  const escapedOption = optionName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const escapedValue = valueName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`(?:^|\\s)--${escapedOption}\\s+<${escapedValue}>(?:\\s|,|$)`, 'm').test(output);
 }
 
 function hasWords(output: string, words: string[]): boolean {

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -793,6 +793,7 @@ test('spec doctor reports current AWP workflow capabilities as JSON', async () =
   for (const id of [
     'workflow_check_command',
     'workflow_check_phase_start_commit_merge',
+    'workflow_check_external_config',
     'workflow_check_finding_disposition',
     'workflow_check_threshold_evidence',
     'workflow_check_readback_evidence',
@@ -811,6 +812,7 @@ test('spec doctor text output is concise and local-only', async () => {
   assert.equal(result.code, 0, result.stderr);
   assert.match(result.stdout, /workflow=awp/);
   assert.match(result.stdout, /status=pass/);
+  assert.match(result.stdout, /workflow_check_external_config=pass/);
   assert.match(result.stdout, /workflow_check_pr_readback=pass/);
   assert.match(result.stdout, /does not call GitHub/i);
   assert.doesNotMatch(result.stdout, /https:\/\/api\.github\.com/i);
@@ -823,6 +825,7 @@ test('spec doctor accepts workflow-check phase tokens with non-pipe separators',
       'Usage: spec workflow-check',
       '--phase <phase>',
       'Supported phases: start, commit, merge',
+      '--config <path>',
       '--finding-disposition <path>',
       '--threshold-evidence <path>',
       '--readback-evidence <path>',
@@ -839,6 +842,35 @@ test('spec doctor accepts workflow-check phase tokens with non-pipe separators',
   const parsed = JSON.parse(result.stdout) as { status: string; capabilities: Array<{ id: string; status: string }> };
   assert.equal(parsed.status, 'pass');
   assert.equal(parsed.capabilities.find((capability) => capability.id === 'workflow_check_phase_start_commit_merge')?.status, 'pass');
+});
+
+test('spec doctor fails when installed workflow-check lacks external config support', async (t) => {
+  const fakeSpec = await writeFakeSpec(t, {
+    rootHelp: 'Usage: spec\\nCommands:\\n  workflow-check\\n  awp-review-check\\n',
+    workflowHelp: [
+      'Usage: spec workflow-check',
+      '--phase <phase>',
+      'Workflow phase: start|commit|merge',
+      '--finding-disposition <path>',
+      '--threshold-evidence <path>',
+      '--readback-evidence <path>',
+      '--pr <number-or-url>',
+      '--config',
+    ].join('\\n'),
+    awpReviewHelp: 'Usage: spec awp-review-check\\n',
+  });
+
+  const result = await runSpec(['doctor', '--workflow', 'awp', '--format', 'json'], {
+    env: { ...process.env, SPEC_DOCTOR_SPEC_BIN: fakeSpec },
+  });
+
+  assert.notEqual(result.code, 0);
+  const parsed = JSON.parse(result.stdout) as { status: string; missing_capabilities: string[]; capabilities: Array<{ id: string; status: string; evidence: string }> };
+  assert.equal(parsed.status, 'fail');
+  assert.ok(parsed.missing_capabilities.includes('workflow_check_external_config'));
+  const capability = parsed.capabilities.find((entry) => entry.id === 'workflow_check_external_config');
+  assert.equal(capability?.status, 'fail');
+  assert.match(capability?.evidence ?? '', /--config <path>/);
 });
 
 test('spec doctor does not report target repo HEAD when installed package root is nested in another git repo', async (t) => {


### PR DESCRIPTION
Closes #338

## Summary
- Add a stable `workflow_check_external_config` capability to `spec doctor --workflow awp`.
- Fail doctor readiness when installed `spec workflow-check --help` lacks `--config <path>`.
- Document external config support in the AI bootstrap install contract.

## Scope
- `src/cli/doctor.ts` capability map.
- Focused CLI integration tests.
- AI bootstrap install contract examples.

## Non-goals
- No `workflow-check` behavior change.
- No `spec plan --config` behavior change.
- No hosted control plane, daemon, dashboard, auto-comment, auto-merge, or hidden worker runtime.
- No target repo or GitHub mutation from doctor.

## Tests / validation
- `pnpm build && node --test --test-name-pattern "spec doctor|AI bootstrap install contract" tests/cli.integration.test.ts tests/docs-links.test.ts` — pass (7 tests)
- `pnpm test` — pass (335 tests, 333 pass, 2 skipped, 0 fail)
- `pnpm build` — pass
- `git diff --check` — pass

## Implementation Evidence
- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/338#issuecomment-4537115486
- Commit hash: 326a771c74b5950da0a4f0b6cf1250191d2064bb

## AWP / routing evidence
- routing_mode: hybrid_awp
- routing_task_class: bounded_implementation_slice
- controller_fallback: denied
- controller_fallback_reason: n/a
- delegation_outcome: completed
- worker: 019e60d8-cdca-7640-a0e7-fe07042027a2
- controller: integrated worker/controller edits and resolved duplicate capability edits before validation

## Spec gate evidence
- spec gate status: pass
- spec evidence ref: workflow-check:start:issue-338
- routing evidence status: pass
- routing evidence ref: workflow-check:start:issue-338
- commit gate status: pass
- finding disposition status: pass

## Scope guard / non-goals confirmation
- Scope stayed within #338 allowed files.
- Doctor remains local-only and read-only.
- No `.spec-injector/`, generated output, or private context committed.

## Final merge gate
- latest head SHA: 326a771c74b5950da0a4f0b6cf1250191d2064bb
- ready_to_merge: yes
