### PR TITLE
docs(workflow): document external-config target adoption

### DIFF
--- a/docs/target-repo-adoption-contract.md
+++ b/docs/target-repo-adoption-contract.md
@@ -14,6 +14,33 @@ Target repos can use the published CLI behavior directly when `spec-injector` is
 - Offline/manual checklist fallback remains valid for repos that have not fully adopted `spec-injector`.
 - Target repo PR bodies only need stable status/ref evidence, not full task packages or full AWP review ledgers.
 
+## External Config Recipe
+
+Target repos do not need to commit `.spec-injector/` just to use `workflow-check`. If a repo keeps its spec config in a shared tooling checkout, temporary bootstrap directory, or other approved location outside the target repo, pass that snapshot explicitly:
+
+```bash
+spec workflow-check --repo . --config <external-config> --phase start --issue <number-or-url> --format json
+spec workflow-check --repo . --config <external-config> --phase commit --pr-body /path/to/pr-body.md --format json
+spec workflow-check --repo . --config <external-config> --phase merge --pr-body /path/to/pr-body.md --head-sha <sha> --readback-evidence /path/to/readback.json --format json
+```
+
+Use the external config for local start / commit / merge PR-body gates when the target repo intentionally does not contain a committed `.spec-injector/config.json`. `merge --pr` readback can still run without local config because it reads PR metadata, checks, reviews, and PR body through read-only helpers; if `--config <external-config>` is provided, the path must exist and validate.
+
+Downstream PR bodies and ledgers should copy status/ref evidence only:
+
+- `spec gate status`
+- `spec evidence ref`
+- `routing evidence status`
+- `routing evidence ref`
+- `finding disposition status`
+- `finding disposition ref`
+- `threshold evidence status`
+- `threshold ledger ref`
+- `latest head SHA`
+- `ready_to_merge`
+
+Keep the full `spec plan` output, task packages, routing ledgers, readback JSON, review transcripts, and private context behind the referenced evidence location. Scope Police should validate the thin status/ref surface and must not parse private or generated spec evidence.
+
 ## When Target Repo PRs Are Still Needed
 
 Downstream repos still need their own PR when they want to change repo-local policy or enforcement:
@@ -28,7 +55,8 @@ Downstream repos still need their own PR when they want to change repo-local pol
 
 ## Non-Negotiable Boundaries
 
-- Do not commit `.spec-injector/out/`, generated task packages, local routing JSON, private context, or private ledgers into target repos.
+- Do not commit `.spec-injector/` into target repos when using an external config snapshot.
+- Do not commit `.spec-injector/out/`, generated task packages, local routing/readback JSON, private context, or private ledgers into target repos.
 - Do not make target repo Scope Police parse full `spec plan` output, full task packages, or full AWP review ledgers.
 - Do not use `spec-injector` as a hosted control plane, daemon, dashboard, merge bot, auto-commenter, or hidden LLM wrapper.
 - Do not treat checker `pass` as human approval.

--- a/tests/hybrid-awp-routing-policy.test.ts
+++ b/tests/hybrid-awp-routing-policy.test.ts
@@ -139,7 +139,13 @@ test('target repo adoption contract remains linked from workflow docs', async ()
   assert.match(contract, /Target Repo Adoption Contract/);
   assert.match(contract, /tachigo/i);
   assert.match(contract, /tachiya/i);
+  assert.match(contract, /workflow-check --repo \. --config <external-config>/);
+  assert.match(contract, /external config/i);
+  assert.match(contract, /status\/ref evidence only/i);
+  assert.match(contract, /local routing\/readback JSON/);
   assert.match(contract, /Do not commit `.spec-injector\/out\/`/);
+  assert.match(contract, /Do not commit `.spec-injector\/`/);
+  assert.match(contract, /private ledgers/);
   assert.match(contract, /does not mutate downstream repos/i);
   assert.match(workflow, /\[target repo adoption contract\]\(target-repo-adoption-contract\.md\)/);
 });


### PR DESCRIPTION
Closes #340

## Summary
- Document `workflow-check --config <external-config>` target repo adoption commands.
- Clarify that downstream PR bodies and ledgers should copy status/ref evidence only.
- Strengthen no-commit boundaries for `.spec-injector/`, generated output, local JSON evidence, private context, and private ledgers.

## Scope
- `docs/target-repo-adoption-contract.md` external config recipe and artifact boundaries.
- `tests/hybrid-awp-routing-policy.test.ts` docs contract assertions.

## Non-goals
- No runtime CLI behavior change.
- No downstream Scope Police changes.
- No hosted control plane, daemon, dashboard, auto-comment, auto-merge, or hidden worker runtime.
- No target repo mutation.

## Tests / validation
- `pnpm build && node --test --test-name-pattern "target repo adoption contract" tests/hybrid-awp-routing-policy.test.ts` — pass (1 test)
- `pnpm test` — pass (335 tests, 333 pass, 2 skipped, 0 fail)
- `pnpm build` — pass
- `git diff --check` — pass

## Implementation Evidence
- Issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/340#issuecomment-4537142150
- Commit hash: 5e834621f77f48872f6eeb3869de11a0befb69e4

## AWP / routing evidence
- routing_mode: hybrid_awp
- routing_task_class: docs_contract_slice
- controller_fallback: allowed
- controller_fallback_reason: agent thread capacity unavailable; docs/test only slice implemented directly by controller
- delegation_outcome: unavailable

## Spec gate evidence
- spec gate status: pass
- spec evidence ref: workflow-check:start:issue-340
- routing evidence status: pass
- routing evidence ref: workflow-check:start:issue-340
- commit gate status: pass
- finding disposition status: pass

## Scope guard / non-goals confirmation
- Scope stayed within #340 docs/test contract files.
- No runtime behavior changed.
- No `.spec-injector/`, generated output, or private context committed.

## Final merge gate
- latest head SHA: 5e834621f77f48872f6eeb3869de11a0befb69e4
- ready_to_merge: yes
