### PR TITLE
feat(preflight): explain artifact match reasons

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Notes:
 - `spec plan ... --dry-run --format prompt --verbose` is the recommended pre-implementation command for AI planning.
 - For a full generated task package file, omit `--dry-run`; output is written under `.spec-injector/out/`.
 - `spec workflow-check` is a local-only, stdout-first workflow gate for autonomous PR evidence. It does not edit GitHub, add/commit files, write task packages, comment, merge, or mutate downstream repos.
-- `spec preflight --target-repo <path>` remains read-only and reports staged downstream spec artifacts as blockers before they become PR evidence problems.
+- `spec preflight --target-repo <path>` remains read-only and reports staged downstream spec artifacts as blockers before they become PR evidence problems; artifact reports include concise match reasons such as spec workspace, routing/readback evidence, generated spec output, or private context.
 - Autonomous worker-routing flow 可在 implementation 開始前使用 [Hybrid AWP routing policy](docs/hybrid-awp-routing-policy.md) 作為 start-gate source of truth。
 - Downstream AI entrypoints 可引用 [AI bootstrap install contract](docs/ai-bootstrap-install-contract.md)，用 `SPEC_INJECTOR_DIR` local runner fallback 與 `spec doctor --workflow awp --format json` 檢查 AWP capability；doctor 也會用 local smoke 確認 `preflight --target-repo` 可拒絕 staged target spec artifacts，不需要 global install。
 - `spec workflow-check --format json` emits the same stable fields as the text output: `phase`, `status`, `repo`, `head_sha`, `checked_at`, `missing_fields`, `warnings`, and `evidence_summary`. Additive fields such as `blocking_reason` and `manual_reason` point to the first deterministic blocker or manual gate.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -222,7 +222,7 @@ Required review checks:
 - Distinguish observations, false positives, false negatives, and follow-up issues.
 - Dogfood does not become target repo implementation.
 - Target repo state is reported if dirty, and work stops before running destructive cleanup.
-- Staged `.spec-injector/`, generated task package, routing/readback JSON, private context, or private ledger artifacts in target repos are blockers, not cleanup prompts.
+- Staged `.spec-injector/`, generated task package, routing/readback JSON, private context, or private ledger artifacts in target repos are blockers, not cleanup prompts. Preflight artifact reports include a concise match reason so reviewers can tell which artifact family triggered the gate.
 - Follow-up issues are separate from target repo code changes.
 
 ### 11. Companion / mascot / future runtime planning

--- a/src/cli/preflight.ts
+++ b/src/cli/preflight.ts
@@ -8,7 +8,11 @@ import {
   getUpstreamState,
   getWorktreeState,
 } from '../utils/git.js';
-import { isSpecArtifactPath, normalizeArtifactPath } from '../utils/artifacts.js';
+import {
+  classifySpecArtifactPath,
+  normalizeArtifactPath,
+  type SpecArtifactMatch,
+} from '../utils/artifacts.js';
 import { run } from '../utils/shell.js';
 
 type PreflightSeverity = 'pass' | 'warning' | 'fail' | 'needs-human-review';
@@ -228,25 +232,25 @@ function buildTargetArtifactChecks(targetRepoPath: string): PreflightCheck[] {
   const unstagedOk = requireGitPathList(unstaged);
   const untrackedOk = requireGitPathList(untracked);
 
-  const stagedArtifacts = unique(stagedOk.paths.filter((entry) => isSpecArtifactPath(entry)));
+  const stagedArtifacts = uniqueArtifactMatches(stagedOk.paths.map((entry) => classifySpecArtifactPath(entry)).filter(isArtifactMatch));
   if (stagedArtifacts.length > 0) {
     checks.push(fail(
       'target repo has staged spec artifacts',
-      `Forbidden staged artifacts: ${stagedArtifacts.join(', ')}. Stop and unstage/remove from target PR; preflight did not modify the target repo.`
+      `Forbidden staged artifacts: ${formatArtifactMatches(stagedArtifacts)}. Stop and unstage/remove from target PR; preflight did not modify the target repo.`
     ));
   } else {
     checks.push(pass('target repo has no staged spec artifacts', targetRepoPath));
   }
 
-  const dirtyArtifacts = unique([
-    ...unstagedOk.paths.filter((entry) => isSpecArtifactPath(entry)),
-    ...untrackedOk.paths.filter((entry) => isSpecArtifactPath(entry)),
-    ...existingGeneratedArtifactPaths(targetRepoPath),
+  const dirtyArtifacts = uniqueArtifactMatches([
+    ...unstagedOk.paths.map((entry) => classifySpecArtifactPath(entry)).filter(isArtifactMatch),
+    ...untrackedOk.paths.map((entry) => classifySpecArtifactPath(entry)).filter(isArtifactMatch),
+    ...existingGeneratedArtifactPaths(targetRepoPath).map((entry) => classifySpecArtifactPath(entry)).filter(isArtifactMatch),
   ]);
   if (dirtyArtifacts.length > 0) {
     checks.push(warning(
       'target repo has local spec artifact risk',
-      `Local-only artifacts detected: ${dirtyArtifacts.join(', ')}. Keep these out of commits and do not copy private context or generated output into the target repo.`
+      `Local-only artifacts detected: ${formatArtifactMatches(dirtyArtifacts)}. Keep these out of commits and do not copy private context or generated output into the target repo.`
     ));
   } else {
     checks.push(pass('target repo has no local spec artifact risk', targetRepoPath));
@@ -287,8 +291,23 @@ function existingGeneratedArtifactPaths(targetRepoPath: string): string[] {
   return candidates.filter((candidate) => fs.existsSync(path.join(targetRepoPath, candidate)));
 }
 
-function unique(values: string[]): string[] {
-  return [...new Set(values.filter(Boolean))];
+function isArtifactMatch(value: SpecArtifactMatch | null): value is SpecArtifactMatch {
+  return value !== null;
+}
+
+function uniqueArtifactMatches(matches: SpecArtifactMatch[]): SpecArtifactMatch[] {
+  const seen = new Set<string>();
+  const uniqueMatches: SpecArtifactMatch[] = [];
+  for (const match of matches) {
+    if (seen.has(match.path)) continue;
+    seen.add(match.path);
+    uniqueMatches.push(match);
+  }
+  return uniqueMatches;
+}
+
+function formatArtifactMatches(matches: SpecArtifactMatch[]): string {
+  return matches.map((match) => `${match.path} (${match.reason})`).join(', ');
 }
 
 function requireGitString(

--- a/src/utils/artifacts.ts
+++ b/src/utils/artifacts.ts
@@ -2,26 +2,69 @@ export function normalizeArtifactPath(value: string): string {
   return value.replaceAll('\\', '/').replace(/^\.\/+/u, '').replace(/\/+$/u, '');
 }
 
+export type SpecArtifactKind =
+  | 'spec-agent-dir'
+  | 'spec-output-dir'
+  | 'issue-task-package'
+  | 'generated-spec-artifact'
+  | 'routing-readback-artifact'
+  | 'private-context'
+  | 'configured-private-exclude';
+
+export type SpecArtifactMatch = {
+  path: string;
+  kind: SpecArtifactKind;
+  reason: string;
+};
+
 export function isSpecArtifactPath(
   rawPath: string,
   options: { privateExcludes?: string[] } = {}
 ): boolean {
+  return classifySpecArtifactPath(rawPath, options) !== null;
+}
+
+export function classifySpecArtifactPath(
+  rawPath: string,
+  options: { privateExcludes?: string[] } = {}
+): SpecArtifactMatch | null {
   const gitPath = normalizeArtifactPath(rawPath);
-  if (!gitPath) return false;
+  if (!gitPath) return null;
 
-  if (gitPath === '.spec-injector' || gitPath.startsWith('.spec-injector/')) return true;
-  if (gitPath.startsWith('spec-output/') || gitPath.startsWith('spec-outputs/')) return true;
-  if (/(^|\/)issue-\d+-task-package\.md$/i.test(gitPath)) return true;
-  if (/(^|\/)(?:task-package|spec-output|spec-evidence)(?:[.-][^/]*)?\.(?:md|json|txt)$/i.test(gitPath)) return true;
-  if (/(^|\/)(?:routing|readback|closeout|merge-closeout|awp-routing|awp-readback|local-routing|local-readback)(?:[-_.][^/]*)?\.(?:json|md|txt)$/i.test(gitPath)) return true;
-  if (/(^|\/)\.?private[-_](?:context|ledger)(?:\/|\.md$|\.json$|\.txt$)/i.test(gitPath)) return true;
+  if (gitPath === '.spec-injector' || gitPath.startsWith('.spec-injector/')) {
+    return artifactMatch(gitPath, 'spec-agent-dir', 'spec-injector workspace artifact');
+  }
+  if (gitPath.startsWith('spec-output/') || gitPath.startsWith('spec-outputs/')) {
+    return artifactMatch(gitPath, 'spec-output-dir', 'spec output directory');
+  }
+  if (/(^|\/)issue-\d+-task-package\.md$/i.test(gitPath)) {
+    return artifactMatch(gitPath, 'issue-task-package', 'generated issue task package');
+  }
+  if (/(^|\/)(?:task-package|spec-output|spec-evidence)(?:[.-][^/]*)?\.(?:md|json|txt)$/i.test(gitPath)) {
+    return artifactMatch(gitPath, 'generated-spec-artifact', 'generated spec artifact');
+  }
+  if (/(^|\/)(?:routing|readback|closeout|merge-closeout|awp-routing|awp-readback|local-routing|local-readback)(?:[-_.][^/]*)?\.(?:json|md|txt)$/i.test(gitPath)) {
+    return artifactMatch(gitPath, 'routing-readback-artifact', 'routing/readback evidence artifact');
+  }
+  if (/(^|\/)\.?private[-_](?:context|ledger)(?:\/|\.md$|\.json$|\.txt$)/i.test(gitPath)) {
+    return artifactMatch(gitPath, 'private-context', 'private context or ledger artifact');
+  }
 
-  return configuredPrivateArtifactPrefixes(options.privateExcludes ?? [])
-    .some((prefix) => gitPath === prefix || gitPath.startsWith(`${prefix}/`));
+  const configuredPrivatePrefix = configuredPrivateArtifactPrefixes(options.privateExcludes ?? [])
+    .find((prefix) => gitPath === prefix || gitPath.startsWith(`${prefix}/`));
+  if (configuredPrivatePrefix) {
+    return artifactMatch(gitPath, 'configured-private-exclude', 'configured private exclude');
+  }
+
+  return null;
 }
 
 export function configuredPrivateArtifactPrefixes(excludes: string[]): string[] {
   return excludes
     .map(normalizeArtifactPath)
     .filter((entry) => /private|secret|credential|context/i.test(entry));
+}
+
+function artifactMatch(path: string, kind: SpecArtifactKind, reason: string): SpecArtifactMatch {
+  return { path, kind, reason };
 }

--- a/tests/cli.integration.test.ts
+++ b/tests/cli.integration.test.ts
@@ -4914,6 +4914,7 @@ test('spec preflight fails when target repo has staged spec artifacts', async (t
   assert.match(result.stdout, /Preflight summary:\s+FAIL/i);
   assert.match(result.stdout, /target repo has staged spec artifacts/i);
   assert.match(result.stdout, /\.spec-injector\/out\/issue-342-task-package\.md/i);
+  assert.match(result.stdout, /spec-injector workspace artifact/i);
   assert.match(result.stdout, /preflight did not modify the target repo/i);
   assertNoRawStackTrace(result);
   const gitLog = (await readGhLog(fixture.gitLogPath)).join('\n');
@@ -4942,6 +4943,7 @@ test('spec preflight warns when target repo has local routing or readback artifa
   assert.match(result.stdout, /Preflight summary:\s+WARNING/i);
   assert.match(result.stdout, /target repo has local spec artifact risk/i);
   assert.match(result.stdout, /awp-readback-evidence\.json/i);
+  assert.match(result.stdout, /routing\/readback evidence artifact/i);
   assert.match(result.stdout, /Keep these out of commits/i);
   const gitLog = (await readGhLog(fixture.gitLogPath)).join('\n');
   assertNoGitMutationCommands(gitLog);

--- a/tests/utils/artifacts.test.ts
+++ b/tests/utils/artifacts.test.ts
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  classifySpecArtifactPath,
+  isSpecArtifactPath,
+  normalizeArtifactPath,
+} from '../../dist/utils/artifacts.js';
+
+test('classifySpecArtifactPath returns stable match reasons for existing artifact families', () => {
+  const cases = [
+    {
+      path: '.spec-injector/out/issue-354-task-package.md',
+      kind: 'spec-agent-dir',
+      reason: 'spec-injector workspace artifact',
+    },
+    {
+      path: 'spec-output/issue-354.md',
+      kind: 'spec-output-dir',
+      reason: 'spec output directory',
+    },
+    {
+      path: 'tmp/issue-354-task-package.md',
+      kind: 'issue-task-package',
+      reason: 'generated issue task package',
+    },
+    {
+      path: 'tmp/spec-evidence.closeout.json',
+      kind: 'generated-spec-artifact',
+      reason: 'generated spec artifact',
+    },
+    {
+      path: 'awp-readback-evidence.json',
+      kind: 'routing-readback-artifact',
+      reason: 'routing/readback evidence artifact',
+    },
+    {
+      path: '.private-context/notes.md',
+      kind: 'private-context',
+      reason: 'private context or ledger artifact',
+    },
+    {
+      path: 'secret-context/notes.md',
+      kind: 'configured-private-exclude',
+      reason: 'configured private exclude',
+      privateExcludes: ['secret-context'],
+    },
+  ];
+
+  for (const entry of cases) {
+    const match = classifySpecArtifactPath(entry.path, { privateExcludes: entry.privateExcludes });
+    assert.equal(match?.path, normalizeArtifactPath(entry.path), entry.path);
+    assert.equal(match?.kind, entry.kind, entry.path);
+    assert.equal(match?.reason, entry.reason, entry.path);
+    assert.equal(isSpecArtifactPath(entry.path, { privateExcludes: entry.privateExcludes }), true, entry.path);
+  }
+});
+
+test('classifySpecArtifactPath returns null for non-artifacts', () => {
+  for (const entry of ['README.md', 'src/workflow-check.ts', 'docs/context.md', 'private-but-normal.md']) {
+    assert.equal(classifySpecArtifactPath(entry), null, entry);
+    assert.equal(isSpecArtifactPath(entry), false, entry);
+  }
+});


### PR DESCRIPTION
Closes #354

## Summary

- Add classifySpecArtifactPath while preserving isSpecArtifactPath.
- Include concise artifact match reasons in preflight target repo staged blockers and local-risk warnings.
- Add utility and preflight regression tests plus docs wording.

## Tests / validation

- pnpm build
- node --test tests/utils/artifacts.test.ts
- node --test --test-name-pattern "spec preflight fails when target repo has staged spec artifacts|spec preflight warns when target repo has local routing or readback artifacts" tests/cli.integration.test.ts
- pnpm test
- git diff --check

## Implementation Evidence

issue evidence comment URL: https://github.com/Erick52106/spec-injector/issues/354#issuecomment-4537441875
commit hash: 4f726bb54b2f2d805f84a54b265f3663170571bd

routing_mode: hybrid_awp
routing_task_class: cli_evidence_detail
controller_fallback: allowed
controller_fallback_reason: agent thread capacity unavailable: multi_agent_v1.spawn_agent returned agent thread limit reached; bounded artifact classifier and preflight evidence detail implemented directly by controller after focused TDD and full validation
delegation_outcome: unavailable
spec_gate_status: pass
spec_evidence_ref: workflow-check:commit:issue-354
routing_evidence_status: pass
routing_evidence_ref: workflow-check:start:issue-354
finding_disposition_status: pass
finding_disposition_ref: workflow-check:finding-disposition:issue-354

## Scope Guard

- This PR is limited to local artifact classification detail, preflight output wording, docs, and tests.

## Non-goals

- no new forbidden artifact families beyond existing behavior
- no broad workflow-check output contract redesign
- no hosted control plane
- no daemon, dashboard, hidden wrapper, auto-comment, or auto-merge behavior
- no target repo mutation

## Review closeout / final merge gate evidence

final merge gate: pass
latest head: 4f726bb54b2f2d805f84a54b265f3663170571bd
ready_to_merge: yes
checks_status: pass
human_review_status: pass
unresolved_review_threads_count: 0
review_finding_disposition: no actionable review findings; CodeRabbit review skipped; Codex review threads none
merge_state_status: CLEAN