### PR TITLE
feat(preflight): report target repo artifact risk

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Notes:
 - `spec plan ... --dry-run --format prompt --verbose` is the recommended pre-implementation command for AI planning.
 - For a full generated task package file, omit `--dry-run`; output is written under `.spec-injector/out/`.
 - `spec workflow-check` is a local-only, stdout-first workflow gate for autonomous PR evidence. It does not edit GitHub, add/commit files, write task packages, comment, merge, or mutate downstream repos.
+- `spec preflight --target-repo <path>` remains read-only and reports staged downstream spec artifacts as blockers before they become PR evidence problems.
 - Autonomous worker-routing flow 可在 implementation 開始前使用 [Hybrid AWP routing policy](docs/hybrid-awp-routing-policy.md) 作為 start-gate source of truth。
 - Downstream AI entrypoints 可引用 [AI bootstrap install contract](docs/ai-bootstrap-install-contract.md)，用 `SPEC_INJECTOR_DIR` local runner fallback 與 `spec doctor --workflow awp --format json` 檢查 AWP capability，不需要 global install。
 - `spec workflow-check --format json` emits the same stable fields as the text output: `phase`, `status`, `repo`, `head_sha`, `checked_at`, `missing_fields`, `warnings`, and `evidence_summary`. Additive fields such as `blocking_reason` and `manual_reason` point to the first deterministic blocker or manual gate.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -212,6 +212,7 @@ Required review checks:
 Required:
 
 - Target repo clean check.
+- Target repo staged spec artifact check when `spec preflight --target-repo` is in scope.
 - No target repo implementation.
 - Report-only output.
 - No automatic `stash`, `clean`, or `reset`.
@@ -221,6 +222,7 @@ Required review checks:
 - Distinguish observations, false positives, false negatives, and follow-up issues.
 - Dogfood does not become target repo implementation.
 - Target repo state is reported if dirty, and work stops before running destructive cleanup.
+- Staged `.spec-injector/`, generated task package, routing/readback JSON, private context, or private ledger artifacts in target repos are blockers, not cleanup prompts.
 - Follow-up issues are separate from target repo code changes.
 
 ### 11. Companion / mascot / future runtime planning

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -96,7 +96,7 @@ spec preflight \
 spec preflight --repo "$PWD" --target-repo <target-repo-path>
 ```
 
-此檢查只回報 target repo 狀態與 safety reminder，不得修改 target repo、不得建立 target repo `.spec-injector/`、不得在 target repo 建 branch / commit / PR。
+此檢查只回報 target repo 狀態、staged spec artifact risk 與 safety reminder，不得修改 target repo、不得建立 target repo `.spec-injector/`、不得在 target repo 建 branch / commit / PR。若 target repo staged `.spec-injector/`、`.spec-injector/out/`、generated task package、routing/readback JSON 或 private context / ledger 類 artifact，preflight 應 fail 並要求 stop-and-report；若只是在 working tree 看到 local-only suspicious artifact，preflight 應 warning，提醒不要把它們放進 target PR。
 
 PR 建立、source issue evidence comment 留下、且 PR body 回填 evidence URL 後，可執行 repo-local evidence consistency checker：
 

--- a/src/cli/preflight.ts
+++ b/src/cli/preflight.ts
@@ -8,6 +8,8 @@ import {
   getUpstreamState,
   getWorktreeState,
 } from '../utils/git.js';
+import { isSpecArtifactPath, normalizeArtifactPath } from '../utils/artifacts.js';
+import { run } from '../utils/shell.js';
 
 type PreflightSeverity = 'pass' | 'warning' | 'fail' | 'needs-human-review';
 
@@ -26,6 +28,10 @@ type PreflightOptions = {
   targetRepo?: string;
   format?: string;
 };
+
+type GitPathListResult =
+  | { kind: 'ok'; label: string; paths: string[] }
+  | { kind: 'error'; label: string; message: string };
 
 export async function preflight(opts: PreflightOptions): Promise<void> {
   const format = parseFormat(opts.format);
@@ -185,12 +191,104 @@ function buildPreflightReport(repoPath: string, opts: PreflightOptions): {
     } else {
       checks.push(needsHumanReview('unable to determine target repo worktree state', targetState.message));
     }
+    checks.push(...buildTargetArtifactChecks(targetRepoPath));
   }
 
   return {
     overall: summarizeOverall(checks),
     checks,
   };
+}
+
+function buildTargetArtifactChecks(targetRepoPath: string): PreflightCheck[] {
+  const checks: PreflightCheck[] = [];
+  const staged = readGitPathList(
+    targetRepoPath,
+    ['git', 'diff', '--cached', '--name-only', '--diff-filter=ACMR', '-z'],
+    'staged target repo paths'
+  );
+  const unstaged = readGitPathList(
+    targetRepoPath,
+    ['git', 'diff', '--name-only', '--diff-filter=ACMR', '-z'],
+    'unstaged target repo paths'
+  );
+  const untracked = readGitPathList(
+    targetRepoPath,
+    ['git', 'ls-files', '--others', '--exclude-standard', '-z'],
+    'untracked target repo paths'
+  );
+
+  const inspectionFailures = [staged, unstaged, untracked].filter((result) => result.kind === 'error');
+  for (const failure of inspectionFailures) {
+    checks.push(needsHumanReview(`unable to inspect ${failure.label}`, failure.message));
+  }
+  if (inspectionFailures.length > 0) return checks;
+
+  const stagedOk = requireGitPathList(staged);
+  const unstagedOk = requireGitPathList(unstaged);
+  const untrackedOk = requireGitPathList(untracked);
+
+  const stagedArtifacts = unique(stagedOk.paths.filter((entry) => isSpecArtifactPath(entry)));
+  if (stagedArtifacts.length > 0) {
+    checks.push(fail(
+      'target repo has staged spec artifacts',
+      `Forbidden staged artifacts: ${stagedArtifacts.join(', ')}. Stop and unstage/remove from target PR; preflight did not modify the target repo.`
+    ));
+  } else {
+    checks.push(pass('target repo has no staged spec artifacts', targetRepoPath));
+  }
+
+  const dirtyArtifacts = unique([
+    ...unstagedOk.paths.filter((entry) => isSpecArtifactPath(entry)),
+    ...untrackedOk.paths.filter((entry) => isSpecArtifactPath(entry)),
+    ...existingGeneratedArtifactPaths(targetRepoPath),
+  ]);
+  if (dirtyArtifacts.length > 0) {
+    checks.push(warning(
+      'target repo has local spec artifact risk',
+      `Local-only artifacts detected: ${dirtyArtifacts.join(', ')}. Keep these out of commits and do not copy private context or generated output into the target repo.`
+    ));
+  } else {
+    checks.push(pass('target repo has no local spec artifact risk', targetRepoPath));
+  }
+
+  return checks;
+}
+
+function readGitPathList(
+  repoPath: string,
+  argv: string[],
+  label: string
+): GitPathListResult {
+  const result = run(argv, { cwd: repoPath });
+  if (result.exitCode !== 0) {
+    return { kind: 'error', label, message: formatShellError(result) };
+  }
+
+  return {
+    kind: 'ok',
+    label,
+    paths: result.stdout.split('\0').filter(Boolean).map(normalizeArtifactPath),
+  };
+}
+
+function requireGitPathList(result: GitPathListResult): Extract<GitPathListResult, { kind: 'ok' }> {
+  if (result.kind === 'ok') return result;
+  throw new Error(`Internal preflight path inspection error: ${result.label}`);
+}
+
+function existingGeneratedArtifactPaths(targetRepoPath: string): string[] {
+  const candidates = [
+    '.spec-injector/out',
+    '.spec-injector/routing',
+    '.spec-injector/readback',
+  ];
+
+  return candidates.filter((candidate) => fs.existsSync(path.join(targetRepoPath, candidate)));
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))];
 }
 
 function requireGitString(
@@ -282,4 +380,9 @@ function canonicalizePath(filePath: string): string {
   } catch {
     return path.resolve(filePath);
   }
+}
+
+function formatShellError(result: { stdout: string; stderr: string; exitCode: number }): string {
+  const message = `${result.stderr}\n${result.stdout}`.trim();
+  return message || `exit ${result.exitCode}`;
 }

--- a/src/cli/workflow-check.ts
+++ b/src/cli/workflow-check.ts
@@ -7,6 +7,11 @@ import { plan } from './plan.js';
 import type { Config } from '../config/types.js';
 import { fetchIssue } from '../github/issue.js';
 import type { Issue } from '../github/types.js';
+import {
+  configuredPrivateArtifactPrefixes,
+  isSpecArtifactPath,
+  normalizeArtifactPath,
+} from '../utils/artifacts.js';
 
 type WorkflowPhase = 'start' | 'commit' | 'merge';
 type WorkflowStatus = 'pass' | 'fail' | 'manual' | 'skipped';
@@ -923,7 +928,7 @@ function readStagedPaths(repoPath: string, config: Config): { forbidden: string[
     };
   }
 
-  const stagedPaths = result.stdout.split('\0').filter(Boolean).map(normalizeGitPath);
+  const stagedPaths = result.stdout.split('\0').filter(Boolean).map(normalizeArtifactPath);
   const forbidden = stagedPaths.filter((stagedPath) => isForbiddenArtifactPath(stagedPath, config));
   return { forbidden, warnings: [] };
 }
@@ -939,18 +944,11 @@ function getDirtyUnstagedWarning(repoPath: string): string | null {
 }
 
 function isForbiddenArtifactPath(gitPath: string, config: Config): boolean {
-  if (gitPath === '.spec-injector' || gitPath.startsWith('.spec-injector/')) return true;
-  if (gitPath.startsWith('spec-output/') || gitPath.startsWith('spec-outputs/')) return true;
-  if (/(^|\/)issue-\d+-task-package\.md$/i.test(gitPath)) return true;
-  if (/(^|\/)(?:task-package|spec-output|spec-evidence)(?:[.-][^/]*)?\.(?:md|json|txt)$/i.test(gitPath)) return true;
-  if (/(^|\/)\.?private[-_]context(\/|\.md$|\.json$|\.txt$)/i.test(gitPath)) return true;
-  return configuredPrivateExcludes(config).some((prefix) => gitPath === prefix || gitPath.startsWith(`${prefix}/`));
+  return isSpecArtifactPath(gitPath, { privateExcludes: configuredPrivateExcludes(config) });
 }
 
 function configuredPrivateExcludes(config: Config): string[] {
-  return (config.specConfig.discovery?.exclude ?? [])
-    .map(normalizeGitPath)
-    .filter((entry) => /private|secret|credential|context/i.test(entry));
+  return configuredPrivateArtifactPrefixes(config.specConfig.discovery?.exclude ?? []);
 }
 
 async function parsePrBodyEvidence(prBodyPath: string, expectedHeadSha?: string): Promise<PrBodyEvidence> {
@@ -1980,10 +1978,6 @@ async function captureConsole(fn: () => Promise<void>): Promise<{ ok: true; warn
     console.warn = originalWarn;
     console.error = originalError;
   }
-}
-
-function normalizeGitPath(value: string): string {
-  return value.replaceAll('\\', '/').replace(/^\.\/+/u, '').replace(/\/+$/u, '');
 }
 
 function unique(values: string[]): string[] {

--- a/src/utils/artifacts.ts
+++ b/src/utils/artifacts.ts
@@ -1,0 +1,27 @@
+export function normalizeArtifactPath(value: string): string {
+  return value.replaceAll('\\', '/').replace(/^\.\/+/u, '').replace(/\/+$/u, '');
+}
+
+export function isSpecArtifactPath(
+  rawPath: string,
+  options: { privateExcludes?: string[] } = {}
+): boolean {
+  const gitPath = normalizeArtifactPath(rawPath);
+  if (!gitPath) return false;
+
+  if (gitPath === '.spec-injector' || gitPath.startsWith('.spec-injector/')) return true;
+  if (gitPath.startsWith('spec-output/') || gitPath.startsWith('spec-outputs/')) return true;
+  if (/(^|\/)issue-\d+-task-package\.md$/i.test(gitPath)) return true;
+  if (/(^|\/)(?:task-package|spec-output|spec-evidence)(?:[.-][^/]*)?\.(?:md|json|txt)$/i.test(gitPath)) return true;
+  if (/(^|\/)(?:routing|readback|closeout|merge-closeout|awp-routing|awp-readback|local-routing|local-readback)(?:[-_.][^/]*)?\.(?:json|md|txt)$/i.test(gitPath)) return true;
+  if (/(^|\/)\.?private[-_](?:context|ledger)(?:\/|\.md$|\.json$|\.txt$)/i.test(gitPath)) return true;
+
+  return configuredPrivateArtifactPrefixes(options.privateExcludes ?? [])
+    .some((prefix) => gitPath === prefix || gitPath.startsWith(`${prefix}/`));
+}
+
+export function configuredPrivateArtifactPrefixes(excludes: string[]): string[] {
+  return excludes
+    .map(normalizeArtifactPath)
+    .filter((entry) => /private|secret|credential|context/i.test(entry));
+}

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -4766,6 +4766,63 @@ test('spec preflight warns when the target repo is dirty and keeps the boundary 
   await assertFileMissing(path.join(targetRepoDir, '.spec-injector'));
 });
 
+test('spec preflight fails when target repo has staged spec artifacts', async (t) => {
+  const fixture = await createPreflightFixture(t);
+  const targetRepoDir = await createTempRepo(t, 'spec-injector-target-staged-artifact-');
+  await writeRepoFiles(targetRepoDir, {
+    'README.md': '# Target Repo Fixture\n',
+  });
+  await initCleanGitRepo(targetRepoDir);
+  const stagedArtifact = path.join(targetRepoDir, '.spec-injector', 'out', 'issue-342-task-package.md');
+  await fs.mkdir(path.dirname(stagedArtifact), { recursive: true });
+  await fs.writeFile(stagedArtifact, '# generated task package\n', 'utf8');
+  await runCommand('git', ['add', '.spec-injector/out/issue-342-task-package.md'], targetRepoDir);
+
+  const result = await runSpec([
+    'preflight',
+    '--repo', fixture.worktreeDir,
+    '--expected-branch', fixture.branchName,
+    '--target-repo', targetRepoDir,
+  ], { env: fixture.env });
+
+  assert.notEqual(result.code, 0);
+  assert.match(result.stdout, /Preflight summary:\s+FAIL/i);
+  assert.match(result.stdout, /target repo has staged spec artifacts/i);
+  assert.match(result.stdout, /\.spec-injector\/out\/issue-342-task-package\.md/i);
+  assert.match(result.stdout, /preflight did not modify the target repo/i);
+  assertNoRawStackTrace(result);
+  const gitLog = (await readGhLog(fixture.gitLogPath)).join('\n');
+  assertNoGitMutationCommands(gitLog);
+  await assertFileExists(stagedArtifact);
+});
+
+test('spec preflight warns when target repo has local routing or readback artifacts', async (t) => {
+  const fixture = await createPreflightFixture(t);
+  const targetRepoDir = await createTempRepo(t, 'spec-injector-target-local-artifact-');
+  await writeRepoFiles(targetRepoDir, {
+    'README.md': '# Target Repo Fixture\n',
+  });
+  await initCleanGitRepo(targetRepoDir);
+  const localArtifact = path.join(targetRepoDir, 'awp-readback-evidence.json');
+  await fs.writeFile(localArtifact, '{"status":"pass"}\n', 'utf8');
+
+  const result = await runSpec([
+    'preflight',
+    '--repo', fixture.worktreeDir,
+    '--expected-branch', fixture.branchName,
+    '--target-repo', targetRepoDir,
+  ], { env: fixture.env });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /Preflight summary:\s+WARNING/i);
+  assert.match(result.stdout, /target repo has local spec artifact risk/i);
+  assert.match(result.stdout, /awp-readback-evidence\.json/i);
+  assert.match(result.stdout, /Keep these out of commits/i);
+  const gitLog = (await readGhLog(fixture.gitLogPath)).join('\n');
+  assertNoGitMutationCommands(gitLog);
+  await assertFileExists(localArtifact);
+});
+
 test('spec evidence-check passes for complete PR and issue evidence without mutating GitHub state', async (t) => {
   const fixture = await createEvidenceCheckFixture(t);
 


### PR DESCRIPTION
Closes #342

## Summary
- 新增共用 spec artifact path classifier，讓 `workflow-check` 和 `preflight` 共用 `.spec-injector/`、generated task package、routing/readback JSON、private context / ledger 類判斷。
- 擴充 `spec preflight --target-repo <path>`：staged spec artifacts 會 fail；local-only dirty/untracked suspicious artifacts 會 warning；全程 read-only，不修改 target repo。
- 更新 README / workflow / validation docs，說明 target repo staged artifact 是 blocker。

## Tests / validation
- `pnpm build && node --test --test-name-pattern "spec preflight" tests/cli.integration.test.ts` passed: 15/15.
- `pnpm test` passed: 337 tests, 335 pass, 2 skipped, 0 fail.
- `pnpm build` passed.
- `git diff --check` passed.
- `spec workflow-check --phase commit --format json` returned manual fallback as expected because PR body was not available before PR creation; staged state was clean.

## Implementation Evidence
issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/342#issuecomment-4537194052
commit hash: c549fbdccf53ec12f25fab5c79a317d24b510733
routing_mode: hybrid_awp
routing_task_class: product_behavior
controller_fallback: allowed
controller_fallback_reason: agent thread capacity unavailable: multi_agent_v1.spawn_agent returned agent thread limit reached; bounded CLI/docs/test slice implemented directly by controller
delegation_outcome: unavailable
spec_gate_status: pass
spec_evidence_ref: workflow-check:commit:342
routing_evidence_status: pass
routing_evidence_ref: workflow-check:start:issue-342
finding_disposition_status: pass
finding_disposition_ref: workflow-check:finding-disposition:342

## Non-goals
- 不修改 target repo。
- 不自動 `stash` / `clean` / `reset`。
- 不新增 daemon、hosted control plane、dashboard、auto-comment、auto-merge 或 worker runtime。
- 不改 `workflow-check` JSON contract 或 exit-code semantics。
- 不要求 downstream Scope Police parse full evidence.

## Scope guard / non-goals confirmation
- 變更只限 `preflight` artifact risk、共用 path classifier、既有 `workflow-check` staged artifact 判斷共用化、測試與文件。
- 未修改 target repo，也未建立 target repo `.spec-injector/`。

## Review closeout / final merge gate evidence
final merge gate: pass
latest head: c549fbdccf53ec12f25fab5c79a317d24b510733
ready_to_merge: yes
