### PR TITLE
refactor(workflow): share durable evidence ref validation

### DIFF
--- a/src/cli/awp-review-check.ts
+++ b/src/cli/awp-review-check.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { isDurableEvidenceRef } from '../utils/evidence-ref.js';
 import { ensureRepoPath } from '../utils/fs.js';
 import { run } from '../utils/shell.js';
 
@@ -91,7 +92,6 @@ const VALID_SOURCES = new Set(['coderabbit', 'codex', 'human', 'ci']);
 const VALID_DECISIONS = new Set(['adopt', 'partial', 'reject', 'defer']);
 const VALID_STRATEGIES = new Set(['local_patch', 'normalize_state_model', 'docs_only', 'test_only', 'no_change', 'split_followup']);
 const VALID_DISPOSITIONS = new Set(['adopted', 'partial', 'rejected', 'deferred', 'superseded']);
-const WEAK_EVIDENCE_REFS = new Set(['', 'n/a', 'none', 'missing', 'unknown', 'pending', 'done', 'ok']);
 const PATCH_BUDGET_RATIO = 0.3;
 
 export async function awpReviewCheck(opts: AwpReviewCheckOptions): Promise<void> {
@@ -451,13 +451,6 @@ function normalize(value: unknown): string {
 
 function normalizeRef(value: unknown): string | null {
   return meaningful(value) ? String(value).trim() : null;
-}
-
-function isDurableEvidenceRef(value: unknown): boolean {
-  const ref = String(value ?? '').trim();
-  const normalized = ref.toLowerCase();
-  if (WEAK_EVIDENCE_REFS.has(normalized)) return false;
-  return /^https?:\/\//i.test(ref) || /^workflow-check:/i.test(ref) || /#issuecomment-\d+/i.test(ref);
 }
 
 function unique(values: string[]): string[] {

--- a/src/cli/workflow-check.ts
+++ b/src/cli/workflow-check.ts
@@ -12,6 +12,7 @@ import {
   isSpecArtifactPath,
   normalizeArtifactPath,
 } from '../utils/artifacts.js';
+import { isDurableEvidenceRef } from '../utils/evidence-ref.js';
 
 type WorkflowPhase = 'start' | 'commit' | 'merge';
 type WorkflowStatus = 'pass' | 'fail' | 'manual' | 'skipped';
@@ -1663,11 +1664,7 @@ function hasEvidenceRefValue(body: string, fieldName: string): boolean {
 }
 
 function isEvidenceRefValue(value: string | null | undefined): boolean {
-  if (!value) return false;
-  const normalized = value.trim().toLowerCase();
-  if (WEAK_FALLBACK_REASONS.has(normalized)) return false;
-  if (['missing', 'pending', 'unknown', 'fail', 'failed'].includes(normalized)) return false;
-  return /^https?:\/\//i.test(value) || /^workflow-check:/i.test(value) || /#issuecomment-\d+/.test(value);
+  return isDurableEvidenceRef(value);
 }
 
 function requiredEnum(value: unknown, allowed: string[], fieldName: string): string {

--- a/src/utils/evidence-ref.ts
+++ b/src/utils/evidence-ref.ts
@@ -1,0 +1,22 @@
+const WEAK_EVIDENCE_REFS = new Set([
+  '',
+  'n/a',
+  'na',
+  'none',
+  'missing',
+  'unknown',
+  'pending',
+  'fail',
+  'failed',
+  'done',
+  'ok',
+  'small',
+  'trivial',
+]);
+
+export function isDurableEvidenceRef(value: unknown): boolean {
+  const ref = String(value ?? '').trim();
+  const normalized = ref.toLowerCase();
+  if (WEAK_EVIDENCE_REFS.has(normalized)) return false;
+  return /^https?:\/\//i.test(ref) || /^workflow-check:/i.test(ref) || /#issuecomment-\d+/i.test(ref);
+}


### PR DESCRIPTION
Closes #348

## Summary
- Add shared `isDurableEvidenceRef` utility for status/ref evidence checks.
- Use it from both `workflow-check` and `awp-review-check` to keep URL / `workflow-check:` / `#issuecomment-<id>` handling aligned.
- Preserve weak placeholder rejection for `missing`, `pending`, `unknown`, `fail`, `failed`, `done`, `ok`, `n/a`, `none`, and similar non-refs.

## Tests / validation
- `pnpm build && node --test --test-name-pattern "non-ref worker evidence values|weak closeout evidence refs|missing routing evidence ref|requires rationale refs" tests/cli.integration.test.ts` passed: 4/4.
- `pnpm test` passed: 339 tests, 337 pass, 2 skipped, 0 fail.
- `pnpm build` passed.
- `git diff --check` passed.
- `spec workflow-check --phase commit --format json` returned manual fallback as expected because PR body was not available before PR creation; staged state was clean.

## Implementation Evidence
issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/348#issuecomment-4537295966
commit hash: 2c19b466cd279ba0c5b11fbcf8695497439195ca
routing_mode: hybrid_awp
routing_task_class: small_docs_template_test
controller_fallback: allowed
controller_fallback_reason: agent thread capacity unavailable: multi_agent_v1.spawn_agent returned agent thread limit reached; bounded refactor/test slice implemented directly by controller
delegation_outcome: unavailable
spec_gate_status: pass
spec_evidence_ref: workflow-check:commit:348
routing_evidence_status: pass
routing_evidence_ref: workflow-check:start:issue-348
finding_disposition_status: pass
finding_disposition_ref: workflow-check:finding-disposition:348

## Non-goals
- 不改 public JSON contract。
- 不新增 GitHub reads/writes。
- 不改 target repo Scope Police expectations。
- 不新增 daemon、hosted control plane、auto-comment、auto-merge。

## Scope guard / non-goals confirmation
- Internal refactor only; existing fixtures continue to define user-visible behavior.

## Review closeout / final merge gate evidence
final merge gate: pass
latest head: 2c19b466cd279ba0c5b11fbcf8695497439195ca
ready_to_merge: yes
