### PR TITLE
feat(workflow): require durable AWP review evidence refs

### DIFF
--- a/docs/awp-review-triage-gates.md
+++ b/docs/awp-review-triage-gates.md
@@ -80,7 +80,7 @@ validation=<command/ref or n/a>
 evidence_ref=<url/path/summary>
 ```
 
-`partial`, `rejected`, `deferred`, and `superseded` require a rationale. Missing disposition for an actionable finding fails or returns manual depending on the available evidence.
+`partial`, `rejected`, `deferred`, and `superseded` require a rationale. Missing disposition for an actionable finding fails or returns manual depending on the available evidence. For actionable findings, `evidence_ref` must be durable evidence, not a placeholder. Accepted refs are HTTP(S) URLs, `workflow-check:` refs, or GitHub `#issuecomment-<id>` anchors. Weak values such as `done`, `ok`, `pending`, `unknown`, `missing`, `n/a`, or `none` do not satisfy closeout ledger evidence.
 
 Downstream PR bodies do not need to inline the full ledger. They can reference a stable local, PR-body, or issue-comment evidence ref.
 

--- a/src/cli/awp-review-check.ts
+++ b/src/cli/awp-review-check.ts
@@ -91,6 +91,7 @@ const VALID_SOURCES = new Set(['coderabbit', 'codex', 'human', 'ci']);
 const VALID_DECISIONS = new Set(['adopt', 'partial', 'reject', 'defer']);
 const VALID_STRATEGIES = new Set(['local_patch', 'normalize_state_model', 'docs_only', 'test_only', 'no_change', 'split_followup']);
 const VALID_DISPOSITIONS = new Set(['adopted', 'partial', 'rejected', 'deferred', 'superseded']);
+const WEAK_EVIDENCE_REFS = new Set(['', 'n/a', 'none', 'missing', 'unknown', 'pending', 'done', 'ok']);
 const PATCH_BUDGET_RATIO = 0.3;
 
 export async function awpReviewCheck(opts: AwpReviewCheckOptions): Promise<void> {
@@ -296,7 +297,7 @@ function assessCloseoutLedger(findings: Finding[]): GateAssessment {
     if (LEDGER_RATIONALE_DISPOSITIONS.has(normalize(finding.disposition)) && !meaningful(finding.rationale)) {
       missing.push('ledger_rationale');
     }
-    if (isActionableFinding(finding) && !meaningful(finding.evidence_ref)) missing.push('ledger_evidence_ref');
+    if (isActionableFinding(finding) && !isDurableEvidenceRef(finding.evidence_ref)) missing.push('ledger_evidence_ref');
     if (isActionableFinding(finding) && !meaningful(finding.validation)) missing.push('ledger_validation');
   }
   return missing.length > 0
@@ -450,6 +451,13 @@ function normalize(value: unknown): string {
 
 function normalizeRef(value: unknown): string | null {
   return meaningful(value) ? String(value).trim() : null;
+}
+
+function isDurableEvidenceRef(value: unknown): boolean {
+  const ref = String(value ?? '').trim();
+  const normalized = ref.toLowerCase();
+  if (WEAK_EVIDENCE_REFS.has(normalized)) return false;
+  return /^https?:\/\//i.test(ref) || /^workflow-check:/i.test(ref) || /#issuecomment-\d+/i.test(ref);
 }
 
 function unique(values: string[]): string[] {

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -4188,6 +4188,33 @@ test('spec awp-review-check accepts fresh review batch and collapses duplicate f
   assert.equal(parsed.closeout_ledger_status, 'pass');
 });
 
+test('spec awp-review-check fails weak closeout evidence refs for actionable findings', async (t) => {
+  const repoDir = await createTempRepo(t, 'spec-injector-awp-review-weak-ref-');
+  await writeConfig(repoDir, { version: 2, guardrails: [] });
+  await initCleanGitRepo(repoDir);
+  const evidencePath = await writeAwpReviewFixture(repoDir, 'fresh-duplicate-pass.json');
+  const raw = JSON.parse(await fs.readFile(evidencePath, 'utf8')) as Record<string, unknown>;
+  const findings = raw.findings as Array<Record<string, unknown>>;
+  findings[0] = {
+    ...findings[0],
+    evidence_ref: 'done',
+  };
+  await fs.writeFile(evidencePath, `${JSON.stringify(raw, null, 2)}\n`, 'utf8');
+
+  const result = await runSpec([
+    'awp-review-check',
+    '--repo', repoDir,
+    '--evidence', evidencePath,
+    '--format', 'json',
+  ]);
+
+  assert.notEqual(result.code, 0);
+  const parsed = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal(parsed.status, 'fail');
+  assert.equal(parsed.closeout_ledger_status, 'fail');
+  assert.ok((parsed.missing_fields as string[]).includes('ledger_evidence_ref'));
+});
+
 test('spec awp-review-check fails stale review head evidence before patching', async (t) => {
   const repoDir = await createTempRepo(t, 'spec-injector-awp-review-stale-');
   await writeConfig(repoDir, { version: 2, guardrails: [] });


### PR DESCRIPTION
Closes #344

## Summary
- Tighten `spec awp-review-check` closeout ledger validation so actionable findings require durable `evidence_ref` values.
- Reject weak placeholders like `done`, `ok`, `pending`, `unknown`, `missing`, `n/a`, and `none`.
- Document accepted durable refs: HTTP(S), `workflow-check:`, or GitHub `#issuecomment-<id>` anchors.

## Tests / validation
- `pnpm build && node --test --test-name-pattern "spec awp-review-check" tests/cli.integration.test.ts` passed: 16/16.
- `pnpm test` passed: 338 tests, 336 pass, 2 skipped, 0 fail.
- `pnpm build` passed.
- `git diff --check` passed.
- `spec workflow-check --phase commit --format json` returned manual fallback as expected because PR body was not available before PR creation; staged state was clean.

## Implementation Evidence
issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/344#issuecomment-4537237700
commit hash: fc4d407e3f58bc7c38023a63bfb6516923474a36
routing_mode: hybrid_awp
routing_task_class: product_behavior
controller_fallback: allowed
controller_fallback_reason: agent thread capacity unavailable: multi_agent_v1.spawn_agent returned agent thread limit reached; bounded CLI/docs/test slice implemented directly by controller
delegation_outcome: unavailable
spec_gate_status: pass
spec_evidence_ref: workflow-check:commit:344
routing_evidence_status: pass
routing_evidence_ref: workflow-check:start:issue-344
finding_disposition_status: pass
finding_disposition_ref: workflow-check:finding-disposition:344

## Non-goals
- 不改 review finding source schema beyond evidence ref quality。
- 不新增 GitHub mutation、daemon、hosted control plane、auto-comment、auto-merge。
- 不要求 downstream Scope Police parse full AWP review ledger。

## Scope guard / non-goals confirmation
- 變更只限 `awp-review-check` closeout ledger evidence ref quality、測試與文件。

## Review closeout / final merge gate evidence
final merge gate: pass
latest head: fc4d407e3f58bc7c38023a63bfb6516923474a36
ready_to_merge: yes
